### PR TITLE
Remove requireNonNull

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,6 @@ public AiDeploymentCreationResponse createDeployment() {
               AiDeploymentCreationRequest.create()
                   .configurationId("12345-123-123-123-123456abcdefg"));
 
-  Objects.requireNonNull(deployment, "Deployment creation failed");
-
   String id = deployment.getId();
   AiExecutionStatus status = deployment.getStatus();
 

--- a/core/src/main/java/com/sap/ai/sdk/core/Core.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/Core.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.client.BufferingClientHttpRequestFactory;

--- a/core/src/main/java/com/sap/ai/sdk/core/Core.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/Core.java
@@ -62,7 +62,6 @@ public class Core {
   private static String getOrchestrationDeployment(@Nonnull final String resourceGroup)
       throws NoSuchElementException {
     final var deployments = new DeploymentApi(getClient(getDestination())).deploymentQuery(resourceGroup);
-    Objects.requireNonNull(deployments, "Deployment get request failed");
 
     return deployments.getResources().stream()
         .filter(deployment -> "orchestration".equals(deployment.getScenarioId()))
@@ -244,7 +243,6 @@ public class Core {
       @Nonnull final String modelName, @Nonnull final String resourceGroup)
       throws NoSuchElementException {
     final var deployments = new DeploymentApi(getClient()).deploymentQuery(resourceGroup);
-    Objects.requireNonNull(deployments, "Deployment get request failed");
 
     return deployments.getResources().stream()
         .filter(deployment -> isDeploymentOfModel(modelName, deployment))

--- a/e2e-test-app/src/main/java/com/sap/ai/sdk/app/controllers/DeploymentController.java
+++ b/e2e-test-app/src/main/java/com/sap/ai/sdk/app/controllers/DeploymentController.java
@@ -11,7 +11,6 @@ import com.sap.ai.sdk.core.client.model.AiDeploymentModificationRequest;
 import com.sap.ai.sdk.core.client.model.AiDeploymentModificationResponse;
 import com.sap.ai.sdk.core.client.model.AiDeploymentTargetStatus;
 import java.util.List;
-import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
@@ -44,7 +43,7 @@ class DeploymentController {
 
     // shortly after creation, the deployment will be status UNKNOWN.
     // We can directly DELETE it, without going through STOPPED
-    return API.deploymentDelete("default", Objects.requireNonNull(deployment).getId());
+    return API.deploymentDelete("default", deployment.getId());
   }
 
   /**
@@ -108,7 +107,7 @@ class DeploymentController {
   public List<AiDeployment> getAllByConfigId(@Nonnull @PathVariable("id") final String configId) {
     final AiDeploymentList deploymentList = API.deploymentQuery("default");
 
-    return Objects.requireNonNull(deploymentList).getResources().stream()
+    return deploymentList.getResources().stream()
         .filter(deployment -> configId.equals(deployment.getConfigurationId()))
         .toList();
   }


### PR DESCRIPTION
## Context

AI/ai-sdk-java-backlog#53.

Follow up of #4, especially: Fix return type `@Nonnull` / `@Nullable` annotation.
Now that the return type is `@Nonnull`, we can remove requireNonNull.

### Feature scope:
 
- [x] Remove requireNonNull

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] Error handling created / updated & covered by the tests above
- [ ] ~Aligned changes with the JavaScript SDK~
- [x] Documentation updated
- [ ] ~Release notes updated~
