### PR TITLE
Added Cloud SDK logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![REUSE status](https://api.reuse.software/badge/git.fsfe.org/reuse/api)](https://api.reuse.software/info/git.fsfe.org/reuse/api)
 [![Fosstars security rating](https://github.com/SAP/cloud-sdk-java/blob/fosstars-report/fosstars_badge.svg)](https://github.com/SAP/cloud-sdk-java/blob/fosstars-report/fosstars_report.md)
 
-# SAP Cloud SDK for AI (for Java)
+# <img src="https://sap.github.io/cloud-sdk/img/logo.svg" alt="SAP Cloud SDK" width="30"/> SAP Cloud SDK for AI (for Java)
 
 > ⚠️ **This is a pre-alpha version of the AI SDK for Java. The APIs are subject to change.** ⚠️
 


### PR DESCRIPTION
## Context

We need to add the Cloud SDK logo like on the Cloud SDK documentation website:
![image](https://github.com/user-attachments/assets/72e1dc0d-c62f-4eea-82db-fbb0dbf5b742)
