### PR TITLE
Enable CI on main

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -1,6 +1,9 @@
 name: "Continuous Integration"
 on:
-  push: # Pull requests and main branch
+  pull_request:
+    branches: [ "*" ]
+  push:
+    branches: [ "main" ]
 
 env:
   MVN_MULTI_THREADED_ARGS: --batch-mode --no-transfer-progress --fail-at-end --show-version --threads 1C

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -1,7 +1,6 @@
 name: "Continuous Integration"
 on:
-  pull_request:
-    branches: [ "*" ]
+  push: # Pull requests and main branch
 
 env:
   MVN_MULTI_THREADED_ARGS: --batch-mode --no-transfer-progress --fail-at-end --show-version --threads 1C

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![build](https://github.com/SAP/ai-sdk-java/actions/workflows/continuous-integration.yaml/badge.svg)
+![build](https://github.com/SAP/ai-sdk-java/actions/workflows/continuous-integration.yaml/badge.svg?branch=main)
 ![CodeQL](https://github.com/SAP/ai-sdk-java/actions/workflows/github-code-scanning/codeql/badge.svg)
 [![REUSE status](https://api.reuse.software/badge/git.fsfe.org/reuse/api)](https://api.reuse.software/info/git.fsfe.org/reuse/api)
 [![Fosstars security rating](https://github.com/SAP/cloud-sdk-java/blob/fosstars-report/fosstars_badge.svg)](https://github.com/SAP/cloud-sdk-java/blob/fosstars-report/fosstars_report.md)


### PR DESCRIPTION
## Context

continuous integration needs to run on main, plus the badge should only show if the main branch succeeds.
Currently the badge shows the latest pull request status.

