### PR TITLE
[PMD] Apply public API rules to protected as well

### DIFF
--- a/.pipeline/sdk_specific_pmd_rules.xml
+++ b/.pipeline/sdk_specific_pmd_rules.xml
@@ -131,7 +131,7 @@
             <property name="xpath">
                 <value>
                     <![CDATA[
-                        //MethodDeclaration[@EffectiveVisibility='public' and @Void=false() and ClassType and not(
+                        //MethodDeclaration[(@EffectiveVisibility='public' or @EffectiveVisibility='protected') and @Void=false() and ClassType and not(
                             ./ModifierList/Annotation[@SimpleName='Nullable'] or
                             ./ModifierList/Annotation[@SimpleName='Nonnull']
                         )]
@@ -185,7 +185,7 @@
                 <value>
                     <![CDATA[
                         //ClassBody
-                        /*[@EffectiveVisibility='public']
+                        /*[(@EffectiveVisibility='public' or @EffectiveVisibility='protected')]
                         /FormalParameters
                         /FormalParameter[
                             ClassType and


### PR DESCRIPTION
We should apply the same quality standards to `protected` API as we have for `public` API.
(Effective) protected API describes methods on public classes, that are reserved for overriding and reusing in extending classes.