### PR TITLE
Fix javadoc in sample code

### DIFF
--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/OrchestrationController.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/OrchestrationController.java
@@ -43,7 +43,7 @@ class OrchestrationController {
   }
 
   /**
-   * Chat request to OpenAI through the Orchestration service with a template
+   * Chat request to OpenAI through the Orchestration service with a template.
    *
    * @return the result object
    */
@@ -62,7 +62,7 @@ class OrchestrationController {
   }
 
   /**
-   * Chat request to OpenAI through the Orchestration service with a template
+   * Chat request to OpenAI through the Orchestration service using message history.
    *
    * @return the result object
    */


### PR DESCRIPTION
## Context

(Very minor)

Seems like one of the javadocs in the sample-code git simply copied to another method.


### Feature scope:
 
n.a.

## Definition of Done

n.a.
