### PR TITLE
fix: [Orchestration] Hide constructors for System- and UserMessage

### DIFF
--- a/docs/release-notes/release_notes.md
+++ b/docs/release-notes/release_notes.md
@@ -8,7 +8,7 @@
 
 ### 🔧 Compatibility Notes
 
--
+- The constructors `UserMessage(MessageContent)` and `SystemMessage(MessageContent)` are removed. Use `Message.user(String)`, `Message.user(ImageItem)`, or `Message.system(String)` instead.
 
 ### ✨ New Functionality
 

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/SystemMessage.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/SystemMessage.java
@@ -4,7 +4,9 @@ import com.google.common.annotations.Beta;
 import java.util.LinkedList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import lombok.experimental.Accessors;
 import lombok.experimental.Tolerate;
@@ -12,6 +14,7 @@ import lombok.experimental.Tolerate;
 /** Represents a chat message as 'system' to the orchestration service. */
 @Value
 @Accessors(fluent = true)
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public class SystemMessage implements Message {
 
   /** The role of the assistant. */

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/UserMessage.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/UserMessage.java
@@ -4,7 +4,9 @@ import com.google.common.annotations.Beta;
 import java.util.LinkedList;
 import java.util.List;
 import javax.annotation.Nonnull;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import lombok.experimental.Accessors;
 import lombok.experimental.Tolerate;
@@ -12,6 +14,7 @@ import lombok.experimental.Tolerate;
 /** Represents a chat message as 'user' to the orchestration service. */
 @Value
 @Accessors(fluent = true)
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public class UserMessage implements Message {
 
   /** The role of the assistant. */


### PR DESCRIPTION
## Context

Before, the constructors for `SystemMessage` and `UserMessage` using a `MessageContent` object where public unintentionally. This PR hides them.

### Feature scope:
 
- [x] Make both constructors package private

## Definition of Done

- [x] Functionality scope stated & covered
- [ ] ~Tests cover the scope above~
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Aligned changes with the JavaScript SDK~
- [ ] ~Documentation updated~
- [x] Release notes updated
