### PR TITLE
fix: Update Response Masking Format

### DIFF
--- a/orchestration/src/test/resources/__files/maskingResponse.json
+++ b/orchestration/src/test/resources/__files/maskingResponse.json
@@ -14,16 +14,7 @@
     "input_masking": {
       "message": "Input to LLM is masked successfully.",
       "data": {
-        "masked_template": [
-          {
-            "role": "system",
-            "content": "Please write an initial response to the below user feedback, stating that we are working on the feedback and will get back to them soon.\nPlease make sure to address the user in person and end with \"Best regards, the AI SDK team\".\n"
-          },
-          {
-            "role": "user",
-            "content": "Username: MASKED_PERSON_2\nuserEmail: MASKED_PERSON_3MASKED_EMAIL_1\nDate: 2022-01-01\n\nI think the SDK is good, but could use some further enhancements.\nMy architect MASKED_PERSON_1 and manager MASKED_PERSON_4 pointed out that we need the grounding capabilities, which aren't supported yet.\n"
-          }
-        ]
+        "masked_template": "[{\"role\": \"system\", \"content\": \"Please write an initial response to the below user feedback, stating that we are working on the feedback and will get back to them soon.\\nPlease make sure to address the user in person and end with \\\"Best regards, the AI SDK team\\\".\\n\"}, {\"role\": \"user\", \"content\": \"Username: MASKED_PERSON_2\\nuserEmail: MASKED_PERSON_1MASKED_EMAIL_1\\nDate: 2022-01-01\\n\\nI think the SDK is good, but could use some further enhancements.\\nMy architect MASKED_PERSON_4 and manager MASKED_PERSON_3 pointed out that we need the grounding capabilities, which aren't supported yet.\\n\"}]"
       }
     },
     "llm": {

--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
@@ -137,9 +137,8 @@ class OrchestrationTest {
     var maskingResult = result.getModuleResults().getInputMasking();
     assertThat(maskingResult.getMessage()).isNotEmpty();
     var data = (Map<String, Object>) maskingResult.getData();
-    var maskedMessage = ((List<Map<String, Object>>) data.get("masked_template")).get(1);
-    assertThat(maskedMessage.get("content"))
-        .asInstanceOf(InstanceOfAssertFactories.STRING)
+    var maskedMessage = (String) data.get("masked_template");
+    assertThat(maskedMessage)
         .describedAs("The masked input should not contain any user names but only pseudonyms")
         .doesNotContain("Mallory", "Alice", "Bob")
         .contains("MASKED_PERSON");


### PR DESCRIPTION
## Context

This PR adjust the tests to reflect a change of in the orchestration response regarding masking.

Note: we assert on the response format to ensure the examples are working as intended, even though the response format is not part of the spec and might change in the future