### PR TITLE
chore: Use absolute URL in release notes

### DIFF
--- a/docs/release-notes/release-notes-0-to-14.md
+++ b/docs/release-notes/release-notes-0-to-14.md
@@ -11,8 +11,8 @@
 ### ✨ New Functionality
 
 - New Orchestration features:
-  - [Spring AI integration](../guides/SPRING_AI_INTEGRATION.md)
-  - [Add Grounding configuration convenience](../guides/ORCHESTRATION_CHAT_COMPLETION.md#grounding)
+  - [Spring AI integration](https://github.com/SAP/ai-sdk-java/tree/main/docs/guides/SPRING_AI_INTEGRATION.md)
+  - [Add Grounding configuration convenience](https://github.com/SAP/ai-sdk-java/tree/main/docs/guides/ORCHESTRATION_CHAT_COMPLETION.md#grounding)
   - Images are now supported as input in newly introduced `MultiChatMessage`.
   - `MultiChatMessage` also allows for multiple content items (text or image) in one object.
   - Grounding input can be masked with `DPIConfig`.

--- a/docs/release-notes/release_notes.md
+++ b/docs/release-notes/release_notes.md
@@ -14,8 +14,8 @@
 
 - Upgrade to release 2502a of AI Core.
 - Orchestration:
-  - [Add `LlamaGuardFilter`](../guides/ORCHESTRATION_CHAT_COMPLETION.md#chat-completion-filter).
-  - [Convenient methods to create messages containing images and multiple text inputs](../guides/ORCHESTRATION_CHAT_COMPLETION.md#add-images-and-multiple-text-inputs-to-a-message)
+  - [Add `LlamaGuardFilter`](https://github.com/SAP/ai-sdk-java/tree/main/docs/guides/ORCHESTRATION_CHAT_COMPLETION.md#chat-completion-filter).
+  - [Convenient methods to create messages containing images and multiple text inputs](https://github.com/SAP/ai-sdk-java/tree/main/docs/guides/ORCHESTRATION_CHAT_COMPLETION.md#add-images-and-multiple-text-inputs-to-a-message)
 
 ### 📈 Improvements
 


### PR DESCRIPTION
Switch to absolute URL for release notes, which will be used somewhere else like GH release.