### PR TITLE
fix e2e: Downgrade dependency _junit-jupiter_

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cloud-sdk.version>5.8.0</cloud-sdk.version>
-    <junit-jupiter.version>5.11.0</junit-jupiter.version>
+    <cloud-sdk.version>5.11.0</cloud-sdk.version>
+    <junit-jupiter.version>5.8.0</junit-jupiter.version>
     <wiremock.version>3.9.1</wiremock.version>
     <assertj-core.version>3.26.3</assertj-core.version>
     <slf4j.version>2.0.16</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cloud-sdk.version>5.11.0</cloud-sdk.version>
+    <cloud-sdk.version>5.8.0</cloud-sdk.version>
     <junit-jupiter.version>5.11.0</junit-jupiter.version>
     <wiremock.version>3.9.1</wiremock.version>
     <assertj-core.version>3.26.3</assertj-core.version>


### PR DESCRIPTION
Fix observed error when running:
```
mvn --batch-mode --no-transfer-progress --fail-at-end --show-version --threads 1C surefire:test -pl :e2e-test-app -DskipTests=false
```

Execution fails:
```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[ERROR] TestEngine with ID 'junit-jupiter' failed to discover tests
```

Workaround is to use old version of `junit-jupiter.version`.
Partially reverting #31