### PR TITLE
Reduce visibility AiCoreService#DOTENV from public to private

### DIFF
--- a/core/src/main/java/com/sap/ai/sdk/core/AiCoreService.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/AiCoreService.java
@@ -43,7 +43,7 @@ public class AiCoreService implements AiCoreDestination {
   private static final String AI_RESOURCE_GROUP = "URL.headers.AI-Resource-Group";
 
   /** loads the .env file from the root of the project */
-  protected static final Dotenv DOTENV = Dotenv.configure().ignoreIfMissing().load();
+  private static final Dotenv DOTENV = Dotenv.configure().ignoreIfMissing().load();
 
   /** The resource group is defined by AiCoreDeployment.withResourceGroup(). */
   @Nonnull String resourceGroup;

--- a/core/src/main/java/com/sap/ai/sdk/core/AiCoreService.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/AiCoreService.java
@@ -43,7 +43,7 @@ public class AiCoreService implements AiCoreDestination {
   private static final String AI_RESOURCE_GROUP = "URL.headers.AI-Resource-Group";
 
   /** loads the .env file from the root of the project */
-  public static final Dotenv DOTENV = Dotenv.configure().ignoreIfMissing().load();
+  protected static final Dotenv DOTENV = Dotenv.configure().ignoreIfMissing().load();
 
   /** The resource group is defined by AiCoreDeployment.withResourceGroup(). */
   @Nonnull String resourceGroup;


### PR DESCRIPTION
Exposing this field publicly leads to some risks:
* User expects API stability
* .. for a field with a third-party class
* Implicit invitation for more util fields (feature creep)
* Auto-completion may confuse the user