### PR TITLE
Run Spotbugs by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -435,9 +435,9 @@ https://gitbox.apache.org/repos/asf?p=maven-pmd-plugin.git;a=blob_plain;f=src/ma
         <artifactId>spotbugs-maven-plugin</artifactId>
         <version>4.8.6.4</version>
         <configuration>
-          <includeFilterFile>.pipeline/spotbugs.xml</includeFilterFile>
+          <includeFilterFile>${project.rootdir}/.pipeline/spotbugs.xml</includeFilterFile>
           <!-- Exclude generated clients -->
-          <excludeFilterFile>.pipeline/spotbugs-exclusions.xml</excludeFilterFile>
+          <excludeFilterFile>${project.rootdir}/.pipeline/spotbugs-exclusions.xml</excludeFilterFile>
           <effort>Max</effort>
           <threshold>Low</threshold>
           <maxHeap>2048</maxHeap>

--- a/pom.xml
+++ b/pom.xml
@@ -442,6 +442,14 @@ https://gitbox.apache.org/repos/asf?p=maven-pmd-plugin.git;a=blob_plain;f=src/ma
           <threshold>Low</threshold>
           <maxHeap>2048</maxHeap>
         </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>verify</phase>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>


### PR DESCRIPTION
- [x] Make the code quality related plugins runnable from sub modules.
- [x] Enable Spotbugs by default

Sample output:
```
mvn clean install -f core

[...]

[INFO] 
[INFO] --- spotbugs:4.8.6.4:check (default) @ core ---
[INFO] BugInstance size is 2
[INFO] Error size is 0
[INFO] Total bugs: 2
[ERROR] High: com.sap.ai.sdk.core.client.model.AiDeployment$LastOperationEnum.fromValue(String) may return null, but is declared @Nonnull [com.sap.ai.sdk.core.client.model.AiDeployment$LastOperationEnum] At AiDeployment.java:[line 181] NP_NONNULL_RETURN_VIOLATION
[ERROR] High: com.sap.ai.sdk.core.client.model.AiDeploymentResponseWithDetails$LastOperationEnum.fromValue(String) may return null, but is declared @Nonnull [com.sap.ai.sdk.core.client.model.AiDeploymentResponseWithDetails$LastOperationEnum] At AiDeploymentResponseWithDetails.java:[line 181] NP_NONNULL_RETURN_VIOLATION
[INFO] 


To see bug detail using the Spotbugs GUI, use the following command "mvn spotbugs:gui"



[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:03 min
[INFO] Finished at: 2024-10-21T10:14:48+02:00
[INFO] ------------------------------------------------------------------------
```
