### PR TITLE
feat: Spring AI Orchestration streaming

### DIFF
--- a/docs/guides/SPRING_AI_INTEGRATION.md
+++ b/docs/guides/SPRING_AI_INTEGRATION.md
@@ -50,8 +50,7 @@ Prompt prompt = new Prompt("What is the capital of France?", opts);
 ChatResponse response = client.call(prompt);
 ```
 
-Please
-find [an example in our Spring Boot application](../../sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/SpringAiOrchestrationController.java).
+Please find [an example in our Spring Boot application](../../sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/SpringAiOrchestrationController.java).
 
 ## Orchestration Masking
 
@@ -76,3 +75,27 @@ ChatResponse response = client.call(prompt);
 
 Please
 find [an example in our Spring Boot application](../../sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/SpringAiOrchestrationController.java).
+
+## Stream chat completion
+
+It's possible to pass a stream of chat completion delta elements, e.g. from the application backend
+to the frontend in real-time.
+
+```java
+ChatModel client = new OrchestrationChatModel();
+OrchestrationModuleConfig config = new OrchestrationModuleConfig().withLlmConfig(GPT_35_TURBO);
+OrchestrationChatOptions opts = new OrchestrationChatOptions(config);
+
+Prompt prompt =
+    new Prompt(
+        "Can you give me the first 100 numbers of the Fibonacci sequence?", opts);
+Flux<ChatResponse> flux = client.stream(prompt);
+
+// also possible to keep only the chat completion text
+Flux<String> responseFlux = 
+    flux.map(chatResponse -> chatResponse.getResult().getOutput().getContent());
+```
+
+_Note: A Spring endpoint can return `Flux` instead of `ResponseEntity`._
+
+Please find [an example in our Spring Boot application](../../sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/SpringAiOrchestrationController.java).

--- a/orchestration/pom.xml
+++ b/orchestration/pom.xml
@@ -60,6 +60,11 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>io.projectreactor</groupId>
+      <artifactId>reactor-core</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.apache.httpcomponents.core5</groupId>
       <artifactId>httpcore5</artifactId>
     </dependency>

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/spring/OrchestrationChatModel.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/spring/OrchestrationChatModel.java
@@ -1,8 +1,12 @@
 package com.sap.ai.sdk.orchestration.spring;
 
+import static com.sap.ai.sdk.orchestration.OrchestrationClient.toCompletionPostRequest;
+
 import com.google.common.annotations.Beta;
 import com.sap.ai.sdk.orchestration.AssistantMessage;
+import com.sap.ai.sdk.orchestration.OrchestrationChatCompletionDelta;
 import com.sap.ai.sdk.orchestration.OrchestrationClient;
+import com.sap.ai.sdk.orchestration.OrchestrationClientException;
 import com.sap.ai.sdk.orchestration.OrchestrationPrompt;
 import com.sap.ai.sdk.orchestration.SystemMessage;
 import com.sap.ai.sdk.orchestration.UserMessage;
@@ -17,6 +21,7 @@ import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
+import reactor.core.publisher.Flux;
 
 /**
  * Spring AI integration for the orchestration service.
@@ -50,6 +55,41 @@ public class OrchestrationChatModel implements ChatModel {
     }
     throw new IllegalArgumentException(
         "Please add OrchestrationChatOptions to the Prompt: new Prompt(\"message\", new OrchestrationChatOptions(config))");
+  }
+
+  @Override
+  @Nonnull
+  public Flux<ChatResponse> stream(@Nonnull final Prompt prompt) {
+
+    if (prompt.getOptions() instanceof OrchestrationChatOptions options) {
+
+      val orchestrationPrompt = toOrchestrationPrompt(prompt);
+      val request = toCompletionPostRequest(orchestrationPrompt, options.getConfig());
+      val stream =
+          client
+              .streamChatCompletionDeltas(request)
+              .peek(OrchestrationChatModel::throwOnContentFilter)
+              .map(OrchestrationSpringChatDelta::new);
+      return Flux.generate(
+          stream::iterator,
+          (iterator, sink) -> {
+            if (iterator.hasNext()) {
+              sink.next(iterator.next());
+            } else {
+              sink.complete();
+            }
+            return iterator;
+          });
+    }
+    throw new IllegalArgumentException(
+        "Please add OrchestrationChatOptions to the Prompt: new Prompt(\"message\", new OrchestrationChatOptions(config))");
+  }
+
+  private static void throwOnContentFilter(@Nonnull final OrchestrationChatCompletionDelta delta) {
+    final String finishReason = delta.getFinishReason();
+    if (finishReason != null && finishReason.equals("content_filter")) {
+      throw new OrchestrationClientException("Content filter filtered the output.");
+    }
   }
 
   @Nonnull

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/spring/OrchestrationSpringChatDelta.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/spring/OrchestrationSpringChatDelta.java
@@ -51,13 +51,12 @@ public class OrchestrationSpringChatDelta extends ChatResponse {
 
   // will be fixed once the generated code add a discriminator which will allow this class to extend
   // CompletionPostResponseStreaming
-  @SuppressWarnings("unchecked")
+  @Nonnull
   private static String getContent(@Nonnull final LLMChoice choice) {
-    val message = (Map<String, Object>) choice.getCustomField("delta");
-    if (message != null && message.get("content") != null) {
-      return message.get("content").toString();
-    }
-    return "";
+    return choice.getCustomField("delta") instanceof Map<?, ?> delta
+            && delta.get("content") instanceof String content
+        ? content
+        : "";
   }
 
   @Nonnull

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/spring/OrchestrationSpringChatDelta.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/spring/OrchestrationSpringChatDelta.java
@@ -49,8 +49,6 @@ public class OrchestrationSpringChatDelta extends ChatResponse {
     return new Generation(new AssistantMessage(getContent(choice)), metadata.build());
   }
 
-  // will be fixed once the generated code add a discriminator which will allow this class to extend
-  // CompletionPostResponseStreaming
   @Nonnull
   private static String getContent(@Nonnull final LLMChoice choice) {
     return choice.getCustomField("delta") instanceof Map<?, ?> delta

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/spring/OrchestrationSpringChatDelta.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/spring/OrchestrationSpringChatDelta.java
@@ -28,13 +28,10 @@ import org.springframework.ai.chat.model.Generation;
 @EqualsAndHashCode(callSuper = true)
 public class OrchestrationSpringChatDelta extends ChatResponse {
 
-  OrchestrationChatCompletionDelta delta;
-
   OrchestrationSpringChatDelta(@Nonnull final OrchestrationChatCompletionDelta delta) {
     super(
         toGenerations((LLMModuleResultSynchronous) delta.getOrchestrationResult()),
         toChatResponseMetadata((LLMModuleResultSynchronous) delta.getOrchestrationResult()));
-    this.delta = delta;
   }
 
   @Nonnull

--- a/orchestration/src/test/java/com/sap/ai/sdk/orchestration/spring/OrchestrationChatDeltaTest.java
+++ b/orchestration/src/test/java/com/sap/ai/sdk/orchestration/spring/OrchestrationChatDeltaTest.java
@@ -7,20 +7,24 @@ import com.sap.ai.sdk.orchestration.model.LLMModuleResultSynchronous;
 import com.sap.ai.sdk.orchestration.model.ResponseChatMessage;
 import com.sap.ai.sdk.orchestration.model.TokenUsage;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.metadata.EmptyUsage;
 import org.springframework.ai.chat.model.Generation;
 
-class OrchestrationChatResponseTest {
+class OrchestrationChatDeltaTest {
 
   @Test
-  void testToAssistantMessage() {
+  void testToGeneration() {
     var choice =
         LLMChoice.create()
             .index(0)
-            .message(ResponseChatMessage.create().role("assistant").content("Hello, world!"))
+            .message(ResponseChatMessage.create().role("wrong").content("wrong"))
             .finishReason("stop");
+    // this will be fixed once the spec is fixed
+    choice.setCustomField("delta", Map.of("content", "Hello, world!"));
 
-    Generation generation = OrchestrationSpringChatResponse.toGeneration(choice);
+    Generation generation = OrchestrationSpringChatDelta.toGeneration(choice);
 
     assertThat(generation.getOutput().getContent()).isEqualTo("Hello, world!");
     assertThat(generation.getMetadata().getFinishReason()).isEqualTo("stop");
@@ -38,7 +42,7 @@ class OrchestrationChatResponseTest {
             .choices(List.of())
             .usage(TokenUsage.create().completionTokens(20).promptTokens(10).totalTokens(30));
 
-    var metadata = OrchestrationSpringChatResponse.toChatResponseMetadata(moduleResult);
+    var metadata = OrchestrationSpringChatDelta.toChatResponseMetadata(moduleResult);
 
     assertThat(metadata.getId()).isEqualTo("test-id");
     assertThat(metadata.getModel()).isEqualTo("test-model");
@@ -50,5 +54,10 @@ class OrchestrationChatResponseTest {
     assertThat(usage.getPromptTokens()).isEqualTo(10L);
     assertThat(usage.getGenerationTokens()).isEqualTo(20L);
     assertThat(usage.getTotalTokens()).isEqualTo(30L);
+
+    // delta without token usage
+    moduleResult.usage(null);
+    metadata = OrchestrationSpringChatDelta.toChatResponseMetadata(moduleResult);
+    assertThat(metadata.getUsage()).isInstanceOf(EmptyUsage.class);
   }
 }

--- a/orchestration/src/test/java/com/sap/ai/sdk/orchestration/spring/OrchestrationChatModelTest.java
+++ b/orchestration/src/test/java/com/sap/ai/sdk/orchestration/spring/OrchestrationChatModelTest.java
@@ -152,7 +152,7 @@ public class OrchestrationChatModelTest {
       assertThat(deltaList.get(1).getResult().getOutput().getContent()).isEqualTo("Sure");
       assertThat(deltaList.get(2).getResult().getOutput().getContent()).isEqualTo("!");
 
-      assertThat(deltaList.get(1).getResult().getMetadata().getFinishReason()).isEqualTo("");
+      assertThat(deltaList.get(0).getResult().getMetadata().getFinishReason()).isEqualTo("");
       assertThat(deltaList.get(1).getResult().getMetadata().getFinishReason()).isEqualTo("");
       assertThat(deltaList.get(2).getResult().getMetadata().getFinishReason()).isEqualTo("stop");
 

--- a/orchestration/src/test/java/com/sap/ai/sdk/orchestration/spring/OrchestrationChatModelTest.java
+++ b/orchestration/src/test/java/com/sap/ai/sdk/orchestration/spring/OrchestrationChatModelTest.java
@@ -7,20 +7,42 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.sap.ai.sdk.orchestration.OrchestrationAiModel.GPT_35_TURBO_16K;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.sap.ai.sdk.orchestration.OrchestrationClient;
+import com.sap.ai.sdk.orchestration.OrchestrationClientException;
 import com.sap.ai.sdk.orchestration.OrchestrationModuleConfig;
 import com.sap.cloud.sdk.cloudplatform.connectivity.ApacheHttpClient5Accessor;
 import com.sap.cloud.sdk.cloudplatform.connectivity.ApacheHttpClient5Cache;
 import com.sap.cloud.sdk.cloudplatform.connectivity.DefaultHttpDestination;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+import java.util.function.Function;
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.io.entity.InputStreamEntity;
+import org.apache.hc.core5.http.message.BasicClassicHttpResponse;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
+import reactor.core.publisher.Flux;
 
 @WireMockTest
 public class OrchestrationChatModelTest {
+
+  private final Function<String, InputStream> fileLoader =
+      filename -> Objects.requireNonNull(getClass().getClassLoader().getResourceAsStream(filename));
 
   private static OrchestrationChatModel client;
   private static OrchestrationModuleConfig config;
@@ -36,6 +58,12 @@ public class OrchestrationChatModelTest {
         new Prompt(
             "Hello World! Why is this phrase so famous?", new OrchestrationChatOptions(config));
     ApacheHttpClient5Accessor.setHttpClientCache(ApacheHttpClient5Cache.DISABLED);
+  }
+
+  @AfterEach
+  void reset() {
+    ApacheHttpClient5Accessor.setHttpClientCache(null);
+    ApacheHttpClient5Accessor.setHttpClientFactory(null);
   }
 
   @Test
@@ -57,6 +85,9 @@ public class OrchestrationChatModelTest {
     assertThatThrownBy(() -> client.call(new Prompt("test")))
         .isExactlyInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Please add OrchestrationChatOptions to the Prompt");
+    assertThatThrownBy(() -> client.stream(new Prompt("test")))
+        .isExactlyInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Please add OrchestrationChatOptions to the Prompt");
   }
 
   @Test
@@ -67,5 +98,67 @@ public class OrchestrationChatModelTest {
     assertThatThrownBy(() -> client.call(new Prompt("test", emptyConfig)))
         .isExactlyInstanceOf(IllegalStateException.class)
         .hasMessageContaining("LLM config is required");
+    assertThatThrownBy(() -> client.stream(new Prompt("test", emptyConfig)))
+        .isExactlyInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("LLM config is required");
+  }
+
+  @Disabled
+  @Test
+  void streamChatCompletionOutputFilterErrorHandling() throws IOException {
+    try (var inputStream = spy(fileLoader.apply("streamChatCompletionOutputFilter.txt"))) {
+
+      final var httpClient = mock(HttpClient.class);
+      ApacheHttpClient5Accessor.setHttpClientFactory(destination -> httpClient);
+
+      // Create a mock response
+      final var mockResponse = new BasicClassicHttpResponse(200, "OK");
+      final var inputStreamEntity = new InputStreamEntity(inputStream, ContentType.TEXT_PLAIN);
+      mockResponse.setEntity(inputStreamEntity);
+      mockResponse.setHeader("Content-Type", "text/event-stream");
+
+      // Configure the HttpClient mock to return the mock response
+      doReturn(mockResponse).when(httpClient).executeOpen(any(), any(), any());
+
+      Flux<ChatResponse> flux = client.stream(prompt);
+      assertThatThrownBy(() -> flux.toStream().forEach(System.out::println))
+          .isInstanceOf(OrchestrationClientException.class)
+          .hasMessage("Content filter filtered the output.");
+
+      Mockito.verify(inputStream, times(1)).close();
+    }
+  }
+
+  @Test
+  void testStreamCompletion() throws IOException {
+    try (var inputStream = spy(fileLoader.apply("streamChatCompletion.txt"))) {
+
+      final var httpClient = mock(HttpClient.class);
+      ApacheHttpClient5Accessor.setHttpClientFactory(destination -> httpClient);
+
+      // Create a mock response
+      final var mockResponse = new BasicClassicHttpResponse(200, "OK");
+      final var inputStreamEntity = new InputStreamEntity(inputStream, ContentType.TEXT_PLAIN);
+      mockResponse.setEntity(inputStreamEntity);
+      mockResponse.setHeader("Content-Type", "text/event-flux");
+
+      // Configure the HttpClient mock to return the mock response
+      doReturn(mockResponse).when(httpClient).executeOpen(any(), any(), any());
+
+      Flux<ChatResponse> flux = client.stream(prompt);
+      var deltaList = flux.toStream().toList();
+
+      assertThat(deltaList).hasSize(3);
+      // the first delta doesn't have any content
+      assertThat(deltaList.get(0).getResult().getOutput().getContent()).isEqualTo("");
+      assertThat(deltaList.get(1).getResult().getOutput().getContent()).isEqualTo("Sure");
+      assertThat(deltaList.get(2).getResult().getOutput().getContent()).isEqualTo("!");
+
+      assertThat(deltaList.get(1).getResult().getMetadata().getFinishReason()).isEqualTo("");
+      assertThat(deltaList.get(1).getResult().getMetadata().getFinishReason()).isEqualTo("");
+      assertThat(deltaList.get(2).getResult().getMetadata().getFinishReason()).isEqualTo("stop");
+
+      Mockito.verify(inputStream, times(1)).close();
+    }
   }
 }

--- a/orchestration/src/test/java/com/sap/ai/sdk/orchestration/spring/OrchestrationChatModelTest.java
+++ b/orchestration/src/test/java/com/sap/ai/sdk/orchestration/spring/OrchestrationChatModelTest.java
@@ -103,7 +103,6 @@ public class OrchestrationChatModelTest {
         .hasMessageContaining("LLM config is required");
   }
 
-  @Disabled
   @Test
   void streamChatCompletionOutputFilterErrorHandling() throws IOException {
     try (var inputStream = spy(fileLoader.apply("streamChatCompletionOutputFilter.txt"))) {

--- a/orchestration/src/test/java/com/sap/ai/sdk/orchestration/spring/OrchestrationChatModelTest.java
+++ b/orchestration/src/test/java/com/sap/ai/sdk/orchestration/spring/OrchestrationChatModelTest.java
@@ -31,7 +31,6 @@ import org.apache.hc.core5.http.io.entity.InputStreamEntity;
 import org.apache.hc.core5.http.message.BasicClassicHttpResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.ai.chat.model.ChatResponse;

--- a/orchestration/src/test/java/com/sap/ai/sdk/orchestration/spring/OrchestrationChatResponseTest.java
+++ b/orchestration/src/test/java/com/sap/ai/sdk/orchestration/spring/OrchestrationChatResponseTest.java
@@ -13,7 +13,7 @@ import org.springframework.ai.chat.model.Generation;
 class OrchestrationChatResponseTest {
 
   @Test
-  void testToAssistantMessage() {
+  void testToGeneration() {
     var choice =
         LLMChoice.create()
             .index(0)

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
     <surefire.version>3.5.2</surefire.version>
     <springframework.version>6.2.1</springframework.version>
     <spring-ai.version>1.0.0-M5</spring-ai.version>
+    <reactor-core.version>3.6.12</reactor-core.version>
     <dotenv-java.version>3.1.0</dotenv-java.version>
     <mockito.version>5.15.2</mockito.version>
     <!-- conflicts resolution -->
@@ -111,6 +112,11 @@
         <groupId>org.springframework.ai</groupId>
         <artifactId>spring-ai-core</artifactId>
         <version>${spring-ai.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.projectreactor</groupId>
+        <artifactId>reactor-core</artifactId>
+        <version>${reactor-core.version}</version>
       </dependency>
       <dependency>
         <groupId>io.github.cdimascio</groupId>

--- a/sample-code/spring-app/pom.xml
+++ b/sample-code/spring-app/pom.xml
@@ -99,6 +99,10 @@
       <version>${springframework.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.projectreactor</groupId>
+      <artifactId>reactor-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
     </dependency>

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/SpringAiOrchestrationController.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/SpringAiOrchestrationController.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.ai.sdk.app.services.SpringAiOrchestrationService;
 import com.sap.ai.sdk.orchestration.spring.OrchestrationSpringChatResponse;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
 
 @SuppressWarnings("unused")
 @RestController
@@ -34,6 +36,14 @@ class SpringAiOrchestrationController {
               MAPPER.writeValueAsString(response.getOrchestrationResponse().getOriginalResponse()));
     }
     return ResponseEntity.ok(response.getResult().getOutput().getContent());
+  }
+
+  @GetMapping("/streamChatCompletion")
+  @Nonnull
+  Flux<String> streamChatCompletion() {
+    return service
+        .streamChatCompletion()
+        .map(chatResponse -> chatResponse.getResult().getOutput().getContent());
   }
 
   @GetMapping("/template")

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OrchestrationService.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OrchestrationService.java
@@ -49,6 +49,19 @@ public class OrchestrationService {
   }
 
   /**
+   * Asynchronous stream of an OpenAI chat request
+   *
+   * @return a stream of assistant message responses
+   */
+  @Nonnull
+  public Stream<String> streamChatCompletion(@Nonnull final String topic) {
+    final var prompt =
+        new OrchestrationPrompt(
+            "Please create a small story about " + topic + " with around 700 words.");
+    return client.streamChatCompletion(prompt, config);
+  }
+
+  /**
    * Chat request to OpenAI through the Orchestration service with a template.
    *
    * @link <a href="https://help.sap.com/docs/sap-ai-core/sap-ai-core-service-guide/templating">SAP
@@ -244,18 +257,5 @@ public class OrchestrationService {
     final var configWithGrounding = config.withGroundingConfig(groundingConfig);
 
     return client.chatCompletion(prompt, configWithGrounding);
-  }
-
-  /**
-   * Asynchronous stream of an OpenAI chat request
-   *
-   * @return the emitter that streams the assistant message response
-   */
-  @Nonnull
-  public Stream<String> streamChatCompletion(@Nonnull final String topic) {
-    final var prompt =
-        new OrchestrationPrompt(
-            "Please create a small story about " + topic + " with around 700 words.");
-    return client.streamChatCompletion(prompt, config);
   }
 }

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/SpringAiOrchestrationService.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/SpringAiOrchestrationService.java
@@ -15,6 +15,7 @@ import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.chat.prompt.PromptTemplate;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
 
 /** Service class for the Orchestration service */
 @Service
@@ -72,5 +73,18 @@ public class SpringAiOrchestrationService {
             opts);
 
     return client.call(prompt);
+  }
+
+  /**
+   * Asynchronous stream of an OpenAI chat request
+   *
+   * @return a stream of assistant message responses
+   */
+  @Nonnull
+  public Flux<ChatResponse> streamChatCompletion() {
+    val prompt =
+        new Prompt(
+            "Can you give me the first 100 numbers of the Fibonacci sequence?", defaultOptions);
+    return client.stream(prompt);
   }
 }

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/SpringAiOrchestrationService.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/SpringAiOrchestrationService.java
@@ -38,6 +38,19 @@ public class SpringAiOrchestrationService {
   }
 
   /**
+   * Asynchronous stream of an OpenAI chat request
+   *
+   * @return a stream of assistant message responses
+   */
+  @Nonnull
+  public Flux<ChatResponse> streamChatCompletion() {
+    val prompt =
+        new Prompt(
+            "Can you give me the first 100 numbers of the Fibonacci sequence?", defaultOptions);
+    return client.stream(prompt);
+  }
+
+  /**
    * Chat request to OpenAI through the Orchestration service with a template.
    *
    * @return the assistant response object
@@ -73,18 +86,5 @@ public class SpringAiOrchestrationService {
             opts);
 
     return client.call(prompt);
-  }
-
-  /**
-   * Asynchronous stream of an OpenAI chat request
-   *
-   * @return a stream of assistant message responses
-   */
-  @Nonnull
-  public Flux<ChatResponse> streamChatCompletion() {
-    val prompt =
-        new Prompt(
-            "Can you give me the first 100 numbers of the Fibonacci sequence?", defaultOptions);
-    return client.stream(prompt);
   }
 }

--- a/sample-code/spring-app/src/main/resources/static/index.html
+++ b/sample-code/spring-app/src/main/resources/static/index.html
@@ -453,6 +453,15 @@
                         <li class="list-group-item">
                             <div class="info-tooltip">
                                 <a class="link-offset-2-hover link-underline link-underline-opacity-0 link-underline-opacity-75-hover endpoint"
+                                   href="/spring-ai-orchestration/streamChatCompletion"><code>/spring-ai-orchestration/streamChatCompletion</code></a>
+                                <div class="tooltip-content">
+                                    Chat request to OpenAI.
+                                </div>
+                            </div>
+                        </li>
+                        <li class="list-group-item">
+                            <div class="info-tooltip">
+                                <a class="link-offset-2-hover link-underline link-underline-opacity-0 link-underline-opacity-75-hover endpoint"
                                    href="/spring-ai-orchestration/template"><code>/spring-ai-orchestration/template</code></a>
                                 <div class="tooltip-content">
                                     Chat request to OpenAI.

--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/SpringAiOrchestrationTest.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/SpringAiOrchestrationTest.java
@@ -3,9 +3,12 @@ package com.sap.ai.sdk.app.controllers;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.sap.ai.sdk.app.services.SpringAiOrchestrationService;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.chat.model.ChatResponse;
 
+@Slf4j
 public class SpringAiOrchestrationTest {
 
   SpringAiOrchestrationService service = new SpringAiOrchestrationService();
@@ -15,6 +18,26 @@ public class SpringAiOrchestrationTest {
     ChatResponse response = service.completion();
     assertThat(response).isNotNull();
     assertThat(response.getResult().getOutput().getContent()).contains("Paris");
+  }
+
+  @Test
+  void testStreamChatCompletion() {
+    final var stream = service.streamChatCompletion().toStream();
+
+    final var filledDeltaCount = new AtomicInteger(0);
+    stream
+        // foreach consumes all elements, closing the stream at the end
+        .forEach(
+        delta -> {
+          log.info("delta: {}", delta);
+          if (!delta.getResult().getOutput().getContent().isEmpty()) {
+            filledDeltaCount.incrementAndGet();
+          }
+        });
+
+    // the first two and the last delta don't have any content
+    // see OpenAiChatCompletionDelta#getDeltaContent
+    assertThat(filledDeltaCount.get()).isGreaterThan(0);
   }
 
   @Test


### PR DESCRIPTION
## Context

AI/ai-sdk-java-backlog#173.

The Spring AI client `OrchestrationChatModel` should have streaming support

### Feature scope:
 
- [x] `OrchestrationChatModel` has a new method stream which overrides the default `ChatModel` implementation

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] Error handling created / updated & covered by the tests above
- [ ] ~Aligned changes with the JavaScript SDK~
- [x] Documentation updated
- [x] Release notes updated -> already there
