### PR TITLE
Dependabot Auto-Merge fix

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -12,7 +12,7 @@ env:
 
 jobs:
 
-  continous-integration:
+  continuous-integration:
     # https://wiki.one.int.sap/wiki/display/DevFw/SUGAR
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -1,9 +1,9 @@
-name: dependabot merger
+name: "Dependabot Auto-Merge"
 
 on:
   workflow_dispatch:
   schedule:
-    - cron: '00 03 * * Mon' # trigger every Monday at 3:00 a.m., as our dependabot is configured to raise PRs every Monday at 2:00 a.m.
+    - cron: '00 04 * * Mon' # trigger every Monday at 04:00 a.m., as our dependabot is configured to raise PRs every Monday at 2:00 a.m.
 
 env:
   DEPENDABOT_GROUPS: |


### PR DESCRIPTION
## Context

The `dependabot-automerge.yaml` workflow did not merge all dependabot PRs. I suspect this is a timing issue. I added one hour.