### PR TITLE
fix: [OpenAI] Make system prompt message handling consistent

### DIFF
--- a/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/ChatCompletionString.java
+++ b/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/ChatCompletionString.java
@@ -5,8 +5,12 @@ import com.sap.ai.sdk.foundationmodels.openai.model.OpenAiChatCompletionParamete
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 
-/** Client for interacting with OpenAI models. Allows for convenient string prompts only. */
-public interface OpenAiClientWithSystemPrompt {
+/**
+ * Client for interacting with OpenAI models. Allows for convenient string prompts only.
+ *
+ * @since 1.2.0
+ */
+public interface ChatCompletionString {
 
   /**
    * Generate a completion for the given user prompt.

--- a/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/OpenAiClient.java
+++ b/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/OpenAiClient.java
@@ -37,7 +37,7 @@ import org.apache.hc.core5.http.message.BasicClassicHttpRequest;
 /** Client for interacting with OpenAI models. */
 @Slf4j
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-public final class OpenAiClient implements OpenAiClientWithSystemPrompt {
+public final class OpenAiClient implements ChatCompletionString {
   private static final String DEFAULT_API_VERSION = "2024-02-01";
   static final ObjectMapper JACKSON = getDefaultObjectMapper();
   @Nullable private String systemPrompt = null;
@@ -113,7 +113,7 @@ public final class OpenAiClient implements OpenAiClientWithSystemPrompt {
    * @return the client
    */
   @Nonnull
-  public OpenAiClientWithSystemPrompt withSystemPrompt(@Nonnull final String systemPrompt) {
+  public ChatCompletionString withSystemPrompt(@Nonnull final String systemPrompt) {
     this.systemPrompt = systemPrompt;
     return this;
   }

--- a/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/OpenAiClientWithSystemPrompt.java
+++ b/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/OpenAiClientWithSystemPrompt.java
@@ -1,0 +1,49 @@
+package com.sap.ai.sdk.foundationmodels.openai;
+
+import com.sap.ai.sdk.foundationmodels.openai.model.OpenAiChatCompletionOutput;
+import com.sap.ai.sdk.foundationmodels.openai.model.OpenAiChatCompletionParameters;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+
+/** Client for interacting with OpenAI models. Allows for convenient string prompts only. */
+public interface OpenAiClientWithSystemPrompt {
+
+  /**
+   * Generate a completion for the given user prompt.
+   *
+   * @param prompt a text message.
+   * @return the completion output
+   * @throws OpenAiClientException if the request fails
+   */
+  @Nonnull
+  OpenAiChatCompletionOutput chatCompletion(@Nonnull final String prompt)
+      throws OpenAiClientException;
+
+  /**
+   * Stream a completion for the given prompt. Returns a <b>lazily</b> populated stream of text
+   * chunks. To access more details about the individual chunks, use {@link
+   * OpenAiClient#streamChatCompletionDeltas(OpenAiChatCompletionParameters)}.
+   *
+   * <p>The stream should be consumed using a try-with-resources block to ensure that the underlying
+   * HTTP connection is closed.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * try (var stream = client.streamChatCompletion("...")) {
+   *       stream.forEach(System.out::println);
+   * }
+   * }</pre>
+   *
+   * <p>Please keep in mind that using a terminal stream operation like {@link Stream#forEach} will
+   * block until all chunks are consumed. Also, for obvious reasons, invoking {@link
+   * Stream#parallel()} on this stream is not supported.
+   *
+   * @param prompt a text message.
+   * @return A stream of message deltas
+   * @throws OpenAiClientException if the request fails or if the finish reason is content_filter
+   * @see OpenAiClient#streamChatCompletionDeltas(OpenAiChatCompletionParameters)
+   */
+  @Nonnull
+  Stream<String> streamChatCompletion(@Nonnull final String prompt) throws OpenAiClientException;
+}


### PR DESCRIPTION
We've noticed inconsistent handling of system prompt in convenience class `OpenAiClient`.

If the user defined a base system prompt, then it may be ignored on subsequent calls.
Instead of just logging a warning, we could harden the API contract(?)