### PR TITLE
Added dependencies instructions

### DIFF
--- a/docs/guides/AI_CORE_DEPLOYMENT.md
+++ b/docs/guides/AI_CORE_DEPLOYMENT.md
@@ -23,12 +23,16 @@ Additionally, include the necessary Maven dependency in your project.
 Add the following dependency to your `pom.xml` file:
 
 ```xml
-<dependency>
-    <groupId>com.sap.ai.sdk</groupId>
-    <artifactId>core</artifactId>
-    <version>${ai-sdk.version}</version>
-</dependency>
+<dependencies>
+    <dependency>
+        <groupId>com.sap.ai.sdk</groupId>
+        <artifactId>core</artifactId>
+        <version>${ai-sdk.version}</version>
+    </dependency>
+</dependencies>
 ```
+
+⚠️ Cloud SDK users should remove version tags from all Cloud SDK dependencies.
 
 See [an example pom in our Spring Boot application](../../sample-code/spring-app/pom.xml)
 

--- a/docs/guides/OPENAI_CHAT_COMPLETION.md
+++ b/docs/guides/OPENAI_CHAT_COMPLETION.md
@@ -37,6 +37,8 @@ Add the following dependency to your `pom.xml` file:
 </dependencies>
 ```
 
+⚠️ Cloud SDK users should remove version tags from all Cloud SDK dependencies.
+
 See [an example pom in our Spring Boot application](../../sample-code/spring-app/pom.xml)
 
 ## Usage

--- a/docs/guides/ORCHESTRATION_CHAT_COMPLETION.md
+++ b/docs/guides/ORCHESTRATION_CHAT_COMPLETION.md
@@ -35,6 +35,8 @@ Add the following dependency to your `pom.xml` file:
 </dependencies>
 ```
 
+⚠️ Cloud SDK users should remove version tags from all Cloud SDK dependencies.
+
 See [an example `pom.xml` in our Spring Boot application](../../sample-code/spring-app/pom.xml).
 
 ## Usage


### PR DESCRIPTION
## Context

A customer was overriding the Cloud SDK version to an older one. This is due to the fact that they are using Cloud SDK in addition to the AI SDK

> ⚠️ Cloud SDK users should remove version tags from all Cloud SDK dependencies.