### PR TITLE
chore: [DevOps] Reschedule E2E Tests

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -2,7 +2,7 @@ name: "End-to-end Tests"
 on:
   workflow_dispatch:
   schedule:
-    - cron: 0 22 * * *
+    - cron: 0 2 * * *
 
 env:
   MVN_MULTI_THREADED_ARGS: --batch-mode --no-transfer-progress --fail-at-end --show-version --threads 1C


### PR DESCRIPTION
Shift the time to not run at the same time as JS