### PR TITLE
fix: Spring AI consistent behaviour with Orchestration streaming

### DIFF
--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/spring/OrchestrationChatModel.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/spring/OrchestrationChatModel.java
@@ -6,14 +6,12 @@ import com.google.common.annotations.Beta;
 import com.sap.ai.sdk.orchestration.AssistantMessage;
 import com.sap.ai.sdk.orchestration.OrchestrationChatCompletionDelta;
 import com.sap.ai.sdk.orchestration.OrchestrationClient;
-import com.sap.ai.sdk.orchestration.OrchestrationClientException;
 import com.sap.ai.sdk.orchestration.OrchestrationPrompt;
 import com.sap.ai.sdk.orchestration.SystemMessage;
 import com.sap.ai.sdk.orchestration.UserMessage;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -79,24 +77,10 @@ public class OrchestrationChatModel implements ChatModel {
                 }
                 return iterator;
               });
-      return flux.map(
-          delta -> {
-            throwOnContentFilter(stream, delta);
-            return new OrchestrationSpringChatDelta(delta);
-          });
+      return flux.map(OrchestrationSpringChatDelta::new);
     }
     throw new IllegalArgumentException(
         "Please add OrchestrationChatOptions to the Prompt: new Prompt(\"message\", new OrchestrationChatOptions(config))");
-  }
-
-  private static void throwOnContentFilter(
-      @Nonnull final Stream<OrchestrationChatCompletionDelta> stream,
-      @Nonnull final OrchestrationChatCompletionDelta delta) {
-    final String finishReason = delta.getFinishReason();
-    if (finishReason != null && finishReason.equals("content_filter")) {
-      stream.close();
-      throw new OrchestrationClientException("Content filter filtered the output.");
-    }
   }
 
   @Nonnull

--- a/orchestration/src/test/java/com/sap/ai/sdk/orchestration/spring/OrchestrationChatModelTest.java
+++ b/orchestration/src/test/java/com/sap/ai/sdk/orchestration/spring/OrchestrationChatModelTest.java
@@ -16,7 +16,6 @@ import static org.mockito.Mockito.times;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.sap.ai.sdk.orchestration.OrchestrationClient;
-import com.sap.ai.sdk.orchestration.OrchestrationClientException;
 import com.sap.ai.sdk.orchestration.OrchestrationModuleConfig;
 import com.sap.cloud.sdk.cloudplatform.connectivity.ApacheHttpClient5Accessor;
 import com.sap.cloud.sdk.cloudplatform.connectivity.ApacheHttpClient5Cache;
@@ -100,31 +99,6 @@ public class OrchestrationChatModelTest {
     assertThatThrownBy(() -> client.stream(new Prompt("test", emptyConfig)))
         .isExactlyInstanceOf(IllegalStateException.class)
         .hasMessageContaining("LLM config is required");
-  }
-
-  @Test
-  void streamChatCompletionOutputFilterErrorHandling() throws IOException {
-    try (var inputStream = spy(fileLoader.apply("streamChatCompletionOutputFilter.txt"))) {
-
-      final var httpClient = mock(HttpClient.class);
-      ApacheHttpClient5Accessor.setHttpClientFactory(destination -> httpClient);
-
-      // Create a mock response
-      final var mockResponse = new BasicClassicHttpResponse(200, "OK");
-      final var inputStreamEntity = new InputStreamEntity(inputStream, ContentType.TEXT_PLAIN);
-      mockResponse.setEntity(inputStreamEntity);
-      mockResponse.setHeader("Content-Type", "text/event-stream");
-
-      // Configure the HttpClient mock to return the mock response
-      doReturn(mockResponse).when(httpClient).executeOpen(any(), any(), any());
-
-      Flux<ChatResponse> flux = client.stream(prompt);
-      assertThatThrownBy(() -> flux.toStream().forEach(System.out::println))
-          .isInstanceOf(OrchestrationClientException.class)
-          .hasMessage("Content filter filtered the output.");
-
-      Mockito.verify(inputStream, times(1)).close();
-    }
   }
 
   @Test


### PR DESCRIPTION
## Context

Spring AI stream should be consistent with `streamChatCompletionDeltas()` which does not throw and return a stream of Deltas

Only `streamChatCompletion()` throws because it returns a stream of String, and the user cannot parse the content filter themselves