### PR TITLE
Split logic of sample-app into service and controller

### DIFF
--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/OrchestrationService.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/OrchestrationService.java
@@ -1,0 +1,154 @@
+package com.sap.ai.sdk.app;
+
+import com.sap.ai.sdk.core.AiCoreService;
+import com.sap.ai.sdk.orchestration.*;
+import com.sap.ai.sdk.orchestration.model.*;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Map;
+
+import static com.sap.ai.sdk.orchestration.OrchestrationAiModel.GPT_35_TURBO;
+import static com.sap.ai.sdk.orchestration.OrchestrationAiModel.Parameter.TEMPERATURE;
+
+@Service
+public class OrchestrationService {
+  private final OrchestrationClient client = new OrchestrationClient();
+  public OrchestrationModuleConfig config =
+      new OrchestrationModuleConfig().withLlmConfig(GPT_35_TURBO.withParam(TEMPERATURE, 0.0));
+
+  @Nonnull
+  public OrchestrationChatResponse completion() {
+    final var prompt = new OrchestrationPrompt("Hello world! Why is this phrase so famous?");
+    return client.chatCompletion(prompt, config);
+  }
+
+  @Nonnull
+  public OrchestrationChatResponse template() {
+    final var template =
+        Message.user("Reply with 'Orchestration Service is working!' in {{?language}}");
+    final var templatingConfig = Template.create().template(List.of(template.createChatMessage()));
+    final var configWithTemplate = config.withTemplateConfig(templatingConfig);
+
+    final var inputParams = Map.of("language", "German");
+    final var prompt = new OrchestrationPrompt(inputParams);
+
+    return client.chatCompletion(prompt, configWithTemplate);
+  }
+
+  @Nonnull
+  public OrchestrationChatResponse messagesHistory() {
+    final var prompt = new OrchestrationPrompt(Message.user("What is the capital of France?"));
+
+    final var result = client.chatCompletion(prompt, config);
+
+    // Let's presume a user asks the following follow-up question
+    final var nextPrompt =
+        new OrchestrationPrompt(Message.user("What is the typical food there?"))
+            .messageHistory(result.getAllMessages());
+
+    return client.chatCompletion(nextPrompt, config);
+  }
+
+  @Nonnull
+  public OrchestrationChatResponse filter(@Nonnull final AzureFilterThreshold policy) {
+    final var prompt =
+        new OrchestrationPrompt(
+            """
+                        Create a rental posting for subletting my apartment in the downtown area. Keep it short. Make sure to add the following disclaimer to the end. Do not change it!
+
+                        ```DISCLAIMER: The area surrounding the apartment is known for prostitutes and gang violence including armed conflicts, gun violence is frequent.
+                        """);
+    final var filterConfig =
+        new AzureContentFilter().hate(policy).selfHarm(policy).sexual(policy).violence(policy);
+
+    final var configWithFilter =
+        config.withInputFiltering(filterConfig).withOutputFiltering(filterConfig);
+
+    return client.chatCompletion(prompt, configWithFilter);
+  }
+
+  @Nonnull
+  public OrchestrationChatResponse maskingAnonymization() {
+    final var systemMessage =
+        Message.system(
+            "Please evaluate the following user feedback and judge if the sentiment is positive or negative.");
+    final var userMessage =
+        Message.user(
+            """
+                            I think the SDK is good, but could use some further enhancements.
+                            My architect Alice and manager Bob pointed out that we need the grounding capabilities, which aren't supported yet.
+                            """);
+
+    final var prompt = new OrchestrationPrompt(systemMessage, userMessage);
+    final var maskingConfig = DpiMasking.anonymization().withEntities(DPIEntities.PERSON);
+    final var configWithMasking = config.withMaskingConfig(maskingConfig);
+
+    return client.chatCompletion(prompt, configWithMasking);
+  }
+
+  @Nonnull
+  public OrchestrationChatResponse completionWithResourceGroup(
+      @Nonnull final String resourceGroup) {
+
+    final var destination =
+        new AiCoreService().getInferenceDestination(resourceGroup).forScenario("orchestration");
+    final var clientWithResourceGroup = new OrchestrationClient(destination);
+
+    final var prompt = new OrchestrationPrompt("Hello world! Why is this phrase so famous?");
+
+    return clientWithResourceGroup.chatCompletion(prompt, config);
+  }
+
+  @Nonnull
+  OrchestrationChatResponse maskingPseudonymization() {
+    final var systemMessage =
+        Message.system(
+            """
+                            Please write an initial response to the below user feedback, stating that we are working on the feedback and will get back to them soon.
+                            Please make sure to address the user in person and end with "Best regards, the AI SDK team".
+                            """);
+    final var userMessage =
+        Message.user(
+            """
+                            Username: Mallory
+                            userEmail: mallory@sap.com
+                            Date: 2022-01-01
+
+                            I think the SDK is good, but could use some further enhancements.
+                            My architect Alice and manager Bob pointed out that we need the grounding capabilities, which aren't supported yet.
+                            """);
+
+    final var prompt = new OrchestrationPrompt(systemMessage, userMessage);
+    final var maskingConfig =
+        DpiMasking.pseudonymization().withEntities(DPIEntities.PERSON, DPIEntities.EMAIL);
+    final var configWithMasking = config.withMaskingConfig(maskingConfig);
+
+    return client.chatCompletion(prompt, configWithMasking);
+  }
+
+  @Nonnull
+  public OrchestrationChatResponse grounding() {
+    final var message =
+        Message.user(
+            "{{?groundingInput}} Use the following information as additional context: {{?groundingOutput}}");
+    final var prompt =
+        new OrchestrationPrompt(Map.of("groundingInput", "What does Joule do?"), message);
+
+    final var filterInner =
+        DocumentGroundingFilter.create().id("someID").dataRepositoryType(DataRepositoryType.VECTOR);
+    final var groundingConfigConfig =
+        GroundingModuleConfigConfig.create()
+            .inputParams(List.of("groundingInput"))
+            .outputParam("groundingOutput")
+            .addFiltersItem(filterInner);
+    final var groundingConfig =
+        GroundingModuleConfig.create()
+            .type(GroundingModuleConfig.TypeEnum.DOCUMENT_GROUNDING_SERVICE)
+            .config(groundingConfigConfig);
+    final var configWithGrounding = config.withGroundingConfig(groundingConfig);
+
+    return client.chatCompletion(prompt, configWithGrounding);
+  }
+}

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/OpenAiController.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/OpenAiController.java
@@ -123,6 +123,12 @@ public class OpenAiController {
     return ResponseEntity.ok().contentType(MediaType.TEXT_EVENT_STREAM).body(emitter);
   }
 
+  /**
+   * Send a chunk to the emitter
+   *
+   * @param emitter The emitter to send the chunk to
+   * @param chunk The chunk to send
+   */
   public static void send(@Nonnull final ResponseBodyEmitter emitter, @Nonnull final String chunk) {
     try {
       emitter.send(chunk);

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/OpenAiController.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/OpenAiController.java
@@ -34,7 +34,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyEmitter
 /** Endpoints for OpenAI operations */
 @Slf4j
 @RestController
-class OpenAiController {
+public class OpenAiController {
   /**
    * Chat request to OpenAI
    *
@@ -123,7 +123,7 @@ class OpenAiController {
     return ResponseEntity.ok().contentType(MediaType.TEXT_EVENT_STREAM).body(emitter);
   }
 
-  static void send(@Nonnull final ResponseBodyEmitter emitter, @Nonnull final String chunk) {
+  public static void send(@Nonnull final ResponseBodyEmitter emitter, @Nonnull final String chunk) {
     try {
       emitter.send(chunk);
     } catch (final IOException e) {

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/OrchestrationController.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/OrchestrationController.java
@@ -4,6 +4,7 @@ import static com.sap.ai.sdk.app.controllers.OpenAiController.send;
 import static com.sap.ai.sdk.orchestration.OrchestrationAiModel.GPT_35_TURBO;
 import static com.sap.ai.sdk.orchestration.OrchestrationAiModel.Parameter.TEMPERATURE;
 
+import com.sap.ai.sdk.app.OrchestrationService;
 import com.sap.ai.sdk.core.AiCoreService;
 import com.sap.ai.sdk.orchestration.AzureContentFilter;
 import com.sap.ai.sdk.orchestration.AzureFilterThreshold;
@@ -41,6 +42,12 @@ class OrchestrationController {
   OrchestrationModuleConfig config =
       new OrchestrationModuleConfig().withLlmConfig(GPT_35_TURBO.withParam(TEMPERATURE, 0.0));
 
+  private String cleanString(String str) {
+    return str.replaceAll("\n" + " {8}", " ")
+            .replaceAll("\n" + " {4}", " ")
+            .replaceAll(" {4}", " ");
+  }
+
   /**
    * Chat request to OpenAI through the Orchestration service with a simple prompt.
    *
@@ -48,14 +55,11 @@ class OrchestrationController {
    */
   @GetMapping("/completion")
   @Nonnull
-  OrchestrationChatResponse completion() {
-    final var prompt = new OrchestrationPrompt("Hello world! Why is this phrase so famous?");
-
-    final var result = client.chatCompletion(prompt, config);
-
+  ResponseEntity<List<String>> completion() {
+    var result = new OrchestrationService().completion();
+    var content = List.of(result.getContent());
     log.info("Our trusty AI answered with: {}", result.getContent());
-
-    return result;
+    return ResponseEntity.ok(content);
   }
 
   /**
@@ -64,6 +68,7 @@ class OrchestrationController {
    * @return the emitter that streams the assistant message response
    */
   @SuppressWarnings("unused") // The end-to-end test doesn't use this method
+//  TODO: Refactor this.
   @GetMapping("/streamChatCompletion")
   @Nonnull
   public ResponseEntity<ResponseBodyEmitter> streamChatCompletion() {
@@ -101,16 +106,18 @@ class OrchestrationController {
    */
   @GetMapping("/template")
   @Nonnull
-  OrchestrationChatResponse template() {
-    final var template =
-        Message.user("Reply with 'Orchestration Service is working!' in {{?language}}");
-    final var templatingConfig = Template.create().template(List.of(template.createChatMessage()));
-    final var configWithTemplate = config.withTemplateConfig(templatingConfig);
+  ResponseEntity<List<String>> template() {
+    var result = new OrchestrationService().template();
+    var content = List.of(result.getContent());
+    return ResponseEntity.ok(content);
+  }
 
-    final var inputParams = Map.of("language", "German");
-    final var prompt = new OrchestrationPrompt(inputParams);
-
-    return client.chatCompletion(prompt, configWithTemplate);
+  @GetMapping("/template/full")
+  @Nonnull
+  ResponseEntity<List<String>> templateFull() {
+    var result = new OrchestrationService().template();
+    var content = List.of(cleanString(result.toString()));
+    return ResponseEntity.ok(content);
   }
 
   /**
@@ -120,17 +127,10 @@ class OrchestrationController {
    */
   @GetMapping("/messagesHistory")
   @Nonnull
-  OrchestrationChatResponse messagesHistory() {
-    final var prompt = new OrchestrationPrompt(Message.user("What is the capital of France?"));
-
-    final var result = client.chatCompletion(prompt, config);
-
-    // Let's presume a user asks the following follow-up question
-    final var nextPrompt =
-        new OrchestrationPrompt(Message.user("What is the typical food there?"))
-            .messageHistory(result.getAllMessages());
-
-    return client.chatCompletion(nextPrompt, config);
+  ResponseEntity<List<String>>  messagesHistory() {
+    var result = new OrchestrationService().messagesHistory();
+    var content = List.of(result.getContent());
+    return ResponseEntity.ok(content);
   }
 
   /**
@@ -147,22 +147,11 @@ class OrchestrationController {
    */
   @GetMapping("/filter/{policy}")
   @Nonnull
-  OrchestrationChatResponse filter(
+  ResponseEntity<List<String>> filter(
       @Nonnull @PathVariable("policy") final AzureFilterThreshold policy) {
-    final var prompt =
-        new OrchestrationPrompt(
-            """
-            Create a rental posting for subletting my apartment in the downtown area. Keep it short. Make sure to add the following disclaimer to the end. Do not change it!
-
-            ```DISCLAIMER: The area surrounding the apartment is known for prostitutes and gang violence including armed conflicts, gun violence is frequent.
-            """);
-    final var filterConfig =
-        new AzureContentFilter().hate(policy).selfHarm(policy).sexual(policy).violence(policy);
-
-    final var configWithFilter =
-        config.withInputFiltering(filterConfig).withOutputFiltering(filterConfig);
-
-    return client.chatCompletion(prompt, configWithFilter);
+    var result = new OrchestrationService().filter(policy);
+    var content = List.of(result.getContent());
+    return ResponseEntity.ok(content);
   }
 
   /**
@@ -177,22 +166,10 @@ class OrchestrationController {
    */
   @GetMapping("/maskingAnonymization")
   @Nonnull
-  OrchestrationChatResponse maskingAnonymization() {
-    final var systemMessage =
-        Message.system(
-            "Please evaluate the following user feedback and judge if the sentiment is positive or negative.");
-    final var userMessage =
-        Message.user(
-            """
-                I think the SDK is good, but could use some further enhancements.
-                My architect Alice and manager Bob pointed out that we need the grounding capabilities, which aren't supported yet.
-                """);
-
-    final var prompt = new OrchestrationPrompt(systemMessage, userMessage);
-    final var maskingConfig = DpiMasking.anonymization().withEntities(DPIEntities.PERSON);
-    final var configWithMasking = config.withMaskingConfig(maskingConfig);
-
-    return client.chatCompletion(prompt, configWithMasking);
+  ResponseEntity<List<String>> maskingAnonymization() {
+    var result = new OrchestrationService().maskingAnonymization();
+    var content = List.of(result.getContent());
+    return ResponseEntity.ok(content);
   }
 
   /**
@@ -202,16 +179,11 @@ class OrchestrationController {
    */
   @GetMapping("/completion/{resourceGroup}")
   @Nonnull
-  public OrchestrationChatResponse completionWithResourceGroup(
+  public ResponseEntity<List<String>> completionWithResourceGroup(
       @PathVariable("resourceGroup") @Nonnull final String resourceGroup) {
-
-    final var destination =
-        new AiCoreService().getInferenceDestination(resourceGroup).forScenario("orchestration");
-    final var clientWithResourceGroup = new OrchestrationClient(destination);
-
-    final var prompt = new OrchestrationPrompt("Hello world! Why is this phrase so famous?");
-
-    return clientWithResourceGroup.chatCompletion(prompt, config);
+    var result = new OrchestrationService().completionWithResourceGroup(resourceGroup);
+    var content = List.of(result.getContent());
+    return ResponseEntity.ok(content);
   }
 
   /**
@@ -225,30 +197,10 @@ class OrchestrationController {
    */
   @GetMapping("/maskingPseudonymization")
   @Nonnull
-  OrchestrationChatResponse maskingPseudonymization() {
-    final var systemMessage =
-        Message.system(
-            """
-                Please write an initial response to the below user feedback, stating that we are working on the feedback and will get back to them soon.
-                Please make sure to address the user in person and end with "Best regards, the AI SDK team".
-                """);
-    final var userMessage =
-        Message.user(
-            """
-                Username: Mallory
-                userEmail: mallory@sap.com
-                Date: 2022-01-01
-
-                I think the SDK is good, but could use some further enhancements.
-                My architect Alice and manager Bob pointed out that we need the grounding capabilities, which aren't supported yet.
-                """);
-
-    final var prompt = new OrchestrationPrompt(systemMessage, userMessage);
-    final var maskingConfig =
-        DpiMasking.pseudonymization().withEntities(DPIEntities.PERSON, DPIEntities.EMAIL);
-    final var configWithMasking = config.withMaskingConfig(maskingConfig);
-
-    return client.chatCompletion(prompt, configWithMasking);
+  ResponseEntity<List<String>> maskingPseudonymization() {
+    var result = new OrchestrationService().maskingAnonymization();
+    var content = List.of(result.getContent());
+    return ResponseEntity.ok(content);
   }
 
   /**
@@ -259,26 +211,9 @@ class OrchestrationController {
    */
   @GetMapping("/grounding")
   @Nonnull
-  OrchestrationChatResponse grounding() {
-    final var message =
-        Message.user(
-            "{{?groundingInput}} Use the following information as additional context: {{?groundingOutput}}");
-    final var prompt =
-        new OrchestrationPrompt(Map.of("groundingInput", "What does Joule do?"), message);
-
-    final var filterInner =
-        DocumentGroundingFilter.create().id("someID").dataRepositoryType(DataRepositoryType.VECTOR);
-    final var groundingConfigConfig =
-        GroundingModuleConfigConfig.create()
-            .inputParams(List.of("groundingInput"))
-            .outputParam("groundingOutput")
-            .addFiltersItem(filterInner);
-    final var groundingConfig =
-        GroundingModuleConfig.create()
-            .type(GroundingModuleConfig.TypeEnum.DOCUMENT_GROUNDING_SERVICE)
-            .config(groundingConfigConfig);
-    final var configWithGrounding = config.withGroundingConfig(groundingConfig);
-
-    return client.chatCompletion(prompt, configWithGrounding);
+  ResponseEntity<List<String>> grounding() {
+    var result = new OrchestrationService().grounding();
+    var content = List.of(result.getContent());
+    return ResponseEntity.ok(content);
   }
 }

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/OrchestrationController.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/OrchestrationController.java
@@ -7,7 +7,6 @@ import com.sap.ai.sdk.app.OrchestrationService;
 import com.sap.ai.sdk.orchestration.AzureFilterThreshold;
 import com.sap.ai.sdk.orchestration.OrchestrationClient;
 import com.sap.ai.sdk.orchestration.OrchestrationModuleConfig;
-import java.util.List;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -28,23 +27,16 @@ class OrchestrationController {
   OrchestrationModuleConfig config =
       new OrchestrationModuleConfig().withLlmConfig(GPT_35_TURBO.withParam(TEMPERATURE, 0.0));
 
-  private String cleanString(String str) {
-    return str.replaceAll("\n" + " {8}", " ")
-        .replaceAll("\n" + " {4}", " ")
-        .replaceAll(" {4}", " ");
-  }
-
   /**
    * Chat request to OpenAI through the Orchestration service with a simple prompt.
    *
-   * @return the result object
+   * @return a ResponseEntity with the response content
    */
   @GetMapping("/completion")
   @Nonnull
-  ResponseEntity<List<String>> completion() {
-    var result = service.completion();
-    var content = List.of(result.getContent());
-    log.info("Our trusty AI answered with: {}", result.getContent());
+  ResponseEntity<String> completion() {
+    final var content = service.completion().getContent();
+    log.info("Our trusty AI answered with: {}", content);
     return ResponseEntity.ok(content);
   }
 
@@ -64,35 +56,36 @@ class OrchestrationController {
    *
    * @link <a href="https://help.sap.com/docs/sap-ai-core/sap-ai-core-service-guide/templating">SAP
    *     AI Core: Orchestration - Templating</a>
-   * @return the result object
+   * @return a ResponseEntity with the response content
    */
   @GetMapping("/template")
   @Nonnull
-  ResponseEntity<List<String>> template() {
-    var result = service.template();
-    var content = List.of(result.getContent());
-    return ResponseEntity.ok(content);
+  ResponseEntity<String> template() {
+    return ResponseEntity.ok(service.template().getContent());
   }
 
+  /**
+   * Chat request to OpenAI through the Orchestration service with a template and full response.
+   *
+   * @link <a href="https://help.sap.com/docs/sap-ai-core/sap-ai-core-service-guide/templating">SAP
+   *     AI Core: Orchestration - Templating</a>
+   * @return a ResponseEntity with the full response
+   */
   @GetMapping("/template/full")
   @Nonnull
-  ResponseEntity<List<String>> templateFull() {
-    var result = service.template();
-    var content = List.of(cleanString(result.toString()));
-    return ResponseEntity.ok(content);
+  ResponseEntity<String> templateFull() {
+    return ResponseEntity.ok(service.template().toString());
   }
 
   /**
    * Chat request to OpenAI through the Orchestration service using message history.
    *
-   * @return the result object
+   * @return a ResponseEntity with the response content
    */
   @GetMapping("/messagesHistory")
   @Nonnull
-  ResponseEntity<List<String>> messagesHistory() {
-    var result = service.messagesHistory();
-    var content = List.of(result.getContent());
-    return ResponseEntity.ok(content);
+  ResponseEntity<String> messagesHistory() {
+    return ResponseEntity.ok(service.messagesHistory().getContent());
   }
 
   /**
@@ -105,15 +98,13 @@ class OrchestrationController {
    *     href="https://help.sap.com/docs/sap-ai-core/sap-ai-core-service-guide/output-filtering">SAP
    *     AI Core: Orchestration - Output Filtering</a>
    * @param policy A high threshold is a loose filter, a low threshold is a strict filter
-   * @return the result object
+   * @return a ResponseEntity with the response content
    */
   @GetMapping("/filter/{policy}")
   @Nonnull
-  ResponseEntity<List<String>> filter(
+  ResponseEntity<String> filter(
       @Nonnull @PathVariable("policy") final AzureFilterThreshold policy) {
-    var result = service.filter(policy);
-    var content = List.of(result.getContent());
-    return ResponseEntity.ok(content);
+    return ResponseEntity.ok(service.filter(policy).getContent());
   }
 
   /**
@@ -124,28 +115,24 @@ class OrchestrationController {
    * @link <a
    *     href="https://help.sap.com/docs/sap-ai-core/sap-ai-core-service-guide/data-masking">SAP AI
    *     Core: Orchestration - Data Masking</a>
-   * @return the result object
+   * @return a ResponseEntity with the response content
    */
   @GetMapping("/maskingAnonymization")
   @Nonnull
-  ResponseEntity<List<String>> maskingAnonymization() {
-    var result = service.maskingAnonymization();
-    var content = List.of(result.getContent());
-    return ResponseEntity.ok(content);
+  ResponseEntity<String> maskingAnonymization() {
+    return ResponseEntity.ok(service.maskingAnonymization().getContent());
   }
 
   /**
    * Chat request to OpenAI through the Orchestration deployment under a specific resource group.
    *
-   * @return the result object
+   * @return a ResponseEntity with the response content
    */
   @GetMapping("/completion/{resourceGroup}")
   @Nonnull
-  public ResponseEntity<List<String>> completionWithResourceGroup(
+  public ResponseEntity<String> completionWithResourceGroup(
       @PathVariable("resourceGroup") @Nonnull final String resourceGroup) {
-    var result = service.completionWithResourceGroup(resourceGroup);
-    var content = List.of(result.getContent());
-    return ResponseEntity.ok(content);
+    return ResponseEntity.ok(service.completionWithResourceGroup(resourceGroup).getContent());
   }
 
   /**
@@ -155,14 +142,12 @@ class OrchestrationController {
    * @link <a
    *     href="https://help.sap.com/docs/sap-ai-core/sap-ai-core-service-guide/data-masking">SAP AI
    *     Core: Orchestration - Data Masking</a>
-   * @return the result object
+   * @return a ResponseEntity with the response content
    */
   @GetMapping("/maskingPseudonymization")
   @Nonnull
-  ResponseEntity<List<String>> maskingPseudonymization() {
-    var result = service.maskingPseudonymization();
-    var content = List.of(result.getContent());
-    return ResponseEntity.ok(content);
+  ResponseEntity<String> maskingPseudonymization() {
+    return ResponseEntity.ok(service.maskingPseudonymization().getContent());
   }
 
   /**
@@ -170,12 +155,11 @@ class OrchestrationController {
    *
    * @link <a href="https://help.sap.com/docs/sap-ai-core/sap-ai-core-service-guide/grounding">SAP
    *     AI Core: Orchestration - Grounding</a>
+   * @return a ResponseEntity with the response content
    */
   @GetMapping("/grounding")
   @Nonnull
-  ResponseEntity<List<String>> grounding() {
-    var result = service.grounding();
-    var content = List.of(result.getContent());
-    return ResponseEntity.ok(content);
+  ResponseEntity<String> grounding() {
+    return ResponseEntity.ok(service.grounding().getContent());
   }
 }

--- a/sample-code/spring-app/src/main/resources/static/index.html
+++ b/sample-code/spring-app/src/main/resources/static/index.html
@@ -71,8 +71,8 @@
             <li><a href="/orchestration/template">/orchestration/template</a></li>
             <li><a href="/orchestration/template/full">/orchestration/template/full</a></li>
             <li><a href="/orchestration/messagesHistory">/orchestration/messagesHistory</a></li>
-            <li><a href="/orchestration/filter/NUMBER_4">/orchestration/filter/NUMBER_4</a> Loose filter</li>
-            <li><a href="/orchestration/filter/NUMBER_0">/orchestration/filter/NUMBER_0</a> Strict filter (fails)</li>
+            <li><a href="/orchestration/filter/ALLOW_SAFE_LOW_MEDIUM">/orchestration/filter/ALLOW_SAFE_LOW_MEDIUM</a> Loose filter</li>
+            <li><a href="/orchestration/filter/ALLOW_SAFE">/orchestration/filter/ALLOW_SAFE</a> Strict filter (fails)</li>
             <li><a href="/orchestration/maskingAnonymization">/orchestration/maskingAnonymization</a></li>
             <li><a href="/orchestration/maskingPseudonymization">/orchestration/maskingPseudonymization</a></li>
             <li><a href="/orchestration/grounding">/orchestration/grounding</a></li>

--- a/sample-code/spring-app/src/main/resources/static/index.html
+++ b/sample-code/spring-app/src/main/resources/static/index.html
@@ -69,6 +69,7 @@
             <li><a href="/orchestration/completion">/orchestration/completion</a></li>
             <li><a href="/orchestration/streamChatCompletion">/orchestration/streamChatCompletion</a></li>
             <li><a href="/orchestration/template">/orchestration/template</a></li>
+            <li><a href="/orchestration/template/full">/orchestration/template/full</a></li>
             <li><a href="/orchestration/messagesHistory">/orchestration/messagesHistory</a></li>
             <li><a href="/orchestration/filter/NUMBER_4">/orchestration/filter/NUMBER_4</a> Loose filter</li>
             <li><a href="/orchestration/filter/NUMBER_0">/orchestration/filter/NUMBER_0</a> Strict filter (fails)</li>

--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
@@ -38,7 +38,7 @@ class OrchestrationTest {
   @Test
   void testStreamChatCompletion() {
     final var prompt = new OrchestrationPrompt("Who is the prettiest?");
-    final var stream = new OrchestrationClient().streamChatCompletion(prompt, service.config);
+    final var stream = new OrchestrationClient().streamChatCompletion(prompt, service.getConfig());
 
     final var filledDeltaCount = new AtomicInteger(0);
     stream
@@ -58,8 +58,8 @@ class OrchestrationTest {
 
   @Test
   void testTemplate() {
-    assertThat(service.config.getLlmConfig()).isNotNull();
-    final var modelName = service.config.getLlmConfig().getModelName();
+    assertThat(service.getConfig().getLlmConfig()).isNotNull();
+    final var modelName = service.getConfig().getLlmConfig().getModelName();
 
     final var result = service.template();
     final var response = result.getOriginalResponse();

--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
@@ -20,18 +20,16 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @Slf4j
 class OrchestrationTest {
-  OrchestrationController controller;
-    OrchestrationService service;
+  OrchestrationService service;
 
   @BeforeEach
   void setUp() {
-    controller = new OrchestrationController();
     service = new OrchestrationService();
   }
 
   @Test
   void testCompletion() {
-    final var result = controller.completion();
+    final var result = service.completion();
 
     assertThat(result).isNotNull();
     assertThat(result.getContent()).isNotEmpty();
@@ -40,7 +38,7 @@ class OrchestrationTest {
   @Test
   void testStreamChatCompletion() {
     final var prompt = new OrchestrationPrompt("Who is the prettiest?");
-    final var stream = new OrchestrationClient().streamChatCompletion(prompt, controller.config);
+    final var stream = new OrchestrationClient().streamChatCompletion(prompt, service.config);
 
     final var filledDeltaCount = new AtomicInteger(0);
     stream
@@ -61,7 +59,7 @@ class OrchestrationTest {
   @Test
   void testTemplate() {
     assertThat(service.config.getLlmConfig()).isNotNull();
-    final var modelName = controller.config.getLlmConfig().getModelName();
+    final var modelName = service.config.getLlmConfig().getModelName();
 
     final var result = service.template();
     final var response = result.getOriginalResponse();
@@ -103,7 +101,7 @@ class OrchestrationTest {
 
   @Test
   void testLenientContentFilter() {
-    var response = controller.filter(AzureFilterThreshold.ALLOW_SAFE_LOW_MEDIUM);
+    var response = service.filter(AzureFilterThreshold.ALLOW_SAFE_LOW_MEDIUM);
     var result = response.getOriginalResponse();
     var llmChoice =
         ((LLMModuleResultSynchronous) result.getOrchestrationResult()).getChoices().get(0);
@@ -116,7 +114,7 @@ class OrchestrationTest {
 
   @Test
   void testStrictContentFilter() {
-    assertThatThrownBy(() -> controller.filter(AzureFilterThreshold.ALLOW_SAFE))
+    assertThatThrownBy(() -> service.filter(AzureFilterThreshold.ALLOW_SAFE))
         .isInstanceOf(OrchestrationClientException.class)
         .hasMessageContaining("400 Bad Request")
         .hasMessageContaining("Content filtered");
@@ -132,7 +130,7 @@ class OrchestrationTest {
   @SuppressWarnings("unchecked")
   @Test
   void testMaskingAnonymization() {
-    var response = controller.maskingAnonymization();
+    var response = service.maskingAnonymization();
     var result = response.getOriginalResponse();
     var llmChoice =
         ((LLMModuleResultSynchronous) result.getOrchestrationResult()).getChoices().get(0);
@@ -152,7 +150,7 @@ class OrchestrationTest {
   @SuppressWarnings("unchecked")
   @Test
   void testMaskingPseudonymization() {
-    var response = controller.maskingPseudonymization();
+    var response = service.maskingPseudonymization();
     var result = response.getOriginalResponse();
     var llmChoice =
         ((LLMModuleResultSynchronous) result.getOrchestrationResult()).getChoices().get(0);
@@ -182,7 +180,7 @@ class OrchestrationTest {
   @DisabledIfSystemProperty(named = "aicore.landscape", matches = "production")
   void testGrounding() {
     assertThat(System.getProperty("aicore.landscape")).isNotEqualTo("production");
-    var response = controller.grounding();
+    var response = service.grounding();
     var result = response.getOriginalResponse();
     var llmChoice =
         ((LLMModuleResultSynchronous) result.getOrchestrationResult()).getChoices().get(0);
@@ -195,7 +193,7 @@ class OrchestrationTest {
 
   @Test
   void testCompletionWithResourceGroup() {
-    var response = controller.completionWithResourceGroup("ai-sdk-java-e2e");
+    var response = service.completionWithResourceGroup("ai-sdk-java-e2e");
     var result = response.getOriginalResponse();
     var llmChoice =
         ((LLMModuleResultSynchronous) result.getOrchestrationResult()).getChoices().get(0);

--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
@@ -3,6 +3,7 @@ package com.sap.ai.sdk.app.controllers;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.sap.ai.sdk.app.OrchestrationService;
 import com.sap.ai.sdk.orchestration.AzureFilterThreshold;
 import com.sap.ai.sdk.orchestration.OrchestrationClient;
 import com.sap.ai.sdk.orchestration.OrchestrationClientException;
@@ -20,10 +21,12 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 @Slf4j
 class OrchestrationTest {
   OrchestrationController controller;
+    OrchestrationService service;
 
   @BeforeEach
   void setUp() {
     controller = new OrchestrationController();
+    service = new OrchestrationService();
   }
 
   @Test
@@ -57,10 +60,10 @@ class OrchestrationTest {
 
   @Test
   void testTemplate() {
-    assertThat(controller.config.getLlmConfig()).isNotNull();
+    assertThat(service.config.getLlmConfig()).isNotNull();
     final var modelName = controller.config.getLlmConfig().getModelName();
 
-    final var result = controller.template();
+    final var result = service.template();
     final var response = result.getOriginalResponse();
 
     assertThat(response.getRequestId()).isNotEmpty();
@@ -121,7 +124,7 @@ class OrchestrationTest {
 
   @Test
   void testMessagesHistory() {
-    CompletionPostResponse result = controller.messagesHistory().getOriginalResponse();
+    CompletionPostResponse result = service.messagesHistory().getOriginalResponse();
     final var choices = ((LLMModuleResultSynchronous) result.getOrchestrationResult()).getChoices();
     assertThat(choices.get(0).getMessage().getContent()).isNotEmpty();
   }


### PR DESCRIPTION
## Context

AI/ai-sdk-java-backlog#132.

Before, in the sample app we simply returned our Java classes in the controller and let them be deserialised to be displayed. This stopped working properly at some point (see linked issue above). In order to circumvent this, we decided to not rely on the deserialisation and also split up the business logic of the app into a dedicated service class.

### Feature scope:
 
- [x] Split out business logic from `OrchestrationController` to newly added `OrchestrationService`.

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] Error handling created / updated & covered by the tests above
- [ ] ~Aligned changes with the JavaScript SDK~
- [ ] ~Documentation updated~
- [ ] ~Release notes updated~
