### PR TITLE
README fix for AICORE_SERVICE_KEY instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Additional methods (not recommended for production):
 **2. Create `.env` file:**
 
 - Create an `.env` file in the root directory of your application
-- Add an entry `AICORE_SERVICE_KEY='<content-of-service-key>'`
+- Add a **one line** entry `AICORE_SERVICE_KEY={...}` with the copied JSON
 
 <details>
 <summary>Set an environment variable instead of .env</summary>

--- a/sample-code/spring-app/README.md
+++ b/sample-code/spring-app/README.md
@@ -17,7 +17,9 @@ Before you can run the sample app, you need to install the AI SDK into your loca
 
 Next, you'll need to set up credentials for the AI Core service: 
 
-* Follow [these instructions](../../README.md#option-1-set-credentials-as-environment-variable) to configure the credentials via environment variables.
+* Follow [these instructions](../../README.md#option-1-set-ai-core-credentials) to create a service key for the AI Core service.
+
+  ⚠️ Put the `.env` file in the sample app directory.
 
 Finally, you can start the sample app:
  


### PR DESCRIPTION
## Context

AI/ai-sdk-java-backlog#57.

The README had mistakes and was unclear in regards to AI Core service binding from a local machine
