### PR TITLE
[Orchestration] Convenience Message on Response

### DIFF
--- a/docs/guides/ORCHESTRATION_CHAT_COMPLETION.md
+++ b/docs/guides/ORCHESTRATION_CHAT_COMPLETION.md
@@ -102,10 +102,7 @@ The LLM response is available as the first choice under the `result.getOrchestra
 Use a prepared template and execute requests with by passing only the input parameters:
 
 ```java
-var template =
-    ChatMessage.create()
-        .role("user")
-        .content("Reply with 'Orchestration Service is working!' in {{?language}}");
+var template = Message.user("Reply with 'Orchestration Service is working!' in {{?language}}");
 var templatingConfig = TemplatingModuleConfig.create().template(template);
 var configWithTemplate = config.withTemplateConfig(templatingConfig);
 
@@ -124,10 +121,10 @@ Include a message history to maintain context in the conversation:
 ```java
 var messagesHistory =
         List.of(
-                ChatMessage.create().role("user").content("What is the capital of France?"),
-                ChatMessage.create().role("assistant").content("The capital of France is Paris."));
+            Message.user("What is the capital of France?"),
+            Message.assistant("The capital of France is Paris."));
 var message =
-        ChatMessage.create().role("user").content("What is the typical food there?");
+    Message.user("What is the typical food there?");
 
 var prompt = new OrchestrationPrompt(message).messageHistory(messagesHistory);
 
@@ -175,12 +172,8 @@ var maskingConfig =
     DpiMasking.anonymization().withEntities(DPIEntities.PHONE, DPIEntities.PERSON);
 var configWithMasking = config.withMaskingConfig(maskingConfig);
 
-var systemMessage = ChatMessage.create()
-        .role("system")
-        .content("Please evaluate the following user feedback and judge if the sentiment is positive or negative.");
-var userMessage = ChatMessage.create()
-        .role("user")
-        .content("""
+var systemMessage = Message.system("Please evaluate the following user feedback and judge if the sentiment is positive or negative.");
+var userMessage = Message.user("""
                  I think the SDK is good, but could use some further enhancements.
                  My architect Alice and manager Bob pointed out that we need the grounding capabilities, which aren't supported yet.
                  """);

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/Message.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/Message.java
@@ -1,5 +1,6 @@
 package com.sap.ai.sdk.orchestration;
 
+import com.google.common.annotations.Beta;
 import com.sap.ai.sdk.orchestration.model.ChatMessage;
 import javax.annotation.Nonnull;
 
@@ -63,5 +64,6 @@ public sealed interface Message permits UserMessage, AssistantMessage, SystemMes
    * @return the content.
    */
   @Nonnull
+  @Beta
   String content();
 }

--- a/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
+++ b/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
@@ -129,9 +129,9 @@ class OrchestrationUnitTest {
 
     final var response = result.getOriginalResponse();
     assertThat(response.getRequestId()).isEqualTo("26ea36b5-c196-4806-a9a6-a686f0c6ad91");
-    assertThat(result.getAllMessages().get(0).getContent())
+    assertThat(result.getAllMessages().get(0).content())
         .isEqualTo("Reply with 'Orchestration Service is working!' in German");
-    assertThat(result.getAllMessages().get(0).getRole()).isEqualTo("user");
+    assertThat(result.getAllMessages().get(0).role()).isEqualTo("user");
     var llm = (LLMModuleResultSynchronous) response.getModuleResults().getLlm();
     assertThat(llm).isNotNull();
     assertThat(llm.getId()).isEqualTo("chatcmpl-9lzPV4kLrXjFckOp2yY454wksWBoj");

--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
@@ -40,9 +40,9 @@ class OrchestrationTest {
     final var response = result.getOriginalResponse();
 
     assertThat(response.getRequestId()).isNotEmpty();
-    assertThat(result.getAllMessages().get(0).getContent())
+    assertThat(result.getAllMessages().get(0).content())
         .isEqualTo("Reply with 'Orchestration Service is working!' in German");
-    assertThat(result.getAllMessages().get(0).getRole()).isEqualTo("user");
+    assertThat(result.getAllMessages().get(0).role()).isEqualTo("user");
     var llm = (LLMModuleResultSynchronous) response.getModuleResults().getLlm();
     assertThat(llm.getId()).isNotEmpty();
     assertThat(llm.getObject()).isEqualTo("chat.completion");


### PR DESCRIPTION
- Mark content getter beta
- Improve e2e test for continuous message interaction.

## Context

AI/ai-sdk-java-backlog#101.

Users should be able to directly plugin the response messages as part of message history for  subsequent prompts.

### Feature scope:
 
- [x] High level Response object returns convenience Message objects
- [x] Tag content getter as Beta
- [x] E2E test for follow up prompting added

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Aligned changes with the JavaScript SDK~
- [x] Documentation updated
- [ ] ~Release notes updated~
