### PR TITLE
Run Checkstyle by default

### DIFF
--- a/.pipeline/checkstyle-suppressions.xml
+++ b/.pipeline/checkstyle-suppressions.xml
@@ -6,6 +6,9 @@
 
 <suppressions>
   <!-- Suppress generated clients -->
-  <suppress files="[/\\]core/client[/\\]" checks=".*"/>
-  <suppress files="[/\\]orchestration/client[/\\]" checks=".*"/>
+  <suppress files="/core/client/" checks=".*"/>
+  <suppress files="/orchestration/client/" checks=".*"/>
+  <!-- Suppress TODOs -->
+  <suppress files="OpenAiChatCompletionParameters.java" checks="TodoComment" lines="95" />
+  <suppress files="OpenAiChatMessage.java" checks="TodoComment" lines="255,271" />
 </suppressions>

--- a/.pipeline/config.yml
+++ b/.pipeline/config.yml
@@ -20,7 +20,7 @@ stages:
       class: 67
   codeCheck:
     checkstyle:
-      high: '3'# Open tasks (to do or fix me)
+      high: '0'
       normal: '0'
       low: '0'
     spotbugs:

--- a/pom.xml
+++ b/pom.xml
@@ -408,6 +408,14 @@
             <version>${checkstyle.version}</version>
           </dependency>
         </dependencies>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>verify</phase>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -396,9 +396,9 @@
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>3.5.0</version>
         <configuration>
-          <configLocation>.pipeline/checkstyle.xml</configLocation>
+          <configLocation>${project.rootdir}/.pipeline/checkstyle.xml</configLocation>
           <!-- Exclude generated clients -->
-          <suppressionsLocation>.pipeline/checkstyle-suppressions.xml</suppressionsLocation>
+          <suppressionsLocation>${project.rootdir}/.pipeline/checkstyle-suppressions.xml</suppressionsLocation>
           <linkXRef>false</linkXRef>
         </configuration>
         <dependencies>


### PR DESCRIPTION
- [x] Make the code quality related plugins runnable from sub modules.
- [x] Enable Checkstyle by default

Sample output:
```
mvn clean install -f foundationmodels/openai

[...]
[INFO] 
[INFO] --- checkstyle:3.5.0:check (default) @ openai ---
[INFO] There are 3 errors reported by Checkstyle 10.18.2 with C:\SAPDevelop\ai-sdk-java\foundation-models\openai/../..//.pipeline/checkstyle.xml ruleset.
[ERROR] src\main\java\com\sap\ai\sdk\foundationmodels\openai\model\OpenAiChatCompletionParameters.java:[95,39] (misc) TodoComment: Comment matches to-do format '(TODO)|(todo)|(ToDo)|(FIXME)|(fixme)|(FixMe)'.
[ERROR] src\main\java\com\sap\ai\sdk\foundationmodels\openai\model\OpenAiChatMessage.java:[255,7] (misc) TodoComment: Comment matches to-do format '(TODO)|(todo)|(ToDo)|(FIXME)|(fixme)|(FixMe)'.
[ERROR] src\main\java\com\sap\ai\sdk\foundationmodels\openai\model\OpenAiChatMessage.java:[271,11] (misc) TodoComment: Comment matches to-do format '(TODO)|(todo)|(ToDo)|(FIXME)|(fixme)|(FixMe)'.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  10.397 s
[INFO] Finished at: 2024-10-21T10:48:31+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-checkstyle-plugin:3.5.0:check (default) on project openai: You have 3 Checkstyle violations. -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
```
