### PR TITLE
Fix e2e test pipeline

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: "Start Application Locally"
         run: |
           cd e2e-test-app
-          .mvn spring-boot:run &
+          mvn spring-boot:run &
           timeout=15
           while ! nc -z localhost 8080; do
             sleep 1


### PR DESCRIPTION
The e2e test failed because of a typo during the migration