### PR TITLE
Drop redundant "model" method prefix

### DIFF
--- a/docs/guides/ORCHESTRATION_CHAT_COMPLETION.md
+++ b/docs/guides/ORCHESTRATION_CHAT_COMPLETION.md
@@ -219,11 +219,11 @@ Change your LLM configuration to add model parameters:
 ```java
 OrchestrationAiModel customGPT4O =
     OrchestrationAiModel.GPT_4O
-        .withModelParams(
+        .withParams(
             Map.of(
                 "max_tokens", 50,
                 "temperature", 0.1,
                 "frequency_penalty", 0,
                 "presence_penalty", 0))
-        .withModelVersion("2024-05-13");
+        .withVersion("2024-05-13");
 ```

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationAiModel.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationAiModel.java
@@ -112,9 +112,6 @@ public class OrchestrationAiModel {
 
   @Nonnull
   LLMModuleConfig createConfig() {
-    return new LLMModuleConfig()
-        .modelName(name)
-        .modelParams(params)
-        .modelVersion(version);
+    return new LLMModuleConfig().modelName(name).modelParams(params).modelVersion(version);
   }
 }

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationAiModel.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationAiModel.java
@@ -13,7 +13,7 @@ import lombok.With;
 @AllArgsConstructor
 public class OrchestrationAiModel {
   /** The name of the model */
-  String modelName;
+  String name;
 
   /**
    * Optional parameters on this model.
@@ -26,10 +26,10 @@ public class OrchestrationAiModel {
    *     "presence_penalty", 0)
    * }</pre>
    */
-  Map<String, Object> modelParams;
+  Map<String, Object> params;
 
   /** The version of the model, defaults to "latest". */
-  String modelVersion;
+  String version;
 
   /** IBM Granite 13B chat completions model */
   public static final OrchestrationAiModel IBM_GRANITE_13B_CHAT =
@@ -106,15 +106,15 @@ public class OrchestrationAiModel {
   public static final OrchestrationAiModel GEMINI_1_5_FLASH =
       new OrchestrationAiModel("gemini-1.5-flash");
 
-  OrchestrationAiModel(@Nonnull final String modelName) {
-    this(modelName, Map.of(), "latest");
+  OrchestrationAiModel(@Nonnull final String name) {
+    this(name, Map.of(), "latest");
   }
 
   @Nonnull
   LLMModuleConfig createConfig() {
     return new LLMModuleConfig()
-        .modelName(modelName)
-        .modelParams(modelParams)
-        .modelVersion(modelVersion);
+        .modelName(name)
+        .modelParams(params)
+        .modelVersion(version);
   }
 }

--- a/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationModuleConfigTest.java
+++ b/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationModuleConfigTest.java
@@ -69,18 +69,16 @@ class OrchestrationModuleConfigTest {
   void testLLMConfig() {
     Map<String, Object> params = Map.of("foo", "bar");
     String version = "2024-05-13";
-    OrchestrationAiModel aiModel = GPT_4O.withModelParams(params).withModelVersion(version);
+    OrchestrationAiModel aiModel = GPT_4O.withParams(params).withVersion(version);
     var config = new OrchestrationModuleConfig().withLlmConfig(aiModel);
 
     assertThat(config.getLlmConfig()).isNotNull();
-    assertThat(config.getLlmConfig().getModelName()).isEqualTo(GPT_4O.getModelName());
+    assertThat(config.getLlmConfig().getModelName()).isEqualTo(GPT_4O.getName());
     assertThat(config.getLlmConfig().getModelParams()).isEqualTo(params);
     assertThat(config.getLlmConfig().getModelVersion()).isEqualTo(version);
 
-    assertThat(GPT_4O.getModelParams())
-        .withFailMessage("Static models should be unchanged")
-        .isEmpty();
-    assertThat(GPT_4O.getModelVersion())
+    assertThat(GPT_4O.getParams()).withFailMessage("Static models should be unchanged").isEmpty();
+    assertThat(GPT_4O.getVersion())
         .withFailMessage("Static models should be unchanged")
         .isEqualTo("latest");
   }

--- a/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
+++ b/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
@@ -63,7 +63,7 @@ import org.junit.jupiter.api.Test;
 @WireMockTest
 class OrchestrationUnitTest {
   static final OrchestrationAiModel CUSTOM_GPT_35 =
-      GPT_35_TURBO_16K.withModelParams(
+      GPT_35_TURBO_16K.withParams(
           Map.of(
               "max_tokens", 50,
               "temperature", 0.1,


### PR DESCRIPTION
Follow up #152

I think we could drop the "model" prefix from the public methods, since the class already has the "model" reference in name.