### PR TITLE
Align handling of empty choices

### DIFF
--- a/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/model/OpenAiChatCompletionOutput.java
+++ b/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/model/OpenAiChatCompletionOutput.java
@@ -40,9 +40,7 @@ public class OpenAiChatCompletionOutput extends OpenAiCompletionOutput
    */
   @Nonnull
   public String getContent() throws OpenAiClientException {
-    if (getChoices().isEmpty()) {
-      return "";
-    }
+    //    We expect choices to be defined and never empty.
     if ("content_filter".equals(getChoices().get(0).getFinishReason())) {
       throw new OpenAiClientException("Content filter filtered the output.");
     }


### PR DESCRIPTION
## Context

This PR aligns the handling of empty choices (which should never occur) in the `OpenAiChatResponseOutput` class with the behaviour discussed in https://github.com/SAP/ai-sdk-java/pull/173.

### Feature scope:
 
- [x] Added comment in the code.


## Definition of Done

- [x] Functionality scope stated & covered
- [ ] ~Tests cover the scope above~
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Aligned changes with the JavaScript SDK~
- [ ] ~Documentation updated~
- [ ] ~Release notes updated~
