### PR TITLE
Notify when main branch fails

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -91,8 +91,7 @@ jobs:
         run: python .pipeline/scripts/print-coverage.py --jacoco-report-pattern "**/target/site/jacoco/jacoco.csv"
 
       - name: "Slack Notification"
-        ## currently disabled, as there are no main builds yet
-        if: false
+        if: ${{ github.ref == 'refs/heads/main' && failure() }}
         uses: slackapi/slack-github-action@v1.27.0
         with:
           payload: |


### PR DESCRIPTION
We forgot to enable the Slack notification on continuous integration when we enabled the workflow on main