### PR TITLE
feat: [Orchestration] Enable and test setting `response_format`

### DIFF
--- a/docs/guides/ORCHESTRATION_CHAT_COMPLETION.md
+++ b/docs/guides/ORCHESTRATION_CHAT_COMPLETION.md
@@ -348,6 +348,7 @@ var schema =
                 "additionalProperties",
                 false);
 
+// Note, that we plan to add more convenient ways to add a JSON schema in the future.
 var templatingConfig =
         Template.create()
                 .template(List.of(template.createChatMessage()))

--- a/docs/guides/ORCHESTRATION_CHAT_COMPLETION.md
+++ b/docs/guides/ORCHESTRATION_CHAT_COMPLETION.md
@@ -367,7 +367,7 @@ var result = client.chatCompletion(prompt, configWithTemplate);
 ```
 The response will adhere to the given JSON schema exactly.
 
-Please find [an example in our Spring Boot application]((../../sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OrchestrationService.java).)
+Please find [an example in our Spring Boot application](../../sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OrchestrationService.java)
 
 ## Set model parameters
 

--- a/docs/guides/ORCHESTRATION_CHAT_COMPLETION.md
+++ b/docs/guides/ORCHESTRATION_CHAT_COMPLETION.md
@@ -304,11 +304,11 @@ Please find [an example in our Spring Boot application](../../sample-code/spring
 
 ## Set a Response Format
 
-It is possible to set the response format for the chat completion. Available options are using `JSON_OBJECT` and `JSON_SCHEMA`.
+It is possible to set the response format for the chat completion. Available options are using `JSON_OBJECT`, `JSON_SCHEMA`, and `TEXT`, where `TEXT` is the default behavior.
 
 ### JSON_OBJECT
 
-If you want to force the response to be a JSON object, you can set the response format as follows:
+Setting the response format to `JSON_OBJECT` tells the AI to respond with JSON, i.e., the response from the AI will be a string consisting of a valid JSON. This does, however, not guarantee that the response adheres to a specific structure (other than being valid JSON).
 
 ```java
 var template = Message.user("What is 'apple' in German?");
@@ -324,14 +324,14 @@ var prompt =
         new OrchestrationPrompt(
                 Message.system(
                         "You are a language translator. Answer using the following JSON format: {\"language\": ..., \"translation\": ...}"));
-var result = client.chatCompletion(prompt, configWithTemplate);
+var response = client.chatCompletion(prompt, configWithTemplate).getContent();
 ```
 Note, that it is necessary to tell the AI model to actually return a JSON object in the prompt. The result might not adhere exactly to the given JSON format, but it will be a JSON object.
 
 
 ### JSON_SCHEMA
 
-If you want the response to adhere to a specific JSON schema, you can set the response format as follows:
+If you want the response to not only consist of valid JSON but additionally adhere to a specific JSON schema, you can use `JSON_SCHEMA`. in order to do that, add a JSON schema to the configuration as shown below and the response will adhere to the given schema.
 
 ```java
 var template = Message.user("Whats '%s' in German?".formatted(word));
@@ -363,9 +363,8 @@ var templatingConfig =
 var configWithTemplate = llmWithImageSupportConfig.withTemplateConfig(templatingConfig);
 
 var prompt = new OrchestrationPrompt(Message.system("You are a language translator."));
-var result = client.chatCompletion(prompt, configWithTemplate);
+var response = client.chatCompletion(prompt, configWithTemplate).getContent();
 ```
-The response will adhere to the given JSON schema exactly.
 
 Please find [an example in our Spring Boot application](../../sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OrchestrationService.java)
 

--- a/docs/release-notes/release_notes.md
+++ b/docs/release-notes/release_notes.md
@@ -16,6 +16,7 @@
 - Orchestration:
   - [Add `LlamaGuardFilter`](../guides/ORCHESTRATION_CHAT_COMPLETION.md#chat-completion-filter).
   - [Convenient methods to create messages containing images and multiple text inputs](../guides/ORCHESTRATION_CHAT_COMPLETION.md#add-images-and-multiple-text-inputs-to-a-message)
+  - [Enable setting the response format](../guides/ORCHESTRATION_CHAT_COMPLETION.md#set-a-response-format)
 
 ### 📈 Improvements
 

--- a/docs/release-notes/release_notes.md
+++ b/docs/release-notes/release_notes.md
@@ -14,9 +14,9 @@
 
 - Upgrade to release 2502a of AI Core.
 - Orchestration:
-  - [Add `LlamaGuardFilter`](../guides/ORCHESTRATION_CHAT_COMPLETION.md#chat-completion-filter).
-  - [Convenient methods to create messages containing images and multiple text inputs](../guides/ORCHESTRATION_CHAT_COMPLETION.md#add-images-and-multiple-text-inputs-to-a-message)
-  - [Enable setting the response format](../guides/ORCHESTRATION_CHAT_COMPLETION.md#set-a-response-format)
+  - [Add `LlamaGuardFilter`](https://github.com/SAP/ai-sdk-java/tree/main/docs/guides/ORCHESTRATION_CHAT_COMPLETION.md#chat-completion-filter).
+  - [Convenient methods to create messages containing images and multiple text inputs](https://github.com/SAP/ai-sdk-java/tree/main/docs/guides/ORCHESTRATION_CHAT_COMPLETION.md#add-images-and-multiple-text-inputs-to-a-message)
+  - [Enable setting the response format](https://github.com/SAP/ai-sdk-java/tree/main/docs/guides/ORCHESTRATION_CHAT_COMPLETION.md#set-a-response-format)
 
 ### 📈 Improvements
 

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/ConfigToRequestTransformer.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/ConfigToRequestTransformer.java
@@ -49,6 +49,7 @@ final class ConfigToRequestTransformer {
      * To be fixed with https://github.tools.sap/AI/llm-orchestration/issues/662
      */
     val messages = template instanceof Template t ? t.getTemplate() : List.<ChatMessage>of();
+    val responseFormat = template instanceof Template t ? t.getResponseFormat() : null;
     val messagesWithPrompt = new ArrayList<>(messages);
     messagesWithPrompt.addAll(
         prompt.getMessages().stream().map(Message::createChatMessage).toList());
@@ -56,7 +57,7 @@ final class ConfigToRequestTransformer {
       throw new IllegalStateException(
           "A prompt is required. Pass at least one message or configure a template with messages or a template reference.");
     }
-    return Template.create().template(messagesWithPrompt);
+    return Template.create().template(messagesWithPrompt).responseFormat(responseFormat);
   }
 
   @Nonnull

--- a/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
+++ b/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
@@ -799,7 +799,7 @@ class OrchestrationUnitTest {
 
     var llmWithImageSupportConfig = new OrchestrationModuleConfig().withLlmConfig(GPT_4O_MINI);
 
-    val template = Message.user("Whats 'Apfel' in German?");
+    val template = Message.user("Whats 'apple' in German?");
     var schema =
         Map.of(
             "type",
@@ -831,6 +831,54 @@ class OrchestrationUnitTest {
 
     final var result =
         client.chatCompletion(prompt, configWithTemplate);
+
+    final var response = result.getOriginalResponse();
+    assertThat(response.getRequestId()).isEqualTo("0759f249-a261-4cb7-99d5-ea6eae2c141c");
+    final var messageList = result.getAllMessages();
+
+    assertThat(((TextItem) messageList.get(0).content().items().get(0)).text())
+        .isEqualTo("Whats 'apple' in German?");
+    assertThat(messageList.get(0).role()).isEqualTo("user");
+    assertThat(((TextItem) messageList.get(1).content().items().get(0)).text())
+        .isEqualTo(
+            "You are a language translator.");
+    assertThat(messageList.get(1).role()).isEqualTo("system");
+    assertThat(((TextItem) messageList.get(2).content().items().get(0)).text())
+        .isEqualTo("{\"translation\":\"Apfel\",\"language\":\"German\"}");
+    assertThat(messageList.get(2).role()).isEqualTo("assistant");
+
+    var llm = (LLMModuleResultSynchronous) response.getModuleResults().getLlm();
+    assertThat(llm).isNotNull();
+    assertThat(llm.getId()).isEqualTo("chatcmpl-AzmCw5QZBi6zQkJPQhvsyjW4Fe90c");
+    assertThat(llm.getObject()).isEqualTo("chat.completion");
+    assertThat(llm.getCreated()).isEqualTo(1739286682);
+    assertThat(llm.getModel()).isEqualTo("gpt-4o-mini-2024-07-18");
+    assertThat(llm.getSystemFingerprint()).isEqualTo("fp_f3927aa00d");
+    var choices = llm.getChoices();
+    assertThat(choices.get(0).getIndex()).isZero();
+    assertThat(choices.get(0).getMessage().getContent())
+        .isEqualTo("{\"translation\":\"Apfel\",\"language\":\"German\"}");
+    assertThat(choices.get(0).getMessage().getRole()).isEqualTo("assistant");
+    assertThat(choices.get(0).getFinishReason()).isEqualTo("stop");
+    var usage = result.getTokenUsage();
+    assertThat(usage.getCompletionTokens()).isEqualTo(10);
+    assertThat(usage.getPromptTokens()).isEqualTo(68);
+    assertThat(usage.getTotalTokens()).isEqualTo(78);
+    var orchestrationResult = (LLMModuleResultSynchronous) response.getOrchestrationResult();
+    assertThat(orchestrationResult.getId()).isEqualTo("chatcmpl-AzmCw5QZBi6zQkJPQhvsyjW4Fe90c");
+    assertThat(orchestrationResult.getObject()).isEqualTo("chat.completion");
+    assertThat(orchestrationResult.getCreated()).isEqualTo(1739286682);
+    assertThat(orchestrationResult.getModel()).isEqualTo("gpt-4o-mini-2024-07-18");
+    choices = orchestrationResult.getChoices();
+    assertThat(choices.get(0).getIndex()).isZero();
+    assertThat(choices.get(0).getMessage().getContent())
+        .isEqualTo("{\"translation\":\"Apfel\",\"language\":\"German\"}");
+    assertThat(choices.get(0).getMessage().getRole()).isEqualTo("assistant");
+    assertThat(choices.get(0).getFinishReason()).isEqualTo("stop");
+    usage = result.getTokenUsage();
+    assertThat(usage.getCompletionTokens()).isEqualTo(10);
+    assertThat(usage.getPromptTokens()).isEqualTo(68);
+    assertThat(usage.getTotalTokens()).isEqualTo(78);
 
     // verify that null fields are absent from the sent request
     try (var requestInputStream = fileLoader.apply("jsonSchemaRequest.json")) {

--- a/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
+++ b/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
@@ -47,6 +47,7 @@ import com.sap.ai.sdk.orchestration.model.LlamaGuard38b;
 import com.sap.ai.sdk.orchestration.model.ResponseFormatJsonObject;
 import com.sap.ai.sdk.orchestration.model.ResponseFormatJsonSchema;
 import com.sap.ai.sdk.orchestration.model.ResponseFormatJsonSchemaJsonSchema;
+import com.sap.ai.sdk.orchestration.model.ResponseFormatText;
 import com.sap.ai.sdk.orchestration.model.SearchDocumentKeyValueListPair;
 import com.sap.ai.sdk.orchestration.model.SearchSelectOptionEnum;
 import com.sap.ai.sdk.orchestration.model.SingleChatMessage;
@@ -965,6 +966,92 @@ class OrchestrationUnitTest {
 
     // verify that null fields are absent from the sent request
     try (var requestInputStream = fileLoader.apply("jsonObjectRequest.json")) {
+      final String request = new String(requestInputStream.readAllBytes());
+      verify(postRequestedFor(anyUrl()).withRequestBody(equalToJson(request)));
+    }
+  }
+
+  @Test
+  void testResponseObjectText() throws IOException {
+    stubFor(
+        post(anyUrl())
+            .willReturn(
+                aResponse()
+                    .withBodyFile("responseFormatTextResponse.json")
+                    .withHeader("Content-Type", "application/json")));
+
+    val llmWithImageSupportConfig = new OrchestrationModuleConfig().withLlmConfig(GPT_4O_MINI);
+
+    val template = Message.user("What is 'apple' in German?");
+
+    val templatingConfig =
+        Template.create()
+            .template(List.of(template.createChatMessage()))
+            .responseFormat(
+                ResponseFormatText.create().type(ResponseFormatText.TypeEnum.TEXT));
+    val configWithTemplate = llmWithImageSupportConfig.withTemplateConfig(templatingConfig);
+
+    val prompt =
+        new OrchestrationPrompt(
+            Message.system(
+                "You are a language translator. Answer using JSON."));
+
+    final var result =
+        client.chatCompletion(prompt, configWithTemplate);
+
+    final var response = result.getOriginalResponse();
+assertThat(response.getRequestId()).isEqualTo("2fe5cbeb-4cdc-4a62-8d0b-29bbd8acde07");
+final var messageList = result.getAllMessages();
+
+assertThat(((TextItem) messageList.get(0).content().items().get(0)).text())
+    .isEqualTo("What is 'apple' in German?");
+assertThat(messageList.get(0).role()).isEqualTo("user");
+assertThat(((TextItem) messageList.get(1).content().items().get(0)).text())
+    .isEqualTo(
+        "You are a language translator. Answer using JSON.");
+assertThat(messageList.get(1).role()).isEqualTo("system");
+    assertThat(((TextItem) messageList.get(2).content().items().get(0)).text())
+        .isEqualTo(
+            "```json\n{\n  \"word\": \"apple\",\n  \"translation\": \"Apfel\",\n  \"language\": \"German\"\n}\n```");
+assertThat(messageList.get(2).role()).isEqualTo("assistant");
+
+var llm = (LLMModuleResultSynchronous) response.getModuleResults().getLlm();
+assertThat(llm).isNotNull();
+assertThat(llm.getId()).isEqualTo("chatcmpl-AzmS9fd4aGRUdEVsQufpFXSVStfck");
+assertThat(llm.getObject()).isEqualTo("chat.completion");
+assertThat(llm.getCreated()).isEqualTo(1739287625);
+assertThat(llm.getModel()).isEqualTo("gpt-4o-mini-2024-07-18");
+assertThat(llm.getSystemFingerprint()).isEqualTo("fp_f3927aa00d");
+var choices = llm.getChoices();
+assertThat(choices.get(0).getIndex()).isZero();
+    assertThat(choices.get(0).getMessage().getContent())
+        .isEqualTo(
+            "```json\n{\n  \"word\": \"apple\",\n  \"translation\": \"Apfel\",\n  \"language\": \"German\"\n}\n```");
+assertThat(choices.get(0).getMessage().getRole()).isEqualTo("assistant");
+assertThat(choices.get(0).getFinishReason()).isEqualTo("stop");
+var usage = result.getTokenUsage();
+assertThat(usage.getCompletionTokens()).isEqualTo(28);
+assertThat(usage.getPromptTokens()).isEqualTo(29);
+assertThat(usage.getTotalTokens()).isEqualTo(57);
+var orchestrationResult = (LLMModuleResultSynchronous) response.getOrchestrationResult();
+assertThat(orchestrationResult.getId()).isEqualTo("chatcmpl-AzmS9fd4aGRUdEVsQufpFXSVStfck");
+assertThat(orchestrationResult.getObject()).isEqualTo("chat.completion");
+assertThat(orchestrationResult.getCreated()).isEqualTo(1739287625);
+assertThat(orchestrationResult.getModel()).isEqualTo("gpt-4o-mini-2024-07-18");
+choices = orchestrationResult.getChoices();
+assertThat(choices.get(0).getIndex()).isZero();
+    assertThat(choices.get(0).getMessage().getContent())
+        .isEqualTo(
+            "```json\n{\n  \"word\": \"apple\",\n  \"translation\": \"Apfel\",\n  \"language\": \"German\"\n}\n```");
+assertThat(choices.get(0).getMessage().getRole()).isEqualTo("assistant");
+assertThat(choices.get(0).getFinishReason()).isEqualTo("stop");
+usage = result.getTokenUsage();
+assertThat(usage.getCompletionTokens()).isEqualTo(28);
+assertThat(usage.getPromptTokens()).isEqualTo(29);
+assertThat(usage.getTotalTokens()).isEqualTo(57);
+
+    // verify that null fields are absent from the sent request
+    try (var requestInputStream = fileLoader.apply("responseFormatTextRequest.json")) {
       final String request = new String(requestInputStream.readAllBytes());
       verify(postRequestedFor(anyUrl()).withRequestBody(equalToJson(request)));
     }

--- a/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
+++ b/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
@@ -806,34 +806,8 @@ class OrchestrationUnitTest {
 
     val prompt = new OrchestrationPrompt(Message.system("You are a language translator."));
 
-    final var result = client.chatCompletion(prompt, configWithTemplate);
-
-    final var response = result.getOriginalResponse();
-    assertThat(response.getRequestId()).isEqualTo("0759f249-a261-4cb7-99d5-ea6eae2c141c");
-    final var messageList = result.getAllMessages();
-
-    assertThat(((TextItem) messageList.get(0).content().items().get(0)).text())
-        .isEqualTo("Whats 'apple' in German?");
-    assertThat(messageList.get(0).role()).isEqualTo("user");
-    assertThat(((TextItem) messageList.get(1).content().items().get(0)).text())
-        .isEqualTo("You are a language translator.");
-    assertThat(messageList.get(1).role()).isEqualTo("system");
-    assertThat(((TextItem) messageList.get(2).content().items().get(0)).text())
-        .isEqualTo("{\"translation\":\"Apfel\",\"language\":\"German\"}");
-    assertThat(messageList.get(2).role()).isEqualTo("assistant");
-
-    var llm = (LLMModuleResultSynchronous) response.getModuleResults().getLlm();
-    assertThat(llm).isNotNull();
-    var choices = llm.getChoices();
-    assertThat(choices.get(0).getIndex()).isZero();
-    assertThat(choices.get(0).getMessage().getContent())
-        .isEqualTo("{\"translation\":\"Apfel\",\"language\":\"German\"}");
-    assertThat(choices.get(0).getMessage().getRole()).isEqualTo("assistant");
-    assertThat(choices.get(0).getIndex()).isZero();
-    assertThat(choices.get(0).getMessage().getContent())
-        .isEqualTo("{\"translation\":\"Apfel\",\"language\":\"German\"}");
-    assertThat(choices.get(0).getMessage().getRole()).isEqualTo("assistant");
-    assertThat(choices.get(0).getFinishReason()).isEqualTo("stop");
+    final var message = client.chatCompletion(prompt, configWithTemplate).getContent();
+    assertThat(message).isEqualTo("{\"translation\":\"Apfel\",\"language\":\"German\"}");
 
     try (var requestInputStream = fileLoader.apply("jsonSchemaRequest.json")) {
       final String request = new String(requestInputStream.readAllBytes());
@@ -866,36 +840,8 @@ class OrchestrationUnitTest {
             Message.system(
                 "You are a language translator. Answer using the following JSON format: {\"language\": ..., \"translation\": ...}"));
 
-    final var result = client.chatCompletion(prompt, configWithTemplate);
-
-    final var response = result.getOriginalResponse();
-    assertThat(response.getRequestId()).isEqualTo("f353a729-3391-4cec-bbf9-7ab39d34ebc1");
-    final var messageList = result.getAllMessages();
-
-    assertThat(((TextItem) messageList.get(0).content().items().get(0)).text())
-        .isEqualTo("What is 'apple' in German?");
-    assertThat(messageList.get(0).role()).isEqualTo("user");
-    assertThat(((TextItem) messageList.get(1).content().items().get(0)).text())
-        .isEqualTo(
-            "You are a language translator. Answer using the following JSON format: {\"language\": ..., \"translation\": ...}");
-    assertThat(messageList.get(1).role()).isEqualTo("system");
-    assertThat(((TextItem) messageList.get(2).content().items().get(0)).text())
-        .isEqualTo("{\"language\": \"German\", \"translation\": \"Apfel\"}");
-    assertThat(messageList.get(2).role()).isEqualTo("assistant");
-
-    var llm = (LLMModuleResultSynchronous) response.getModuleResults().getLlm();
-    assertThat(llm).isNotNull();
-    var choices = llm.getChoices();
-    assertThat(choices.get(0).getIndex()).isZero();
-    assertThat(choices.get(0).getMessage().getContent())
-        .isEqualTo("{\"language\": \"German\", \"translation\": \"Apfel\"}");
-    assertThat(choices.get(0).getMessage().getRole()).isEqualTo("assistant");
-    assertThat(choices.get(0).getFinishReason()).isEqualTo("stop");
-    assertThat(choices.get(0).getIndex()).isZero();
-    assertThat(choices.get(0).getMessage().getContent())
-        .isEqualTo("{\"language\": \"German\", \"translation\": \"Apfel\"}");
-    assertThat(choices.get(0).getMessage().getRole()).isEqualTo("assistant");
-    assertThat(choices.get(0).getFinishReason()).isEqualTo("stop");
+    final var message = client.chatCompletion(prompt, configWithTemplate).getContent();
+    assertThat(message).isEqualTo("{\"language\": \"German\", \"translation\": \"Apfel\"}");
 
     try (var requestInputStream = fileLoader.apply("jsonObjectRequest.json")) {
       final String request = new String(requestInputStream.readAllBytes());
@@ -925,37 +871,10 @@ class OrchestrationUnitTest {
         new OrchestrationPrompt(
             Message.system("You are a language translator. Answer using JSON."));
 
-    final var result = client.chatCompletion(prompt, configWithTemplate);
-
-    final var response = result.getOriginalResponse();
-    assertThat(response.getRequestId()).isEqualTo("2fe5cbeb-4cdc-4a62-8d0b-29bbd8acde07");
-    final var messageList = result.getAllMessages();
-
-    assertThat(((TextItem) messageList.get(0).content().items().get(0)).text())
-        .isEqualTo("What is 'apple' in German?");
-    assertThat(messageList.get(0).role()).isEqualTo("user");
-    assertThat(((TextItem) messageList.get(1).content().items().get(0)).text())
-        .isEqualTo("You are a language translator. Answer using JSON.");
-    assertThat(messageList.get(1).role()).isEqualTo("system");
-    assertThat(((TextItem) messageList.get(2).content().items().get(0)).text())
+    final var message = client.chatCompletion(prompt, configWithTemplate).getContent();
+    assertThat(message)
         .isEqualTo(
             "```json\n{\n  \"word\": \"apple\",\n  \"translation\": \"Apfel\",\n  \"language\": \"German\"\n}\n```");
-    assertThat(messageList.get(2).role()).isEqualTo("assistant");
-
-    var llm = (LLMModuleResultSynchronous) response.getModuleResults().getLlm();
-    assertThat(llm).isNotNull();
-    var choices = llm.getChoices();
-    assertThat(choices.get(0).getIndex()).isZero();
-    assertThat(choices.get(0).getMessage().getContent())
-        .isEqualTo(
-            "```json\n{\n  \"word\": \"apple\",\n  \"translation\": \"Apfel\",\n  \"language\": \"German\"\n}\n```");
-    assertThat(choices.get(0).getMessage().getRole()).isEqualTo("assistant");
-    assertThat(choices.get(0).getFinishReason()).isEqualTo("stop");
-    assertThat(choices.get(0).getMessage().getContent())
-        .isEqualTo(
-            "```json\n{\n  \"word\": \"apple\",\n  \"translation\": \"Apfel\",\n  \"language\": \"German\"\n}\n```");
-    assertThat(choices.get(0).getMessage().getRole()).isEqualTo("assistant");
-    assertThat(choices.get(0).getFinishReason()).isEqualTo("stop");
 
     try (var requestInputStream = fileLoader.apply("responseFormatTextRequest.json")) {
       final String request = new String(requestInputStream.readAllBytes());

--- a/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
+++ b/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
@@ -790,7 +790,7 @@ class OrchestrationUnitTest {
   }
 
   @Test
-  void testJsonSchema() throws IOException {
+  void testResponseObjectJsonSchema() throws IOException {
     stubFor(
         post(anyUrl())
             .willReturn(
@@ -887,7 +887,7 @@ class OrchestrationUnitTest {
   }
 
   @Test
-  void testJsonObject() throws IOException {
+  void testResponseObjectJsonObject() throws IOException {
     stubFor(
         post(anyUrl())
             .willReturn(

--- a/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
+++ b/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
@@ -897,10 +897,9 @@ class OrchestrationUnitTest {
                     .withBodyFile("jsonObjectResponse.json")
                     .withHeader("Content-Type", "application/json")));
 
-    var llmWithImageSupportConfig = new OrchestrationModuleConfig().withLlmConfig(GPT_4O_MINI);
+    val llmWithImageSupportConfig = new OrchestrationModuleConfig().withLlmConfig(GPT_4O_MINI);
 
     val template = Message.user("What is 'apple' in German?");
-
     val templatingConfig =
         Template.create()
             .template(List.of(template.createChatMessage()))
@@ -983,7 +982,6 @@ class OrchestrationUnitTest {
     val llmWithImageSupportConfig = new OrchestrationModuleConfig().withLlmConfig(GPT_4O_MINI);
 
     val template = Message.user("What is 'apple' in German?");
-
     val templatingConfig =
         Template.create()
             .template(List.of(template.createChatMessage()))

--- a/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
+++ b/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
@@ -740,35 +740,15 @@ class OrchestrationUnitTest {
             "Well, this image features the logo of SAP, a software company, set against a gradient blue background transitioning from light to dark. The main color in the image is blue.");
 
     assertThat(response).isNotNull();
-    assertThat(response.getRequestId()).isEqualTo("8d973a0d-c2cf-437b-a765-08d66bf446d8");
-    assertThat(response.getModuleResults()).isNotNull();
-    assertThat(response.getModuleResults().getTemplating()).hasSize(2);
-
     var llmResults = (LLMModuleResultSynchronous) response.getModuleResults().getLlm();
     assertThat(llmResults).isNotNull();
-    assertThat(llmResults.getId()).isEqualTo("chatcmpl-AyGx4yLYUH79TK81i21BaABoUpf4v");
-    assertThat(llmResults.getObject()).isEqualTo("chat.completion");
-    assertThat(llmResults.getCreated()).isEqualTo(1738928206);
-    assertThat(llmResults.getModel()).isEqualTo("gpt-4o-mini-2024-07-18");
-    assertThat(llmResults.getSystemFingerprint()).isEqualTo("fp_f3927aa00d");
     assertThat(llmResults.getChoices()).hasSize(1);
     assertThat(llmResults.getChoices().get(0).getMessage().getContent())
         .isEqualTo(
             "Well, this image features the logo of SAP, a software company, set against a gradient blue background transitioning from light to dark. The main color in the image is blue.");
     assertThat(llmResults.getChoices().get(0).getFinishReason()).isEqualTo("stop");
     assertThat(llmResults.getChoices().get(0).getMessage().getRole()).isEqualTo("assistant");
-    assertThat(llmResults.getChoices().get(0).getIndex()).isZero();
-    assertThat(llmResults.getUsage().getCompletionTokens()).isEqualTo(35);
-    assertThat(llmResults.getUsage().getPromptTokens()).isEqualTo(250);
-    assertThat(llmResults.getUsage().getTotalTokens()).isEqualTo(285);
-
     var orchestrationResult = (LLMModuleResultSynchronous) response.getOrchestrationResult();
-    assertThat(orchestrationResult).isNotNull();
-    assertThat(orchestrationResult.getId()).isEqualTo("chatcmpl-AyGx4yLYUH79TK81i21BaABoUpf4v");
-    assertThat(orchestrationResult.getObject()).isEqualTo("chat.completion");
-    assertThat(orchestrationResult.getCreated()).isEqualTo(1738928206);
-    assertThat(orchestrationResult.getModel()).isEqualTo("gpt-4o-mini-2024-07-18");
-    assertThat(orchestrationResult.getSystemFingerprint()).isEqualTo("fp_f3927aa00d");
     assertThat(orchestrationResult.getChoices()).hasSize(1);
     assertThat(orchestrationResult.getChoices().get(0).getMessage().getContent())
         .isEqualTo(
@@ -776,10 +756,6 @@ class OrchestrationUnitTest {
     assertThat(orchestrationResult.getChoices().get(0).getFinishReason()).isEqualTo("stop");
     assertThat(orchestrationResult.getChoices().get(0).getMessage().getRole())
         .isEqualTo("assistant");
-    assertThat(orchestrationResult.getChoices().get(0).getIndex()).isZero();
-    assertThat(orchestrationResult.getUsage().getCompletionTokens()).isEqualTo(35);
-    assertThat(orchestrationResult.getUsage().getPromptTokens()).isEqualTo(250);
-    assertThat(orchestrationResult.getUsage().getTotalTokens()).isEqualTo(285);
 
     try (var requestInputStream = fileLoader.apply("multiMessageRequest.json")) {
       final String requestBody = new String(requestInputStream.readAllBytes());
@@ -848,38 +824,17 @@ class OrchestrationUnitTest {
 
     var llm = (LLMModuleResultSynchronous) response.getModuleResults().getLlm();
     assertThat(llm).isNotNull();
-    assertThat(llm.getId()).isEqualTo("chatcmpl-AzmCw5QZBi6zQkJPQhvsyjW4Fe90c");
-    assertThat(llm.getObject()).isEqualTo("chat.completion");
-    assertThat(llm.getCreated()).isEqualTo(1739286682);
-    assertThat(llm.getModel()).isEqualTo("gpt-4o-mini-2024-07-18");
-    assertThat(llm.getSystemFingerprint()).isEqualTo("fp_f3927aa00d");
     var choices = llm.getChoices();
     assertThat(choices.get(0).getIndex()).isZero();
     assertThat(choices.get(0).getMessage().getContent())
         .isEqualTo("{\"translation\":\"Apfel\",\"language\":\"German\"}");
     assertThat(choices.get(0).getMessage().getRole()).isEqualTo("assistant");
-    assertThat(choices.get(0).getFinishReason()).isEqualTo("stop");
-    var usage = result.getTokenUsage();
-    assertThat(usage.getCompletionTokens()).isEqualTo(10);
-    assertThat(usage.getPromptTokens()).isEqualTo(68);
-    assertThat(usage.getTotalTokens()).isEqualTo(78);
-    var orchestrationResult = (LLMModuleResultSynchronous) response.getOrchestrationResult();
-    assertThat(orchestrationResult.getId()).isEqualTo("chatcmpl-AzmCw5QZBi6zQkJPQhvsyjW4Fe90c");
-    assertThat(orchestrationResult.getObject()).isEqualTo("chat.completion");
-    assertThat(orchestrationResult.getCreated()).isEqualTo(1739286682);
-    assertThat(orchestrationResult.getModel()).isEqualTo("gpt-4o-mini-2024-07-18");
-    choices = orchestrationResult.getChoices();
     assertThat(choices.get(0).getIndex()).isZero();
     assertThat(choices.get(0).getMessage().getContent())
         .isEqualTo("{\"translation\":\"Apfel\",\"language\":\"German\"}");
     assertThat(choices.get(0).getMessage().getRole()).isEqualTo("assistant");
     assertThat(choices.get(0).getFinishReason()).isEqualTo("stop");
-    usage = result.getTokenUsage();
-    assertThat(usage.getCompletionTokens()).isEqualTo(10);
-    assertThat(usage.getPromptTokens()).isEqualTo(68);
-    assertThat(usage.getTotalTokens()).isEqualTo(78);
 
-    // verify that null fields are absent from the sent request
     try (var requestInputStream = fileLoader.apply("jsonSchemaRequest.json")) {
       final String request = new String(requestInputStream.readAllBytes());
       verify(postRequestedFor(anyUrl()).withRequestBody(equalToJson(request)));
@@ -930,38 +885,18 @@ class OrchestrationUnitTest {
 
     var llm = (LLMModuleResultSynchronous) response.getModuleResults().getLlm();
     assertThat(llm).isNotNull();
-    assertThat(llm.getId()).isEqualTo("chatcmpl-Azm2iclgMiLcQHP3cGQANArkxoiGx");
-    assertThat(llm.getObject()).isEqualTo("chat.completion");
-    assertThat(llm.getCreated()).isEqualTo(1739286048);
-    assertThat(llm.getModel()).isEqualTo("gpt-4o-mini-2024-07-18");
-    assertThat(llm.getSystemFingerprint()).isEqualTo("fp_f3927aa00d");
     var choices = llm.getChoices();
     assertThat(choices.get(0).getIndex()).isZero();
     assertThat(choices.get(0).getMessage().getContent())
         .isEqualTo("{\"language\": \"German\", \"translation\": \"Apfel\"}");
     assertThat(choices.get(0).getMessage().getRole()).isEqualTo("assistant");
     assertThat(choices.get(0).getFinishReason()).isEqualTo("stop");
-    var usage = result.getTokenUsage();
-    assertThat(usage.getCompletionTokens()).isEqualTo(13);
-    assertThat(usage.getPromptTokens()).isEqualTo(41);
-    assertThat(usage.getTotalTokens()).isEqualTo(54);
-    var orchestrationResult = (LLMModuleResultSynchronous) response.getOrchestrationResult();
-    assertThat(orchestrationResult.getId()).isEqualTo("chatcmpl-Azm2iclgMiLcQHP3cGQANArkxoiGx");
-    assertThat(orchestrationResult.getObject()).isEqualTo("chat.completion");
-    assertThat(orchestrationResult.getCreated()).isEqualTo(1739286048);
-    assertThat(orchestrationResult.getModel()).isEqualTo("gpt-4o-mini-2024-07-18");
-    choices = orchestrationResult.getChoices();
     assertThat(choices.get(0).getIndex()).isZero();
     assertThat(choices.get(0).getMessage().getContent())
         .isEqualTo("{\"language\": \"German\", \"translation\": \"Apfel\"}");
     assertThat(choices.get(0).getMessage().getRole()).isEqualTo("assistant");
     assertThat(choices.get(0).getFinishReason()).isEqualTo("stop");
-    usage = result.getTokenUsage();
-    assertThat(usage.getCompletionTokens()).isEqualTo(13);
-    assertThat(usage.getPromptTokens()).isEqualTo(41);
-    assertThat(usage.getTotalTokens()).isEqualTo(54);
 
-    // verify that null fields are absent from the sent request
     try (var requestInputStream = fileLoader.apply("jsonObjectRequest.json")) {
       final String request = new String(requestInputStream.readAllBytes());
       verify(postRequestedFor(anyUrl()).withRequestBody(equalToJson(request)));
@@ -1009,11 +944,6 @@ class OrchestrationUnitTest {
 
     var llm = (LLMModuleResultSynchronous) response.getModuleResults().getLlm();
     assertThat(llm).isNotNull();
-    assertThat(llm.getId()).isEqualTo("chatcmpl-AzmS9fd4aGRUdEVsQufpFXSVStfck");
-    assertThat(llm.getObject()).isEqualTo("chat.completion");
-    assertThat(llm.getCreated()).isEqualTo(1739287625);
-    assertThat(llm.getModel()).isEqualTo("gpt-4o-mini-2024-07-18");
-    assertThat(llm.getSystemFingerprint()).isEqualTo("fp_f3927aa00d");
     var choices = llm.getChoices();
     assertThat(choices.get(0).getIndex()).isZero();
     assertThat(choices.get(0).getMessage().getContent())
@@ -1021,28 +951,12 @@ class OrchestrationUnitTest {
             "```json\n{\n  \"word\": \"apple\",\n  \"translation\": \"Apfel\",\n  \"language\": \"German\"\n}\n```");
     assertThat(choices.get(0).getMessage().getRole()).isEqualTo("assistant");
     assertThat(choices.get(0).getFinishReason()).isEqualTo("stop");
-    var usage = result.getTokenUsage();
-    assertThat(usage.getCompletionTokens()).isEqualTo(28);
-    assertThat(usage.getPromptTokens()).isEqualTo(29);
-    assertThat(usage.getTotalTokens()).isEqualTo(57);
-    var orchestrationResult = (LLMModuleResultSynchronous) response.getOrchestrationResult();
-    assertThat(orchestrationResult.getId()).isEqualTo("chatcmpl-AzmS9fd4aGRUdEVsQufpFXSVStfck");
-    assertThat(orchestrationResult.getObject()).isEqualTo("chat.completion");
-    assertThat(orchestrationResult.getCreated()).isEqualTo(1739287625);
-    assertThat(orchestrationResult.getModel()).isEqualTo("gpt-4o-mini-2024-07-18");
-    choices = orchestrationResult.getChoices();
-    assertThat(choices.get(0).getIndex()).isZero();
     assertThat(choices.get(0).getMessage().getContent())
         .isEqualTo(
             "```json\n{\n  \"word\": \"apple\",\n  \"translation\": \"Apfel\",\n  \"language\": \"German\"\n}\n```");
     assertThat(choices.get(0).getMessage().getRole()).isEqualTo("assistant");
     assertThat(choices.get(0).getFinishReason()).isEqualTo("stop");
-    usage = result.getTokenUsage();
-    assertThat(usage.getCompletionTokens()).isEqualTo(28);
-    assertThat(usage.getPromptTokens()).isEqualTo(29);
-    assertThat(usage.getTotalTokens()).isEqualTo(57);
 
-    // verify that null fields are absent from the sent request
     try (var requestInputStream = fileLoader.apply("responseFormatTextRequest.json")) {
       final String request = new String(requestInputStream.readAllBytes());
       verify(postRequestedFor(anyUrl()).withRequestBody(equalToJson(request)));

--- a/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
+++ b/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
@@ -830,8 +830,7 @@ class OrchestrationUnitTest {
 
     val prompt = new OrchestrationPrompt(Message.system("You are a language translator."));
 
-    final var result =
-        client.chatCompletion(prompt, configWithTemplate);
+    final var result = client.chatCompletion(prompt, configWithTemplate);
 
     final var response = result.getOriginalResponse();
     assertThat(response.getRequestId()).isEqualTo("0759f249-a261-4cb7-99d5-ea6eae2c141c");
@@ -841,8 +840,7 @@ class OrchestrationUnitTest {
         .isEqualTo("Whats 'apple' in German?");
     assertThat(messageList.get(0).role()).isEqualTo("user");
     assertThat(((TextItem) messageList.get(1).content().items().get(0)).text())
-        .isEqualTo(
-            "You are a language translator.");
+        .isEqualTo("You are a language translator.");
     assertThat(messageList.get(1).role()).isEqualTo("system");
     assertThat(((TextItem) messageList.get(2).content().items().get(0)).text())
         .isEqualTo("{\"translation\":\"Apfel\",\"language\":\"German\"}");
@@ -904,7 +902,8 @@ class OrchestrationUnitTest {
         Template.create()
             .template(List.of(template.createChatMessage()))
             .responseFormat(
-                ResponseFormatJsonObject.create().type(ResponseFormatJsonObject.TypeEnum.JSON_OBJECT));
+                ResponseFormatJsonObject.create()
+                    .type(ResponseFormatJsonObject.TypeEnum.JSON_OBJECT));
     val configWithTemplate = llmWithImageSupportConfig.withTemplateConfig(templatingConfig);
 
     val prompt =
@@ -912,8 +911,7 @@ class OrchestrationUnitTest {
             Message.system(
                 "You are a language translator. Answer using the following JSON format: {\"language\": ..., \"translation\": ...}"));
 
-    final var result =
-        client.chatCompletion(prompt, configWithTemplate);
+    final var result = client.chatCompletion(prompt, configWithTemplate);
 
     final var response = result.getOriginalResponse();
     assertThat(response.getRequestId()).isEqualTo("f353a729-3391-4cec-bbf9-7ab39d34ebc1");
@@ -985,68 +983,64 @@ class OrchestrationUnitTest {
     val templatingConfig =
         Template.create()
             .template(List.of(template.createChatMessage()))
-            .responseFormat(
-                ResponseFormatText.create().type(ResponseFormatText.TypeEnum.TEXT));
+            .responseFormat(ResponseFormatText.create().type(ResponseFormatText.TypeEnum.TEXT));
     val configWithTemplate = llmWithImageSupportConfig.withTemplateConfig(templatingConfig);
 
     val prompt =
         new OrchestrationPrompt(
-            Message.system(
-                "You are a language translator. Answer using JSON."));
+            Message.system("You are a language translator. Answer using JSON."));
 
-    final var result =
-        client.chatCompletion(prompt, configWithTemplate);
+    final var result = client.chatCompletion(prompt, configWithTemplate);
 
     final var response = result.getOriginalResponse();
-assertThat(response.getRequestId()).isEqualTo("2fe5cbeb-4cdc-4a62-8d0b-29bbd8acde07");
-final var messageList = result.getAllMessages();
+    assertThat(response.getRequestId()).isEqualTo("2fe5cbeb-4cdc-4a62-8d0b-29bbd8acde07");
+    final var messageList = result.getAllMessages();
 
-assertThat(((TextItem) messageList.get(0).content().items().get(0)).text())
-    .isEqualTo("What is 'apple' in German?");
-assertThat(messageList.get(0).role()).isEqualTo("user");
-assertThat(((TextItem) messageList.get(1).content().items().get(0)).text())
-    .isEqualTo(
-        "You are a language translator. Answer using JSON.");
-assertThat(messageList.get(1).role()).isEqualTo("system");
+    assertThat(((TextItem) messageList.get(0).content().items().get(0)).text())
+        .isEqualTo("What is 'apple' in German?");
+    assertThat(messageList.get(0).role()).isEqualTo("user");
+    assertThat(((TextItem) messageList.get(1).content().items().get(0)).text())
+        .isEqualTo("You are a language translator. Answer using JSON.");
+    assertThat(messageList.get(1).role()).isEqualTo("system");
     assertThat(((TextItem) messageList.get(2).content().items().get(0)).text())
         .isEqualTo(
             "```json\n{\n  \"word\": \"apple\",\n  \"translation\": \"Apfel\",\n  \"language\": \"German\"\n}\n```");
-assertThat(messageList.get(2).role()).isEqualTo("assistant");
+    assertThat(messageList.get(2).role()).isEqualTo("assistant");
 
-var llm = (LLMModuleResultSynchronous) response.getModuleResults().getLlm();
-assertThat(llm).isNotNull();
-assertThat(llm.getId()).isEqualTo("chatcmpl-AzmS9fd4aGRUdEVsQufpFXSVStfck");
-assertThat(llm.getObject()).isEqualTo("chat.completion");
-assertThat(llm.getCreated()).isEqualTo(1739287625);
-assertThat(llm.getModel()).isEqualTo("gpt-4o-mini-2024-07-18");
-assertThat(llm.getSystemFingerprint()).isEqualTo("fp_f3927aa00d");
-var choices = llm.getChoices();
-assertThat(choices.get(0).getIndex()).isZero();
+    var llm = (LLMModuleResultSynchronous) response.getModuleResults().getLlm();
+    assertThat(llm).isNotNull();
+    assertThat(llm.getId()).isEqualTo("chatcmpl-AzmS9fd4aGRUdEVsQufpFXSVStfck");
+    assertThat(llm.getObject()).isEqualTo("chat.completion");
+    assertThat(llm.getCreated()).isEqualTo(1739287625);
+    assertThat(llm.getModel()).isEqualTo("gpt-4o-mini-2024-07-18");
+    assertThat(llm.getSystemFingerprint()).isEqualTo("fp_f3927aa00d");
+    var choices = llm.getChoices();
+    assertThat(choices.get(0).getIndex()).isZero();
     assertThat(choices.get(0).getMessage().getContent())
         .isEqualTo(
             "```json\n{\n  \"word\": \"apple\",\n  \"translation\": \"Apfel\",\n  \"language\": \"German\"\n}\n```");
-assertThat(choices.get(0).getMessage().getRole()).isEqualTo("assistant");
-assertThat(choices.get(0).getFinishReason()).isEqualTo("stop");
-var usage = result.getTokenUsage();
-assertThat(usage.getCompletionTokens()).isEqualTo(28);
-assertThat(usage.getPromptTokens()).isEqualTo(29);
-assertThat(usage.getTotalTokens()).isEqualTo(57);
-var orchestrationResult = (LLMModuleResultSynchronous) response.getOrchestrationResult();
-assertThat(orchestrationResult.getId()).isEqualTo("chatcmpl-AzmS9fd4aGRUdEVsQufpFXSVStfck");
-assertThat(orchestrationResult.getObject()).isEqualTo("chat.completion");
-assertThat(orchestrationResult.getCreated()).isEqualTo(1739287625);
-assertThat(orchestrationResult.getModel()).isEqualTo("gpt-4o-mini-2024-07-18");
-choices = orchestrationResult.getChoices();
-assertThat(choices.get(0).getIndex()).isZero();
+    assertThat(choices.get(0).getMessage().getRole()).isEqualTo("assistant");
+    assertThat(choices.get(0).getFinishReason()).isEqualTo("stop");
+    var usage = result.getTokenUsage();
+    assertThat(usage.getCompletionTokens()).isEqualTo(28);
+    assertThat(usage.getPromptTokens()).isEqualTo(29);
+    assertThat(usage.getTotalTokens()).isEqualTo(57);
+    var orchestrationResult = (LLMModuleResultSynchronous) response.getOrchestrationResult();
+    assertThat(orchestrationResult.getId()).isEqualTo("chatcmpl-AzmS9fd4aGRUdEVsQufpFXSVStfck");
+    assertThat(orchestrationResult.getObject()).isEqualTo("chat.completion");
+    assertThat(orchestrationResult.getCreated()).isEqualTo(1739287625);
+    assertThat(orchestrationResult.getModel()).isEqualTo("gpt-4o-mini-2024-07-18");
+    choices = orchestrationResult.getChoices();
+    assertThat(choices.get(0).getIndex()).isZero();
     assertThat(choices.get(0).getMessage().getContent())
         .isEqualTo(
             "```json\n{\n  \"word\": \"apple\",\n  \"translation\": \"Apfel\",\n  \"language\": \"German\"\n}\n```");
-assertThat(choices.get(0).getMessage().getRole()).isEqualTo("assistant");
-assertThat(choices.get(0).getFinishReason()).isEqualTo("stop");
-usage = result.getTokenUsage();
-assertThat(usage.getCompletionTokens()).isEqualTo(28);
-assertThat(usage.getPromptTokens()).isEqualTo(29);
-assertThat(usage.getTotalTokens()).isEqualTo(57);
+    assertThat(choices.get(0).getMessage().getRole()).isEqualTo("assistant");
+    assertThat(choices.get(0).getFinishReason()).isEqualTo("stop");
+    usage = result.getTokenUsage();
+    assertThat(usage.getCompletionTokens()).isEqualTo(28);
+    assertThat(usage.getPromptTokens()).isEqualTo(29);
+    assertThat(usage.getTotalTokens()).isEqualTo(57);
 
     // verify that null fields are absent from the sent request
     try (var requestInputStream = fileLoader.apply("responseFormatTextRequest.json")) {

--- a/orchestration/src/test/resources/__files/jsonObjectResponse.json
+++ b/orchestration/src/test/resources/__files/jsonObjectResponse.json
@@ -1,0 +1,59 @@
+{
+  "request_id": "f353a729-3391-4cec-bbf9-7ab39d34ebc1",
+  "module_results": {
+    "templating": [
+      {
+        "role": "user",
+        "content": "What is 'apple' in German?"
+      },
+      {
+        "role": "system",
+        "content": "You are a language translator. Answer using the following JSON format: {\"language\": ..., \"translation\": ...}"
+      }
+    ],
+    "llm": {
+      "id": "chatcmpl-Azm2iclgMiLcQHP3cGQANArkxoiGx",
+      "object": "chat.completion",
+      "created": 1739286048,
+      "model": "gpt-4o-mini-2024-07-18",
+      "system_fingerprint": "fp_f3927aa00d",
+      "choices": [
+        {
+          "index": 0,
+          "message": {
+            "role": "assistant",
+            "content": "{\"language\": \"German\", \"translation\": \"Apfel\"}"
+          },
+          "finish_reason": "stop"
+        }
+      ],
+      "usage": {
+        "completion_tokens": 13,
+        "prompt_tokens": 41,
+        "total_tokens": 54
+      }
+    }
+  },
+  "orchestration_result": {
+    "id": "chatcmpl-Azm2iclgMiLcQHP3cGQANArkxoiGx",
+    "object": "chat.completion",
+    "created": 1739286048,
+    "model": "gpt-4o-mini-2024-07-18",
+    "system_fingerprint": "fp_f3927aa00d",
+    "choices": [
+      {
+        "index": 0,
+        "message": {
+          "role": "assistant",
+          "content": "{\"language\": \"German\", \"translation\": \"Apfel\"}"
+        },
+        "finish_reason": "stop"
+      }
+    ],
+    "usage": {
+      "completion_tokens": 13,
+      "prompt_tokens": 41,
+      "total_tokens": 54
+    }
+  }
+}

--- a/orchestration/src/test/resources/__files/jsonSchemaResponse.json
+++ b/orchestration/src/test/resources/__files/jsonSchemaResponse.json
@@ -1,10 +1,10 @@
 {
-  "request_id": "6bb75be9-6ffa-48b7-857f-acc6a3b6067b",
+  "request_id": "0759f249-a261-4cb7-99d5-ea6eae2c141c",
   "module_results": {
     "templating": [
       {
         "role": "user",
-        "content": "Whats 'Apfel' in German?"
+        "content": "Whats 'apple' in German?"
       },
       {
         "role": "system",
@@ -12,9 +12,9 @@
       }
     ],
     "llm": {
-      "id": "chatcmpl-AzRZVc31my2jV7iKpN6UdTDM2VDD7",
+      "id": "chatcmpl-AzmCw5QZBi6zQkJPQhvsyjW4Fe90c",
       "object": "chat.completion",
-      "created": 1739207357,
+      "created": 1739286682,
       "model": "gpt-4o-mini-2024-07-18",
       "system_fingerprint": "fp_f3927aa00d",
       "choices": [
@@ -22,22 +22,22 @@
           "index": 0,
           "message": {
             "role": "assistant",
-            "content": "{\"translation\":\"Apple\",\"language\":\"English\"}"
+            "content": "{\"translation\":\"Apfel\",\"language\":\"German\"}"
           },
           "finish_reason": "stop"
         }
       ],
       "usage": {
-        "completion_tokens": 9,
-        "prompt_tokens": 69,
+        "completion_tokens": 10,
+        "prompt_tokens": 68,
         "total_tokens": 78
       }
     }
   },
   "orchestration_result": {
-    "id": "chatcmpl-AzRZVc31my2jV7iKpN6UdTDM2VDD7",
+    "id": "chatcmpl-AzmCw5QZBi6zQkJPQhvsyjW4Fe90c",
     "object": "chat.completion",
-    "created": 1739207357,
+    "created": 1739286682,
     "model": "gpt-4o-mini-2024-07-18",
     "system_fingerprint": "fp_f3927aa00d",
     "choices": [
@@ -45,14 +45,14 @@
         "index": 0,
         "message": {
           "role": "assistant",
-          "content": "{\"translation\":\"Apple\",\"language\":\"English\"}"
+          "content": "{\"translation\":\"Apfel\",\"language\":\"German\"}"
         },
         "finish_reason": "stop"
       }
     ],
     "usage": {
-      "completion_tokens": 9,
-      "prompt_tokens": 69,
+      "completion_tokens": 10,
+      "prompt_tokens": 68,
       "total_tokens": 78
     }
   }

--- a/orchestration/src/test/resources/__files/jsonSchemaResponse.json
+++ b/orchestration/src/test/resources/__files/jsonSchemaResponse.json
@@ -1,0 +1,59 @@
+{
+  "request_id": "6bb75be9-6ffa-48b7-857f-acc6a3b6067b",
+  "module_results": {
+    "templating": [
+      {
+        "role": "user",
+        "content": "Whats 'Apfel' in German?"
+      },
+      {
+        "role": "system",
+        "content": "You are a language translator."
+      }
+    ],
+    "llm": {
+      "id": "chatcmpl-AzRZVc31my2jV7iKpN6UdTDM2VDD7",
+      "object": "chat.completion",
+      "created": 1739207357,
+      "model": "gpt-4o-mini-2024-07-18",
+      "system_fingerprint": "fp_f3927aa00d",
+      "choices": [
+        {
+          "index": 0,
+          "message": {
+            "role": "assistant",
+            "content": "{\"translation\":\"Apple\",\"language\":\"English\"}"
+          },
+          "finish_reason": "stop"
+        }
+      ],
+      "usage": {
+        "completion_tokens": 9,
+        "prompt_tokens": 69,
+        "total_tokens": 78
+      }
+    }
+  },
+  "orchestration_result": {
+    "id": "chatcmpl-AzRZVc31my2jV7iKpN6UdTDM2VDD7",
+    "object": "chat.completion",
+    "created": 1739207357,
+    "model": "gpt-4o-mini-2024-07-18",
+    "system_fingerprint": "fp_f3927aa00d",
+    "choices": [
+      {
+        "index": 0,
+        "message": {
+          "role": "assistant",
+          "content": "{\"translation\":\"Apple\",\"language\":\"English\"}"
+        },
+        "finish_reason": "stop"
+      }
+    ],
+    "usage": {
+      "completion_tokens": 9,
+      "prompt_tokens": 69,
+      "total_tokens": 78
+    }
+  }
+}

--- a/orchestration/src/test/resources/__files/responseFormatTextResponse.json
+++ b/orchestration/src/test/resources/__files/responseFormatTextResponse.json
@@ -1,0 +1,59 @@
+{
+  "request_id": "2fe5cbeb-4cdc-4a62-8d0b-29bbd8acde07",
+  "module_results": {
+    "templating": [
+      {
+        "role": "user",
+        "content": "What is 'apple' in German?"
+      },
+      {
+        "role": "system",
+        "content": "You are a language translator. Answer using JSON."
+      }
+    ],
+    "llm": {
+      "id": "chatcmpl-AzmS9fd4aGRUdEVsQufpFXSVStfck",
+      "object": "chat.completion",
+      "created": 1739287625,
+      "model": "gpt-4o-mini-2024-07-18",
+      "system_fingerprint": "fp_f3927aa00d",
+      "choices": [
+        {
+          "index": 0,
+          "message": {
+            "role": "assistant",
+            "content": "```json\n{\n  \"word\": \"apple\",\n  \"translation\": \"Apfel\",\n  \"language\": \"German\"\n}\n```"
+          },
+          "finish_reason": "stop"
+        }
+      ],
+      "usage": {
+        "completion_tokens": 28,
+        "prompt_tokens": 29,
+        "total_tokens": 57
+      }
+    }
+  },
+  "orchestration_result": {
+    "id": "chatcmpl-AzmS9fd4aGRUdEVsQufpFXSVStfck",
+    "object": "chat.completion",
+    "created": 1739287625,
+    "model": "gpt-4o-mini-2024-07-18",
+    "system_fingerprint": "fp_f3927aa00d",
+    "choices": [
+      {
+        "index": 0,
+        "message": {
+          "role": "assistant",
+          "content": "```json\n{\n  \"word\": \"apple\",\n  \"translation\": \"Apfel\",\n  \"language\": \"German\"\n}\n```"
+        },
+        "finish_reason": "stop"
+      }
+    ],
+    "usage": {
+      "completion_tokens": 28,
+      "prompt_tokens": 29,
+      "total_tokens": 57
+    }
+  }
+}

--- a/orchestration/src/test/resources/jsonObjectRequest.json
+++ b/orchestration/src/test/resources/jsonObjectRequest.json
@@ -1,0 +1,28 @@
+{
+  "orchestration_config" : {
+    "module_configurations" : {
+      "llm_module_config" : {
+        "model_name" : "gpt-4o-mini",
+        "model_params" : { },
+        "model_version" : "latest"
+      },
+      "templating_module_config" : {
+        "template" : [ {
+          "role" : "user",
+          "content" : "What is 'apple' in German?"
+        }, {
+          "role" : "system",
+          "content" : "You are a language translator. Answer using the following JSON format: {\"language\": ..., \"translation\": ...}"
+        } ],
+        "defaults" : { },
+        "response_format" : {
+          "type" : "json_object"
+        },
+        "tools" : [ ]
+      }
+    },
+    "stream" : false
+  },
+  "input_params" : { },
+  "messages_history" : [ ]
+}

--- a/orchestration/src/test/resources/jsonSchemaRequest.json
+++ b/orchestration/src/test/resources/jsonSchemaRequest.json
@@ -1,0 +1,49 @@
+{
+  "orchestration_config": {
+    "module_configurations": {
+      "templating_module_config": {
+        "template": [
+          {
+            "role": "user",
+            "content": "{{?input}}"
+          }
+        ],
+        "defaults" : { },
+        "tools" : [ ]
+      },
+      "response_format": {
+        "type": "json_schema",
+        "json_schema": {
+          "name": "translation_response",
+          "strict": true,
+          "schema": {
+            "type": "object",
+            "properties": {
+              "language": {"type": "string"},
+              "translation": {"type": "string"}
+            },
+            "required": ["language", "translation"],
+            "additionalProperties": false
+          }
+        }
+      },
+      "llm_module_config": {
+        "model_name": "gpt-35-turbo-16k",
+        "model_params": {
+          "max_tokens": 50,
+          "temperature": 0.1,
+          "frequency_penalty": 0,
+          "presence_penalty": 0,
+          "top_p" : 1,
+          "n" : 1
+        },
+        "model_version": "latest"
+      }
+    },
+    "stream": false
+  },
+  "input_params": {
+    "input": "Reply with 'Orchestration Service is working!' in German"
+  },
+  "messages_history": []
+}

--- a/orchestration/src/test/resources/jsonSchemaRequest.json
+++ b/orchestration/src/test/resources/jsonSchemaRequest.json
@@ -1,49 +1,46 @@
 {
-  "orchestration_config": {
-    "module_configurations": {
-      "templating_module_config": {
-        "template": [
-          {
-            "role": "user",
-            "content": "{{?input}}"
-          }
-        ],
+  "orchestration_config" : {
+    "module_configurations" : {
+      "llm_module_config" : {
+        "model_name" : "gpt-4o-mini",
+        "model_params" : { },
+        "model_version" : "latest"
+      },
+      "templating_module_config" : {
+        "template" : [ {
+          "role" : "user",
+          "content" : "Whats 'Apfel' in German?"
+        }, {
+          "role" : "system",
+          "content" : "You are a language translator."
+        } ],
         "defaults" : { },
-        "tools" : [ ]
-      },
-      "response_format": {
-        "type": "json_schema",
-        "json_schema": {
-          "name": "translation_response",
-          "strict": true,
-          "schema": {
-            "type": "object",
-            "properties": {
-              "language": {"type": "string"},
-              "translation": {"type": "string"}
+        "response_format" : {
+          "type" : "json_schema",
+          "json_schema" : {
+            "description" : "Output schema for language translation.",
+            "name" : "translation_response",
+            "schema" : {
+              "type" : "object",
+              "properties" : {
+                "translation" : {
+                  "type" : "string"
+                },
+                "language" : {
+                  "type" : "string"
+                }
+              },
+              "additionalProperties" : false,
+              "required" : [ "language", "translation" ]
             },
-            "required": ["language", "translation"],
-            "additionalProperties": false
+            "strict" : true
           }
-        }
-      },
-      "llm_module_config": {
-        "model_name": "gpt-35-turbo-16k",
-        "model_params": {
-          "max_tokens": 50,
-          "temperature": 0.1,
-          "frequency_penalty": 0,
-          "presence_penalty": 0,
-          "top_p" : 1,
-          "n" : 1
         },
-        "model_version": "latest"
+        "tools" : [ ]
       }
     },
-    "stream": false
+    "stream" : false
   },
-  "input_params": {
-    "input": "Reply with 'Orchestration Service is working!' in German"
-  },
-  "messages_history": []
+  "input_params" : { },
+  "messages_history" : [ ]
 }

--- a/orchestration/src/test/resources/jsonSchemaRequest.json
+++ b/orchestration/src/test/resources/jsonSchemaRequest.json
@@ -9,7 +9,7 @@
       "templating_module_config" : {
         "template" : [ {
           "role" : "user",
-          "content" : "Whats 'Apfel' in German?"
+          "content" : "Whats 'apple' in German?"
         }, {
           "role" : "system",
           "content" : "You are a language translator."

--- a/orchestration/src/test/resources/responseFormatTextRequest.json
+++ b/orchestration/src/test/resources/responseFormatTextRequest.json
@@ -1,0 +1,28 @@
+{
+  "orchestration_config" : {
+    "module_configurations" : {
+      "llm_module_config" : {
+        "model_name" : "gpt-4o-mini",
+        "model_params" : { },
+        "model_version" : "latest"
+      },
+      "templating_module_config" : {
+        "template" : [ {
+          "role" : "user",
+          "content" : "What is 'apple' in German?"
+        }, {
+          "role" : "system",
+          "content" : "You are a language translator. Answer using JSON."
+        } ],
+        "defaults" : { },
+        "response_format" : {
+          "type" : "text"
+        },
+        "tools" : [ ]
+      }
+    },
+    "stream" : false
+  },
+  "input_params" : { },
+  "messages_history" : [ ]
+}

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/OrchestrationController.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/OrchestrationController.java
@@ -214,4 +214,26 @@ class OrchestrationController {
     }
     return response.getContent();
   }
+
+  @GetMapping("/responseFormatJsonSchema")
+  @Nonnull
+  Object responseFormatJsonSchema(
+      @RequestParam(value = "format", required = false) final String format) {
+    final var response = service.responseFormatJsonSchema("apple");
+    if ("json".equals(format)) {
+      return response;
+    }
+    return response.getContent();
+  }
+
+  @GetMapping("/responseFormatJsonObject")
+  @Nonnull
+  Object responseFormatJsonObject(
+      @RequestParam(value = "format", required = false) final String format) {
+    final var response = service.responseFormatJsonObject("apple");
+    if ("json".equals(format)) {
+      return response;
+    }
+    return response.getContent();
+  }
 }

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OrchestrationService.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OrchestrationService.java
@@ -126,7 +126,7 @@ public class OrchestrationService {
    * @return the assistant response object
    */
   @Nonnull
-  public OrchestrationChatResponse responseFormat(@Nonnull final String word) {
+  public OrchestrationChatResponse jsonSchema(@Nonnull final String word) {
     final var llmWithImageSupportConfig =
         new OrchestrationModuleConfig().withLlmConfig(GPT_4O_MINI);
 

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OrchestrationService.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OrchestrationService.java
@@ -22,8 +22,10 @@ import com.sap.ai.sdk.orchestration.model.DataRepositoryType;
 import com.sap.ai.sdk.orchestration.model.DocumentGroundingFilter;
 import com.sap.ai.sdk.orchestration.model.GroundingFilterSearchConfiguration;
 import com.sap.ai.sdk.orchestration.model.LlamaGuard38b;
+import com.sap.ai.sdk.orchestration.model.ResponseFormatJsonObject;
 import com.sap.ai.sdk.orchestration.model.ResponseFormatJsonSchema;
 import com.sap.ai.sdk.orchestration.model.ResponseFormatJsonSchemaJsonSchema;
+import com.sap.ai.sdk.orchestration.model.ResponseFormatText;
 import com.sap.ai.sdk.orchestration.model.SearchDocumentKeyValueListPair;
 import com.sap.ai.sdk.orchestration.model.SearchSelectOptionEnum;
 import com.sap.ai.sdk.orchestration.model.Template;
@@ -114,52 +116,6 @@ public class OrchestrationService {
 
     val inputParams = Map.of("language", language);
     val prompt = new OrchestrationPrompt(inputParams);
-
-    return client.chatCompletion(prompt, configWithTemplate);
-  }
-
-  /**
-   * Chat request to OpenAI through the Orchestration service with a template.
-   *
-   * @link <a href="https://help.sap.com/docs/sap-ai-core/sap-ai-core-service-guide/templating">SAP
-   *     AI Core: Orchestration - Templating</a>
-   * @return the assistant response object
-   */
-  @Nonnull
-  public OrchestrationChatResponse jsonSchema(@Nonnull final String word) {
-    final var llmWithImageSupportConfig =
-        new OrchestrationModuleConfig().withLlmConfig(GPT_4O_MINI);
-
-    val template = Message.user("Whats '%s' in German?".formatted(word));
-    var schema =
-        Map.of(
-            "type",
-            "object",
-            "properties",
-            Map.of(
-                "language", Map.of("type", "string"),
-                "translation", Map.of("type", "string")),
-            "required",
-            List.of("language", "translation"),
-            "additionalProperties",
-            false);
-
-    val templatingConfig =
-        Template.create()
-            .template(List.of(template.createChatMessage()))
-            .responseFormat(
-                ResponseFormatJsonSchema.create()
-                    .type(ResponseFormatJsonSchema.TypeEnum.JSON_SCHEMA)
-                    .jsonSchema(
-                        ResponseFormatJsonSchemaJsonSchema.create()
-                            .name("translation_response")
-                            .schema(schema)
-                            .strict(true)
-                            .description("Output schema for language translation.")));
-    val configWithTemplate = llmWithImageSupportConfig.withTemplateConfig(templatingConfig);
-    //    log.info("Template config: {}", templatingConfig);
-
-    val prompt = new OrchestrationPrompt(Message.system("You are a language translator."));
 
     return client.chatCompletion(prompt, configWithTemplate);
   }
@@ -381,5 +337,111 @@ public class OrchestrationService {
     val configWithGrounding = config.withGrounding(groundingConfig);
 
     return client.chatCompletion(prompt, configWithGrounding);
+  }
+
+  /**
+   * Chat request to OpenAI through the Orchestration service using response format with JSON
+   * schema.
+   *
+   * @link <a
+   *     href="https://help.sap.com/docs/sap-ai-core/sap-ai-core-service-guide/structured-output">SAP
+   *     AI Core: Orchestration - Templating</a>
+   * @return the assistant response object
+   */
+  @Nonnull
+  public OrchestrationChatResponse responseFormatJsonSchema(@Nonnull final String word) {
+    final var llmWithImageSupportConfig =
+        new OrchestrationModuleConfig().withLlmConfig(GPT_4O_MINI);
+
+    val template = Message.user("Whats '%s' in German?".formatted(word));
+    var schema =
+        Map.of(
+            "type",
+            "object",
+            "properties",
+            Map.of(
+                "language", Map.of("type", "string"),
+                "translation", Map.of("type", "string")),
+            "required",
+            List.of("language", "translation"),
+            "additionalProperties",
+            false);
+
+    val templatingConfig =
+        Template.create()
+            .template(List.of(template.createChatMessage()))
+            .responseFormat(
+                ResponseFormatJsonSchema.create()
+                    .type(ResponseFormatJsonSchema.TypeEnum.JSON_SCHEMA)
+                    .jsonSchema(
+                        ResponseFormatJsonSchemaJsonSchema.create()
+                            .name("translation_response")
+                            .schema(schema)
+                            .strict(true)
+                            .description("Output schema for language translation.")));
+    val configWithTemplate = llmWithImageSupportConfig.withTemplateConfig(templatingConfig);
+
+    val prompt = new OrchestrationPrompt(Message.system("You are a language translator."));
+
+    return client.chatCompletion(prompt, configWithTemplate);
+  }
+
+  /**
+   * Chat request to OpenAI through the Orchestration service using the response format option 'JSON
+   * object'.
+   *
+   * @link <a
+   *     href="https://help.sap.com/docs/sap-ai-core/sap-ai-core-service-guide/structured-output">SAP
+   *     AI Core: Orchestration - Templating</a>
+   * @return the assistant response object
+   */
+  @Nonnull
+  public OrchestrationChatResponse responseFormatJsonObject(@Nonnull final String word) {
+    final var llmWithImageSupportConfig =
+        new OrchestrationModuleConfig().withLlmConfig(GPT_4O_MINI);
+
+    val template = Message.user("What is '%s' in German?".formatted(word));
+    val templatingConfig =
+        Template.create()
+            .template(List.of(template.createChatMessage()))
+            .responseFormat(
+                ResponseFormatJsonObject.create()
+                    .type(ResponseFormatJsonObject.TypeEnum.JSON_OBJECT));
+    val configWithTemplate = llmWithImageSupportConfig.withTemplateConfig(templatingConfig);
+
+    val prompt =
+        new OrchestrationPrompt(
+            Message.system(
+                "You are a language translator. Answer using the following JSON format: {\"language\": ..., \"translation\": ...}"));
+
+    return client.chatCompletion(prompt, configWithTemplate);
+  }
+
+  /**
+   * Chat request to OpenAI through the Orchestration service using the response format option
+   * 'text'.
+   *
+   * @link <a
+   *     href="https://help.sap.com/docs/sap-ai-core/sap-ai-core-service-guide/structured-output">SAP
+   *     AI Core: Orchestration - Templating</a>
+   * @return the assistant response object
+   */
+  @Nonnull
+  public OrchestrationChatResponse responseFormatText(@Nonnull final String word) {
+    final var llmWithImageSupportConfig =
+        new OrchestrationModuleConfig().withLlmConfig(GPT_4O_MINI);
+
+    val template = Message.user("Whats '%s' in German?".formatted(word));
+    val templatingConfig =
+        Template.create()
+            .template(List.of(template.createChatMessage()))
+            .responseFormat(ResponseFormatText.create().type(ResponseFormatText.TypeEnum.TEXT));
+    val configWithTemplate = llmWithImageSupportConfig.withTemplateConfig(templatingConfig);
+
+    val prompt =
+        new OrchestrationPrompt(
+            Message.system("You are a language translator. Answer using JSON."));
+
+    return client.chatCompletion(prompt, configWithTemplate);
   }
 }

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OrchestrationService.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OrchestrationService.java
@@ -423,7 +423,7 @@ public class OrchestrationService {
    *
    * @link <a
    *     href="https://help.sap.com/docs/sap-ai-core/sap-ai-core-service-guide/structured-output">SAP
-   *     AI Core: Orchestration - Templating</a>
+   *     AI Core: Orchestration - Structured Output</a>
    * @return the assistant response object
    */
   @Nonnull

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OrchestrationService.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OrchestrationService.java
@@ -345,7 +345,7 @@ public class OrchestrationService {
    *
    * @link <a
    *     href="https://help.sap.com/docs/sap-ai-core/sap-ai-core-service-guide/structured-output">SAP
-   *     AI Core: Orchestration - Templating</a>
+   *     AI Core: Orchestration - Structured Output</a>
    * @return the assistant response object
    */
   @Nonnull

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OrchestrationService.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OrchestrationService.java
@@ -392,7 +392,7 @@ public class OrchestrationService {
    *
    * @link <a
    *     href="https://help.sap.com/docs/sap-ai-core/sap-ai-core-service-guide/structured-output">SAP
-   *     AI Core: Orchestration - Templating</a>
+   *     AI Core: Orchestration - Structured Output</a>
    * @return the assistant response object
    */
   @Nonnull

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OrchestrationService.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OrchestrationService.java
@@ -354,7 +354,7 @@ public class OrchestrationService {
         new OrchestrationModuleConfig().withLlmConfig(GPT_4O_MINI);
 
     val template = Message.user("Whats '%s' in German?".formatted(word));
-    var schema =
+    val schema =
         Map.of(
             "type",
             "object",

--- a/sample-code/spring-app/src/main/resources/static/index.html
+++ b/sample-code/spring-app/src/main/resources/static/index.html
@@ -372,6 +372,28 @@
                                     </div>
                                 </div>
                             </li>
+                            <li class="list-group-item">
+                                <div class="info-tooltip">
+                                    <button type="submit" formaction="/orchestration/responseFormatJsonSchema"
+                                            class="link-offset-2-hover link-underline link-underline-opacity-0 link-underline-opacity-75-hover endpoint">
+                                        <code>/orchestration/responseFormatJsonSchema</code>
+                                    </button>
+                                    <div class="tooltip-content">
+                                        Chat request to an LLM through the Orchestration service where the output will adhere to a given JSON schema.
+                                    </div>
+                                </div>
+                            </li>
+                            <li class="list-group-item">
+                                <div class="info-tooltip">
+                                    <button type="submit" formaction="/orchestration/responseFormatJsonObject"
+                                            class="link-offset-2-hover link-underline link-underline-opacity-0 link-underline-opacity-75-hover endpoint">
+                                        <code>/orchestration/responseFormatJsonObject</code>
+                                    </button>
+                                    <div class="tooltip-content">
+                                        Chat request to an LLM through the Orchestration service where the output will be a JSON object.
+                                    </div>
+                                </div>
+                            </li>
                         </ul>
                     </div>
                 </div>

--- a/sample-code/spring-app/src/main/resources/static/index.html
+++ b/sample-code/spring-app/src/main/resources/static/index.html
@@ -390,7 +390,7 @@
                                         <code>/orchestration/responseFormatJsonObject</code>
                                     </button>
                                     <div class="tooltip-content">
-                                        Chat request to an LLM through the Orchestration service where the output will be a JSON object.
+                                        Chat request to an LLM through the Orchestration service where the output will consist of valid JSON.
                                     </div>
                                 </div>
                             </li>

--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
@@ -295,4 +295,15 @@ class OrchestrationTest {
     final var choices = ((LLMModuleResultSynchronous) result.getOrchestrationResult()).getChoices();
     assertThat(choices.get(0).getMessage().getContent()).isNotEmpty();
   }
+
+  @Test
+  void testResponseFormat() {
+    final var result =
+        service.responseFormat("Apple")
+            .getOriginalResponse();
+    final var choices = ((LLMModuleResultSynchronous) result.getOrchestrationResult()).getChoices();
+    assertThat(choices.get(0).getMessage().getContent()).isNotEmpty();
+    assertThat(choices.get(0).getMessage().getContent()).contains("\"language\":\"German\"");
+    assertThat(choices.get(0).getMessage().getContent()).contains("\"translation\":\"Apfel\"");
+  }
 }

--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
@@ -297,13 +297,31 @@ class OrchestrationTest {
   }
 
   @Test
-  void testResponseFormat() {
+  void testResponseFormatJsonSchema() {
     final var result =
-        service.jsonSchema("Apple")
+        service.responseFormatJsonSchema("Apple")
             .getOriginalResponse();
     final var choices = ((LLMModuleResultSynchronous) result.getOrchestrationResult()).getChoices();
     assertThat(choices.get(0).getMessage().getContent()).isNotEmpty();
     assertThat(choices.get(0).getMessage().getContent()).contains("\"language\":\"German\"");
     assertThat(choices.get(0).getMessage().getContent()).contains("\"translation\":\"Apfel\"");
+  }
+
+  @Test
+  void testResponseFormatJsonObject() {
+    final var result =
+        service.responseFormatJsonObject("Apple")
+            .getOriginalResponse();
+    final var choices = ((LLMModuleResultSynchronous) result.getOrchestrationResult()).getChoices();
+    assertThat(choices.get(0).getMessage().getContent()).isNotEmpty();
+  }
+
+  @Test
+  void testResponseFormatText() {
+    final var result =
+        service.responseFormatText("Apple")
+            .getOriginalResponse();
+    final var choices = ((LLMModuleResultSynchronous) result.getOrchestrationResult()).getChoices();
+    assertThat(choices.get(0).getMessage().getContent()).isNotEmpty();
   }
 }

--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
@@ -299,7 +299,7 @@ class OrchestrationTest {
   @Test
   void testResponseFormatJsonSchema() {
     final var result =
-        service.responseFormatJsonSchema("Apple")
+        service.responseFormatJsonSchema("apple")
             .getOriginalResponse();
     final var choices = ((LLMModuleResultSynchronous) result.getOrchestrationResult()).getChoices();
     assertThat(choices.get(0).getMessage().getContent()).isNotEmpty();
@@ -310,7 +310,7 @@ class OrchestrationTest {
   @Test
   void testResponseFormatJsonObject() {
     final var result =
-        service.responseFormatJsonObject("Apple")
+        service.responseFormatJsonObject("apple")
             .getOriginalResponse();
     final var choices = ((LLMModuleResultSynchronous) result.getOrchestrationResult()).getChoices();
     assertThat(choices.get(0).getMessage().getContent()).isNotEmpty();
@@ -319,7 +319,7 @@ class OrchestrationTest {
   @Test
   void testResponseFormatText() {
     final var result =
-        service.responseFormatText("Apple")
+        service.responseFormatText("apple")
             .getOriginalResponse();
     final var choices = ((LLMModuleResultSynchronous) result.getOrchestrationResult()).getChoices();
     assertThat(choices.get(0).getMessage().getContent()).isNotEmpty();

--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
@@ -298,9 +298,7 @@ class OrchestrationTest {
 
   @Test
   void testResponseFormatJsonSchema() {
-    final var result =
-        service.responseFormatJsonSchema("apple")
-            .getOriginalResponse();
+    final var result = service.responseFormatJsonSchema("apple").getOriginalResponse();
     final var choices = ((LLMModuleResultSynchronous) result.getOrchestrationResult()).getChoices();
     assertThat(choices.get(0).getMessage().getContent()).isNotEmpty();
     assertThat(choices.get(0).getMessage().getContent()).contains("\"language\":\"German\"");
@@ -309,18 +307,14 @@ class OrchestrationTest {
 
   @Test
   void testResponseFormatJsonObject() {
-    final var result =
-        service.responseFormatJsonObject("apple")
-            .getOriginalResponse();
+    final var result = service.responseFormatJsonObject("apple").getOriginalResponse();
     final var choices = ((LLMModuleResultSynchronous) result.getOrchestrationResult()).getChoices();
     assertThat(choices.get(0).getMessage().getContent()).isNotEmpty();
   }
 
   @Test
   void testResponseFormatText() {
-    final var result =
-        service.responseFormatText("apple")
-            .getOriginalResponse();
+    final var result = service.responseFormatText("apple").getOriginalResponse();
     final var choices = ((LLMModuleResultSynchronous) result.getOrchestrationResult()).getChoices();
     assertThat(choices.get(0).getMessage().getContent()).isNotEmpty();
   }

--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
@@ -299,7 +299,7 @@ class OrchestrationTest {
   @Test
   void testResponseFormat() {
     final var result =
-        service.responseFormat("Apple")
+        service.jsonSchema("Apple")
             .getOriginalResponse();
     final var choices = ((LLMModuleResultSynchronous) result.getOrchestrationResult()).getChoices();
     assertThat(choices.get(0).getMessage().getContent()).isNotEmpty();


### PR DESCRIPTION
## Context

AI/ai-sdk-java-backlog#162.

This PR enables and tests using the `response_format` option for chat completion. There are 3 options:
- `JSON_OBJECT` tells the AI to respond in JSON format (without giving the explicit structure)
- `JSON_SCHEMA` tells the AI to respond with JSON that adheres to a given JSON schema
- `TEXT` tells the AI to respond in plain text

Note, that this PR does not cover convenience API. Convenience API for JSON schema is split into a new issue AI/ai-sdk-java-backlog#195.

### Feature scope:
 
- [x] Enable the use of `response_format`
- [x] document usage in sample app and docs
- [x] add unit and e2e tests

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Aligned changes with the JavaScript SDK~
- [x] Documentation updated
- [x] Release notes updated
