### PR TITLE
Added Response Convenience

### DIFF
--- a/docs/guides/ORCHESTRATION_CHAT_COMPLETION.md
+++ b/docs/guides/ORCHESTRATION_CHAT_COMPLETION.md
@@ -91,8 +91,7 @@ var prompt = new OrchestrationPrompt("Hello world! Why is this phrase so famous?
 
 var result = client.chatCompletion(prompt, config);
 
-String messageResult =
-        result.getOrchestrationResult().getChoices().get(0).getMessage().getContent();
+String messageResult = result.getContent();
 ```
 
 In this example, the Orchestration service generates a response to the user message "Hello world! Why is this phrase so famous?".

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationClient.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationClient.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.sap.ai.sdk.core.AiCoreDeployment;
 import com.sap.ai.sdk.core.AiCoreService;
 import com.sap.ai.sdk.orchestration.client.model.CompletionPostRequest;
-import com.sap.ai.sdk.orchestration.client.model.CompletionPostResponse;
 import com.sap.ai.sdk.orchestration.client.model.ModuleConfigs;
 import com.sap.ai.sdk.orchestration.client.model.OrchestrationConfig;
 import com.sap.cloud.sdk.cloudplatform.connectivity.ApacheHttpClient5Accessor;
@@ -75,7 +74,7 @@ public class OrchestrationClient {
    * @throws OrchestrationClientException if the request fails.
    */
   @Nonnull
-  public CompletionPostResponse chatCompletion(
+  public OrchestrationResponse chatCompletion(
       @Nonnull final OrchestrationPrompt prompt, @Nonnull final OrchestrationModuleConfig config)
       throws OrchestrationClientException {
 
@@ -104,7 +103,7 @@ public class OrchestrationClient {
    * @throws OrchestrationClientException If the request fails.
    */
   @Nonnull
-  public CompletionPostResponse executeRequest(@Nonnull final CompletionPostRequest request)
+  public OrchestrationResponse executeRequest(@Nonnull final CompletionPostRequest request)
       throws OrchestrationClientException {
     final BasicClassicHttpRequest postRequest = new HttpPost("/completion");
     try {
@@ -133,13 +132,13 @@ public class OrchestrationClient {
   }
 
   @Nonnull
-  CompletionPostResponse executeRequest(@Nonnull final BasicClassicHttpRequest request) {
+  OrchestrationResponse executeRequest(@Nonnull final BasicClassicHttpRequest request) {
     try {
       val destination = deployment.get().destination();
       log.debug("Using destination {} to connect to orchestration service", destination);
       val client = ApacheHttpClient5Accessor.getHttpClient(destination);
       return client.execute(
-          request, new OrchestrationResponseHandler<>(CompletionPostResponse.class));
+          request, new OrchestrationResponseHandler<>(OrchestrationResponse.class));
     } catch (NoSuchElementException
         | DestinationAccessException
         | DestinationNotFoundException

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationResponse.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationResponse.java
@@ -1,0 +1,26 @@
+package com.sap.ai.sdk.orchestration;
+
+import com.sap.ai.sdk.orchestration.client.model.CompletionPostResponse;
+import javax.annotation.Nonnull;
+
+/** Orchestration chat completion output. */
+public class OrchestrationResponse extends CompletionPostResponse {
+  /**
+   * Get the message content from the output.
+   *
+   * <p>Note: If there are multiple choices only the first one is returned
+   *
+   * @return the message content or empty string.
+   * @throws OrchestrationClientException if the content filter filtered the output.
+   */
+  @Nonnull
+  public String getContent() throws OrchestrationClientException {
+    if (getOrchestrationResult().getChoices().isEmpty()) {
+      return "";
+    }
+    if ("content_filter".equals(getOrchestrationResult().getChoices().get(0).getFinishReason())) {
+      throw new OrchestrationClientException("Content filter filtered the output.");
+    }
+    return getOrchestrationResult().getChoices().get(0).getMessage().getContent();
+  }
+}

--- a/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
+++ b/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
@@ -115,8 +115,7 @@ class OrchestrationUnitTest {
     final var result = client.chatCompletion(prompt, config);
 
     assertThat(result).isNotNull();
-    assertThat(result.getOrchestrationResult().getChoices().get(0).getMessage().getContent())
-        .isNotEmpty();
+    assertThat(result.getContent()).isNotEmpty();
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <enforcer.skipBanGeneratedModulesReference>false</enforcer.skipBanGeneratedModulesReference>
     <!-- Test coverage -->
     <coverage.instruction>74%</coverage.instruction>
-    <coverage.branch>62%</coverage.branch>
+    <coverage.branch>60%</coverage.branch>
     <coverage.complexity>67%</coverage.complexity>
     <coverage.line>75%</coverage.line>
     <coverage.method>80%</coverage.method>

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/OrchestrationController.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/OrchestrationController.java
@@ -3,10 +3,10 @@ package com.sap.ai.sdk.app.controllers;
 import com.sap.ai.sdk.orchestration.OrchestrationClient;
 import com.sap.ai.sdk.orchestration.OrchestrationModuleConfig;
 import com.sap.ai.sdk.orchestration.OrchestrationPrompt;
+import com.sap.ai.sdk.orchestration.OrchestrationResponse;
 import com.sap.ai.sdk.orchestration.client.model.AzureContentSafety;
 import com.sap.ai.sdk.orchestration.client.model.AzureThreshold;
 import com.sap.ai.sdk.orchestration.client.model.ChatMessage;
-import com.sap.ai.sdk.orchestration.client.model.CompletionPostResponse;
 import com.sap.ai.sdk.orchestration.client.model.DPIEntities;
 import com.sap.ai.sdk.orchestration.client.model.DPIEntityConfig;
 import com.sap.ai.sdk.orchestration.client.model.FilterConfig;
@@ -44,7 +44,7 @@ class OrchestrationController {
    */
   @GetMapping("/completion")
   @Nonnull
-  public CompletionPostResponse completion() {
+  public OrchestrationResponse completion() {
     final var prompt = new OrchestrationPrompt("Hello world! Why is this phrase so famous?");
 
     return client.chatCompletion(prompt, config);
@@ -57,7 +57,7 @@ class OrchestrationController {
    */
   @GetMapping("/template")
   @Nonnull
-  public CompletionPostResponse template() {
+  public OrchestrationResponse template() {
     final var template =
         ChatMessage.create()
             .role("user")
@@ -78,7 +78,7 @@ class OrchestrationController {
    */
   @GetMapping("/messagesHistory")
   @Nonnull
-  public CompletionPostResponse messagesHistory() {
+  public OrchestrationResponse messagesHistory() {
     final List<ChatMessage> messagesHistory =
         List.of(
             ChatMessage.create().role("user").content("What is the capital of France?"),
@@ -99,7 +99,7 @@ class OrchestrationController {
    */
   @GetMapping("/filter/{threshold}")
   @Nonnull
-  public CompletionPostResponse filter(
+  public OrchestrationResponse filter(
       @Nonnull @PathVariable("threshold") final AzureThreshold threshold) {
     final var prompt =
         new OrchestrationPrompt(
@@ -146,7 +146,7 @@ class OrchestrationController {
    */
   @GetMapping("/maskingAnonymization")
   @Nonnull
-  public CompletionPostResponse maskingAnonymization() {
+  public OrchestrationResponse maskingAnonymization() {
     final var systemMessage =
         ChatMessage.create()
             .role("system")
@@ -177,7 +177,7 @@ class OrchestrationController {
    */
   @GetMapping("/maskingPseudonymization")
   @Nonnull
-  public CompletionPostResponse maskingPseudonymization() {
+  public OrchestrationResponse maskingPseudonymization() {
     final var systemMessage =
         ChatMessage.create()
             .role("system")

--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
@@ -25,8 +25,7 @@ class OrchestrationTest {
     final var result = controller.completion();
 
     assertThat(result).isNotNull();
-    assertThat(result.getOrchestrationResult().getChoices().get(0).getMessage().getContent())
-        .isNotEmpty();
+    assertThat(result.getContent()).isNotEmpty();
   }
 
   @Test


### PR DESCRIPTION
## Context

AI/ai-sdk-java-backlog#110.

As an orchestration user, I want to have a convenient way of accessing the LLM result and further related information.

### Feature scope:
 
- [x] Added ``OrchestrationResponse`` extends ``CompletionPostResponse``

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Aligned changes with the JavaScript SDK~
- [x] Documentation updated
- [ ] ~Release notes updated~
