### PR TITLE
Data Masking Convenience

### DIFF
--- a/docs/guides/ORCHESTRATION_CHAT_COMPLETION.md
+++ b/docs/guides/ORCHESTRATION_CHAT_COMPLETION.md
@@ -185,7 +185,7 @@ Use the data masking module to anonymize personal information in the input:
 
 ```java
 var maskingConfig =
-    DpiMasking.anonymization().withEntities(DPIEntities.PERSON, DPIEntities.EMAIL);
+    DpiMasking.anonymization().withEntities(DPIEntities.PHONE, DPIEntities.PERSON);
 var configWithMasking = config.withMaskingConfig(maskingConfig);
 
 var systemMessage = ChatMessage.create()

--- a/docs/guides/ORCHESTRATION_CHAT_COMPLETION.md
+++ b/docs/guides/ORCHESTRATION_CHAT_COMPLETION.md
@@ -204,7 +204,7 @@ var result =
     new OrchestrationClient().chatCompletion(prompt, configWithMasking);
 ```
 
-In this example, the input will be masked before the call to the LLM and unmasked in the output.
+In this example, the input will be masked before the call to the LLM and will remain masked in the output.
 
 ### Set model parameters
 

--- a/docs/guides/ORCHESTRATION_CHAT_COMPLETION.md
+++ b/docs/guides/ORCHESTRATION_CHAT_COMPLETION.md
@@ -184,8 +184,9 @@ var result =
 Use the data masking module to anonymize personal information in the input:
 
 ```java
-var maskingConfig = DpiMaskingConfig.pseudonymization().withEntities(DPIEntities.PERSON, DPIEntities.EMAIL);
-var configWithMasking = config.withDpiMaskingConfig(maskingConfig);
+var maskingConfig =
+    DpiMasking.anonymization().withEntities(DPIEntities.PERSON, DPIEntities.EMAIL);
+var configWithMasking = config.withMaskingConfig(maskingConfig);
 
 var systemMessage = ChatMessage.create()
         .role("system")

--- a/docs/guides/ORCHESTRATION_CHAT_COMPLETION.md
+++ b/docs/guides/ORCHESTRATION_CHAT_COMPLETION.md
@@ -184,15 +184,8 @@ var result =
 Use the data masking module to anonymize personal information in the input:
 
 ```java
-var maskingProvider =
-    MaskingProviderConfig.create()
-        .type(MaskingProviderConfig.TypeEnum.SAP_DATA_PRIVACY_INTEGRATION)
-        .method(MaskingProviderConfig.MethodEnum.ANONYMIZATION)
-        .entities(
-            DPIEntityConfig.create().type(DPIEntities.PHONE),
-            DPIEntityConfig.create().type(DPIEntities.PERSON));
-var maskingConfig = MaskingModuleConfig.create().maskingProviders(maskingProvider);
-var configWithMasking = config.withMaskingConfig(maskingConfig);
+var maskingConfig = DpiMaskingConfig.pseudonymization().withEntities(DPIEntities.PERSON, DPIEntities.EMAIL);
+var configWithMasking = config.withDpiMaskingConfig(maskingConfig);
 
 var systemMessage = ChatMessage.create()
         .role("system")
@@ -210,7 +203,7 @@ var result =
     new OrchestrationClient().chatCompletion(prompt, configWithMasking);
 ```
 
-In this example, the input will be masked before the call to the LLM. Note that data cannot be unmasked in the LLM output.
+In this example, the input will be masked before the call to the LLM and unmasked in the output.
 
 ### Set model parameters
 

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/DpiMasking.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/DpiMasking.java
@@ -76,6 +76,7 @@ public class DpiMasking implements MaskingProvider {
   }
 
   @Nonnull
+  @Override
   public MaskingProviderConfig createConfig() {
     val entitiesDTO = entities.stream().map(it -> new DPIEntityConfig().type(it)).toList();
     return new DPIConfig()

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/DpiMasking.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/DpiMasking.java
@@ -75,7 +75,6 @@ public class DpiMasking implements MaskingProvider {
     }
   }
 
-  /** {@inheritDoc} */
   @Nonnull
   public MaskingProviderConfig createConfig() {
     val entitiesDTO = entities.stream().map(it -> new DPIEntityConfig().type(it)).toList();

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/DpiMasking.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/DpiMasking.java
@@ -7,7 +7,7 @@ import static com.sap.ai.sdk.orchestration.client.model.DPIConfig.TypeEnum.SAP_D
 import com.sap.ai.sdk.orchestration.client.model.DPIConfig;
 import com.sap.ai.sdk.orchestration.client.model.DPIEntities;
 import com.sap.ai.sdk.orchestration.client.model.DPIEntityConfig;
-import com.sap.ai.sdk.orchestration.client.model.MaskingModuleConfig;
+import com.sap.ai.sdk.orchestration.client.model.MaskingProviderConfig;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -25,7 +25,7 @@ import lombok.val;
 @Value
 @Getter(AccessLevel.PACKAGE)
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-public class DpiMaskingConfig {
+public class DpiMasking implements MaskingProvider {
   @Nonnull DPIConfig.MethodEnum maskingMethod;
   @Nonnull List<DPIEntities> entities;
 
@@ -36,7 +36,7 @@ public class DpiMaskingConfig {
    */
   @Nonnull
   public static Builder anonymization() {
-    return new DpiMaskingConfig.Builder(ANONYMIZATION);
+    return new DpiMasking.Builder(ANONYMIZATION);
   }
 
   /**
@@ -46,18 +46,7 @@ public class DpiMaskingConfig {
    */
   @Nonnull
   public static Builder pseudonymization() {
-    return new DpiMaskingConfig.Builder(PSEUDONYMIZATION);
-  }
-
-  @Nonnull
-  MaskingModuleConfig createConfig() {
-    val entitiesDTO = entities.stream().map(it -> new DPIEntityConfig().type(it)).toList();
-    return new MaskingModuleConfig()
-        .addMaskingProvidersItem(
-            new DPIConfig()
-                .type(SAP_DATA_PRIVACY_INTEGRATION)
-                .method(maskingMethod)
-                .entities(entitiesDTO));
+    return new DpiMasking.Builder(PSEUDONYMIZATION);
   }
 
   /**
@@ -73,16 +62,26 @@ public class DpiMaskingConfig {
      *
      * @param entity An entity type to mask (required)
      * @param entities Additional entity types to mask (optional)
-     * @return A configured {@link DpiMaskingConfig} instance
+     * @return A configured {@link DpiMasking} instance
      * @see DPIEntities
      */
     @Nonnull
-    public DpiMaskingConfig withEntities(
+    public DpiMasking withEntities(
         @Nonnull final DPIEntities entity, @Nonnull final DPIEntities... entities) {
       val entitiesList = new ArrayList<DPIEntities>();
       entitiesList.add(entity);
       entitiesList.addAll(Arrays.asList(entities));
-      return new DpiMaskingConfig(maskingMethod, entitiesList);
+      return new DpiMasking(maskingMethod, entitiesList);
     }
+  }
+
+  /** {@inheritDoc} */
+  @Nonnull
+  public MaskingProviderConfig createConfig() {
+    val entitiesDTO = entities.stream().map(it -> new DPIEntityConfig().type(it)).toList();
+    return new DPIConfig()
+        .type(SAP_DATA_PRIVACY_INTEGRATION)
+        .method(maskingMethod)
+        .entities(entitiesDTO);
   }
 }

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/DpiMaskingConfig.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/DpiMaskingConfig.java
@@ -1,0 +1,88 @@
+package com.sap.ai.sdk.orchestration;
+
+import static com.sap.ai.sdk.orchestration.client.model.DPIConfig.MethodEnum.ANONYMIZATION;
+import static com.sap.ai.sdk.orchestration.client.model.DPIConfig.MethodEnum.PSEUDONYMIZATION;
+import static com.sap.ai.sdk.orchestration.client.model.DPIConfig.TypeEnum.SAP_DATA_PRIVACY_INTEGRATION;
+
+import com.sap.ai.sdk.orchestration.client.model.DPIConfig;
+import com.sap.ai.sdk.orchestration.client.model.DPIEntities;
+import com.sap.ai.sdk.orchestration.client.model.DPIEntityConfig;
+import com.sap.ai.sdk.orchestration.client.model.MaskingModuleConfig;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.annotation.Nonnull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import lombok.val;
+
+/**
+ * SAP Data Privacy Integration (DPI) can mask personally identifiable information using either
+ * anonymization or pseudonymization.
+ */
+@Value
+@Getter(AccessLevel.PACKAGE)
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class DpiMaskingConfig {
+  @Nonnull DPIConfig.MethodEnum maskingMethod;
+  @Nonnull List<DPIEntities> entities;
+
+  /**
+   * Build a configuration applying anonymization.
+   *
+   * @return A builder configured for anonymization
+   */
+  @Nonnull
+  public static Builder anonymization() {
+    return new DpiMaskingConfig.Builder(ANONYMIZATION);
+  }
+
+  /**
+   * Build a configuration applying pseudonymization.
+   *
+   * @return A builder configured for pseudonymization
+   */
+  @Nonnull
+  public static Builder pseudonymization() {
+    return new DpiMaskingConfig.Builder(PSEUDONYMIZATION);
+  }
+
+  @Nonnull
+  MaskingModuleConfig createConfig() {
+    val entitiesDTO = entities.stream().map(it -> new DPIEntityConfig().type(it)).toList();
+    return new MaskingModuleConfig()
+        .addMaskingProvidersItem(
+            new DPIConfig()
+                .type(SAP_DATA_PRIVACY_INTEGRATION)
+                .method(maskingMethod)
+                .entities(entitiesDTO));
+  }
+
+  /**
+   * Builder for creating DPI masking configurations. Allows specifying which entity types should be
+   * masked in the input text.
+   */
+  @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+  public static class Builder {
+    private final DPIConfig.MethodEnum maskingMethod;
+
+    /**
+     * Specifies which entities should be masked in the input text.
+     *
+     * @param entity An entity type to mask (required)
+     * @param entities Additional entity types to mask (optional)
+     * @return A configured {@link DpiMaskingConfig} instance
+     * @see DPIEntities
+     */
+    @Nonnull
+    public DpiMaskingConfig withEntities(
+        @Nonnull final DPIEntities entity, @Nonnull final DPIEntities... entities) {
+      val entitiesList = new ArrayList<DPIEntities>();
+      entitiesList.add(entity);
+      entitiesList.addAll(Arrays.asList(entities));
+      return new DpiMaskingConfig(maskingMethod, entitiesList);
+    }
+  }
+}

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/MaskingProvider.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/MaskingProvider.java
@@ -1,0 +1,16 @@
+package com.sap.ai.sdk.orchestration;
+
+import com.sap.ai.sdk.orchestration.client.model.MaskingProviderConfig;
+import javax.annotation.Nonnull;
+
+/** Interface for masking configurations. */
+public interface MaskingProvider {
+
+  /**
+   * Create a masking provider for the configuration.
+   *
+   * @return the masking provider
+   */
+  @Nonnull
+  MaskingProviderConfig createConfig();
+}

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationModuleConfig.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationModuleConfig.java
@@ -62,4 +62,17 @@ public class OrchestrationModuleConfig {
   public OrchestrationModuleConfig withLlmConfig(@Nonnull final OrchestrationAiModel aiModel) {
     return withLlmConfig(aiModel.createConfig());
   }
+
+  /**
+   * Creates a new configuration with the given Data Masking configuration.
+   *
+   * @param dpiMasking The Data Masking configuration to use.
+   * @return A new configuration with the given Data Masking configuration.
+   */
+  @Tolerate
+  @Nonnull
+  public OrchestrationModuleConfig withDpiMaskingConfig(
+      @Nonnull final DpiMaskingConfig dpiMasking) {
+    return withMaskingConfig(dpiMasking.createConfig());
+  }
 }

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationModuleConfig.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationModuleConfig.java
@@ -4,6 +4,7 @@ import com.sap.ai.sdk.orchestration.client.model.FilteringModuleConfig;
 import com.sap.ai.sdk.orchestration.client.model.LLMModuleConfig;
 import com.sap.ai.sdk.orchestration.client.model.MaskingModuleConfig;
 import com.sap.ai.sdk.orchestration.client.model.TemplatingModuleConfig;
+import java.util.Arrays;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.AccessLevel;
@@ -12,6 +13,7 @@ import lombok.NoArgsConstructor;
 import lombok.Value;
 import lombok.With;
 import lombok.experimental.Tolerate;
+import lombok.val;
 
 /**
  * Represents the configuration for the orchestration service. Allows for configuring the different
@@ -66,13 +68,20 @@ public class OrchestrationModuleConfig {
   /**
    * Creates a new configuration with the given Data Masking configuration.
    *
-   * @param dpiMasking The Data Masking configuration to use.
+   * @param maskingProvider The Data Masking configuration to use.
+   * @param maskingProviders Additional Data Masking configurations to use.
    * @return A new configuration with the given Data Masking configuration.
    */
   @Tolerate
   @Nonnull
-  public OrchestrationModuleConfig withDpiMaskingConfig(
-      @Nonnull final DpiMaskingConfig dpiMasking) {
-    return withMaskingConfig(dpiMasking.createConfig());
+  public OrchestrationModuleConfig withMaskingConfig(
+      @Nonnull final MaskingProvider maskingProvider,
+      @Nonnull final MaskingProvider... maskingProviders) {
+    val newMaskingConfig =
+        new MaskingModuleConfig().addMaskingProvidersItem(maskingProvider.createConfig());
+    Arrays.stream(maskingProviders)
+        .forEach(it -> newMaskingConfig.addMaskingProvidersItem(it.createConfig()));
+
+    return withMaskingConfig(newMaskingConfig);
   }
 }

--- a/orchestration/src/test/java/com/sap/ai/sdk/orchestration/ConfigToRequestTransformerTest.java
+++ b/orchestration/src/test/java/com/sap/ai/sdk/orchestration/ConfigToRequestTransformerTest.java
@@ -1,5 +1,6 @@
 package com.sap.ai.sdk.orchestration;
 
+import static com.sap.ai.sdk.orchestration.OrchestrationAiModel.GPT_4O;
 import static com.sap.ai.sdk.orchestration.OrchestrationUnitTest.CUSTOM_GPT_35;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -100,5 +101,27 @@ class ConfigToRequestTransformerTest {
     assertThat(configModified.getMaskingConfig().getMaskingProviders())
         .withFailMessage("withMaskingConfig() should overwrite the existing config and not append")
         .hasSize(1);
+  }
+
+  @Test
+  void testLLMConfig() {
+    Map<String, Object> params = Map.of("foo", "bar");
+    String version = "2024-05-13";
+    OrchestrationAiModel aiModel = GPT_4O.withModelParams(params).withModelVersion(version);
+    var config = new OrchestrationModuleConfig().withLlmConfig(aiModel);
+
+    var actual = ConfigToRequestTransformer.toModuleConfigs(config);
+
+    assertThat(actual.getLlmModuleConfig()).isNotNull();
+    assertThat(actual.getLlmModuleConfig().getModelName()).isEqualTo(GPT_4O.getModelName());
+    assertThat(actual.getLlmModuleConfig().getModelParams()).isEqualTo(params);
+    assertThat(actual.getLlmModuleConfig().getModelVersion()).isEqualTo(version);
+
+    assertThat(GPT_4O.getModelParams())
+        .withFailMessage("Static models should be unchanged")
+        .isEmpty();
+    assertThat(GPT_4O.getModelVersion())
+        .withFailMessage("Static models should be unchanged")
+        .isEqualTo("latest");
   }
 }

--- a/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
+++ b/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
@@ -34,19 +34,15 @@ import com.sap.ai.sdk.orchestration.client.model.AzureContentSafetyFilterConfig;
 import com.sap.ai.sdk.orchestration.client.model.AzureThreshold;
 import com.sap.ai.sdk.orchestration.client.model.ChatMessage;
 import com.sap.ai.sdk.orchestration.client.model.CompletionPostRequest;
-import com.sap.ai.sdk.orchestration.client.model.DPIConfig;
 import com.sap.ai.sdk.orchestration.client.model.DPIEntities;
-import com.sap.ai.sdk.orchestration.client.model.DPIEntityConfig;
 import com.sap.ai.sdk.orchestration.client.model.FilteringModuleConfig;
 import com.sap.ai.sdk.orchestration.client.model.GenericModuleResult;
 import com.sap.ai.sdk.orchestration.client.model.InputFilteringConfig;
 import com.sap.ai.sdk.orchestration.client.model.LLMModuleResultSynchronous;
-import com.sap.ai.sdk.orchestration.client.model.MaskingModuleConfig;
 import com.sap.ai.sdk.orchestration.client.model.OutputFilteringConfig;
 import com.sap.cloud.sdk.cloudplatform.connectivity.DefaultHttpDestination;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -306,10 +302,9 @@ class OrchestrationUnitTest {
                     .withBodyFile("maskingResponse.json")
                     .withHeader("Content-Type", "application/json")));
 
-    final var maskingConfig =
-        createMaskingConfig(DPIConfig.MethodEnum.PSEUDONYMIZATION, DPIEntities.PHONE);
+    final var maskingConfig = DpiMaskingConfig.pseudonymization().withEntities(DPIEntities.PHONE);
 
-    final var result = client.chatCompletion(prompt, config.withMaskingConfig(maskingConfig));
+    final var result = client.chatCompletion(prompt, config.withDpiMaskingConfig(maskingConfig));
     final var response = result.getOriginalResponse();
 
     assertThat(response).isNotNull();
@@ -326,20 +321,6 @@ class OrchestrationUnitTest {
           postRequestedFor(urlPathEqualTo("/v2/inference/deployments/abcdef0123456789/completion"))
               .withRequestBody(equalToJson(request)));
     }
-  }
-
-  private static MaskingModuleConfig createMaskingConfig(
-      @Nonnull final DPIConfig.MethodEnum method, @Nonnull final DPIEntities... entities) {
-
-    final var entityConfigs =
-        Arrays.stream(entities).map(it -> new DPIEntityConfig().type(it)).toList();
-    return new MaskingModuleConfig()
-        .maskingProviders(
-            List.of(
-                new DPIConfig()
-                    .type(DPIConfig.TypeEnum.SAP_DATA_PRIVACY_INTEGRATION)
-                    .method(method)
-                    .entities(entityConfigs)));
   }
 
   @Test

--- a/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
+++ b/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
@@ -302,9 +302,9 @@ class OrchestrationUnitTest {
                     .withBodyFile("maskingResponse.json")
                     .withHeader("Content-Type", "application/json")));
 
-    final var maskingConfig = DpiMaskingConfig.pseudonymization().withEntities(DPIEntities.PHONE);
+    final var maskingConfig = DpiMasking.pseudonymization().withEntities(DPIEntities.PHONE);
 
-    final var result = client.chatCompletion(prompt, config.withDpiMaskingConfig(maskingConfig));
+    final var result = client.chatCompletion(prompt, config.withMaskingConfig(maskingConfig));
     final var response = result.getOriginalResponse();
 
     assertThat(response).isNotNull();

--- a/pom.xml
+++ b/pom.xml
@@ -76,11 +76,11 @@
     <enforcer.skipEnforceScopeLombok>false</enforcer.skipEnforceScopeLombok>
     <enforcer.skipBanGeneratedModulesReference>false</enforcer.skipBanGeneratedModulesReference>
     <!-- Test coverage -->
-    <coverage.instruction>74%</coverage.instruction>
+    <coverage.instruction>75%</coverage.instruction>
     <coverage.branch>67%</coverage.branch>
-    <coverage.complexity>67%</coverage.complexity>
-    <coverage.line>75%</coverage.line>
-    <coverage.method>80%</coverage.method>
+    <coverage.complexity>69%</coverage.complexity>
+    <coverage.line>76%</coverage.line>
+    <coverage.method>85%</coverage.method>
     <coverage.class>85%</coverage.class>
   </properties>
 

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/OrchestrationController.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/OrchestrationController.java
@@ -2,7 +2,7 @@ package com.sap.ai.sdk.app.controllers;
 
 import static com.sap.ai.sdk.orchestration.OrchestrationAiModel.GPT_35_TURBO;
 
-import com.sap.ai.sdk.orchestration.DpiMaskingConfig;
+import com.sap.ai.sdk.orchestration.DpiMasking;
 import com.sap.ai.sdk.orchestration.OrchestrationChatResponse;
 import com.sap.ai.sdk.orchestration.OrchestrationClient;
 import com.sap.ai.sdk.orchestration.OrchestrationModuleConfig;
@@ -155,8 +155,8 @@ class OrchestrationController {
     """);
 
     final var prompt = new OrchestrationPrompt(systemMessage, userMessage);
-    final var maskingConfig = DpiMaskingConfig.anonymization().withEntities(DPIEntities.PERSON);
-    final var configWithMasking = config.withDpiMaskingConfig(maskingConfig);
+    final var maskingConfig = DpiMasking.anonymization().withEntities(DPIEntities.PERSON);
+    final var configWithMasking = config.withMaskingConfig(maskingConfig);
 
     return client.chatCompletion(prompt, configWithMasking);
   }
@@ -193,8 +193,8 @@ class OrchestrationController {
 
     final var prompt = new OrchestrationPrompt(systemMessage, userMessage);
     final var maskingConfig =
-        DpiMaskingConfig.pseudonymization().withEntities(DPIEntities.PERSON, DPIEntities.EMAIL);
-    final var configWithMasking = config.withDpiMaskingConfig(maskingConfig);
+        DpiMasking.pseudonymization().withEntities(DPIEntities.PERSON, DPIEntities.EMAIL);
+    final var configWithMasking = config.withMaskingConfig(maskingConfig);
 
     return client.chatCompletion(prompt, configWithMasking);
   }

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/OrchestrationController.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/OrchestrationController.java
@@ -2,6 +2,7 @@ package com.sap.ai.sdk.app.controllers;
 
 import static com.sap.ai.sdk.orchestration.OrchestrationAiModel.GPT_35_TURBO;
 
+import com.sap.ai.sdk.orchestration.DpiMaskingConfig;
 import com.sap.ai.sdk.orchestration.OrchestrationChatResponse;
 import com.sap.ai.sdk.orchestration.OrchestrationClient;
 import com.sap.ai.sdk.orchestration.OrchestrationModuleConfig;
@@ -10,15 +11,11 @@ import com.sap.ai.sdk.orchestration.client.model.AzureContentSafety;
 import com.sap.ai.sdk.orchestration.client.model.AzureContentSafetyFilterConfig;
 import com.sap.ai.sdk.orchestration.client.model.AzureThreshold;
 import com.sap.ai.sdk.orchestration.client.model.ChatMessage;
-import com.sap.ai.sdk.orchestration.client.model.DPIConfig;
 import com.sap.ai.sdk.orchestration.client.model.DPIEntities;
-import com.sap.ai.sdk.orchestration.client.model.DPIEntityConfig;
 import com.sap.ai.sdk.orchestration.client.model.FilteringModuleConfig;
 import com.sap.ai.sdk.orchestration.client.model.InputFilteringConfig;
-import com.sap.ai.sdk.orchestration.client.model.MaskingModuleConfig;
 import com.sap.ai.sdk.orchestration.client.model.OutputFilteringConfig;
 import com.sap.ai.sdk.orchestration.client.model.Template;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
@@ -158,9 +155,8 @@ class OrchestrationController {
     """);
 
     final var prompt = new OrchestrationPrompt(systemMessage, userMessage);
-    final var maskingConfig =
-        createMaskingConfig(DPIConfig.MethodEnum.ANONYMIZATION, DPIEntities.PERSON);
-    final var configWithMasking = config.withMaskingConfig(maskingConfig);
+    final var maskingConfig = DpiMaskingConfig.anonymization().withEntities(DPIEntities.PERSON);
+    final var configWithMasking = config.withDpiMaskingConfig(maskingConfig);
 
     return client.chatCompletion(prompt, configWithMasking);
   }
@@ -197,31 +193,9 @@ class OrchestrationController {
 
     final var prompt = new OrchestrationPrompt(systemMessage, userMessage);
     final var maskingConfig =
-        createMaskingConfig(
-            DPIConfig.MethodEnum.PSEUDONYMIZATION, DPIEntities.PERSON, DPIEntities.EMAIL);
-    final var configWithMasking = config.withMaskingConfig(maskingConfig);
+        DpiMaskingConfig.pseudonymization().withEntities(DPIEntities.PERSON, DPIEntities.EMAIL);
+    final var configWithMasking = config.withDpiMaskingConfig(maskingConfig);
 
     return client.chatCompletion(prompt, configWithMasking);
-  }
-
-  /**
-   * Helper method to build masking configurations.
-   *
-   * @param method Either anonymization or pseudonymization.
-   * @param entities The entities to mask.
-   * @return A new masking configuration object.
-   */
-  private static MaskingModuleConfig createMaskingConfig(
-      @Nonnull final DPIConfig.MethodEnum method, @Nonnull final DPIEntities... entities) {
-
-    final var entityConfigs =
-        Arrays.stream(entities).map(it -> new DPIEntityConfig().type(it)).toList();
-    return new MaskingModuleConfig()
-        .maskingProviders(
-            List.of(
-                new DPIConfig()
-                    .type(DPIConfig.TypeEnum.SAP_DATA_PRIVACY_INTEGRATION)
-                    .method(method)
-                    .entities(entityConfigs)));
   }
 }


### PR DESCRIPTION
## Context

AI/ai-sdk-java-backlog#102.

As an orchestration user, I want to have a convenient way of configuring data masking.

### Feature scope:
 
- [x] Created `withDpiMaskingConfig(DpiMaskingConfig)`

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] Error handling created / updated & covered by the tests above
- [ ] ~Aligned changes with the JavaScript SDK~
- [x] Documentation updated
- [ ] ~Release notes updated~
