### PR TITLE
[Doc] For request/parameter objects, use `var` instead of type

### DIFF
--- a/docs/guides/AI_CORE_DEPLOYMENT.md
+++ b/docs/guides/AI_CORE_DEPLOYMENT.md
@@ -69,12 +69,12 @@ Use the following code snippet to create a deployment in SAP AI Core:
 ```java
 var api = new DeploymentApi();
 var resourceGroupId = "default";
+var configurationId = "12345-123-123-123-123456abcdefg";
 
-AiDeploymentCreationRequest request =
-    AiDeploymentCreationRequest.create().configurationId("12345-123-123-123-123456abcdefg");
-AiDeploymentCreationResponse deployment = api.create(resourceGroupId, request);
+var request = AiDeploymentCreationRequest.create().configurationId(configurationId);
+var deployment = api.create(resourceGroupId, request);
 
-var id = deployment.getId();
+String id = deployment.getId();
 AiExecutionStatus status = deployment.getStatus();
 ```
 

--- a/docs/guides/OPENAI_CHAT_COMPLETION.md
+++ b/docs/guides/OPENAI_CHAT_COMPLETION.md
@@ -89,7 +89,7 @@ In addition to the prerequisites above, we assume you have already set up the fo
 ### Simple chat completion
 
 ```java
-OpenAiChatCompletionOutput result =
+var result =
     OpenAiClient.forModel(GPT_35_TURBO)
         .withSystemPrompt("You are a helpful AI")
         .chatCompletion("Hello World! Why is this phrase so famous?");
@@ -107,8 +107,7 @@ var userMessage =
 var request =
     new OpenAiChatCompletionParameters().addMessages(systemMessage, userMessage);
 
-OpenAiChatCompletionOutput result =
-    OpenAiClient.forModel(GPT_35_TURBO).chatCompletion(request);
+var result = OpenAiClient.forModel(GPT_35_TURBO).chatCompletion(request);
 
 String resultMessage = result.getContent();
 ```
@@ -167,12 +166,12 @@ Any asynchronous library can be used, such as the classic Thread API.
 ```java
 var message = "Can you give me the first 100 numbers of the Fibonacci sequence?";
 
-OpenAiChatMessage.OpenAiChatUserMessage userMessage =
+var userMessage =
     new OpenAiChatMessage.OpenAiChatUserMessage().addText(message);
-OpenAiChatCompletionParameters requestParameters =
+var requestParameters =
     new OpenAiChatCompletionParameters().addMessages(userMessage);
 
-OpenAiClient client = OpenAiClient.forModel(GPT_35_TURBO);
+var client = OpenAiClient.forModel(GPT_35_TURBO);
 var totalOutput = new OpenAiChatCompletionOutput();
 
 // Prepare the stream before starting the thread to handle any initialization exceptions
@@ -206,7 +205,7 @@ Boot's `ResponseBodyEmitter` to stream the chat completion delta messages to the
 Get the embeddings of a text input in list of float values:
 
 ```java
-OpenAiEmbeddingParameters request = new OpenAiEmbeddingParameters().setInput("Hello World");
+var request = new OpenAiEmbeddingParameters().setInput("Hello World");
 
 OpenAiEmbeddingOutput embedding = OpenAiClient.forModel(TEXT_EMBEDDING_ADA_002).embedding(request);
 ```


### PR DESCRIPTION
To improve focus, I think it's worth to only explicitly declare the "interesting" result types.

We did this in other parts of the docs already.

Not a strong opinion, I'm fine with using this PR as discussion starter.