### PR TITLE
fix: [DevOps] Dependency vulnerability scan to 12.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -710,7 +710,7 @@ https://gitbox.apache.org/repos/asf?p=maven-pmd-plugin.git;a=blob_plain;f=src/ma
       <plugin>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-maven</artifactId>
-        <version>12.0.0</version>
+        <version>12.1.0</version>
         <configuration>
           <connectionTimeout>60000</connectionTimeout>
           <nvdMaxRetryCount>20</nvdMaxRetryCount>

--- a/pom.xml
+++ b/pom.xml
@@ -710,7 +710,7 @@ https://gitbox.apache.org/repos/asf?p=maven-pmd-plugin.git;a=blob_plain;f=src/ma
       <plugin>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-maven</artifactId>
-        <version>11.1.1</version>
+        <version>12.0.0</version>
         <configuration>
           <connectionTimeout>60000</connectionTimeout>
           <nvdMaxRetryCount>20</nvdMaxRetryCount>


### PR DESCRIPTION
## Context

The dependency vulnerability scan failed because of a bug. It was [fixed in 12.1.0](https://github.com/jeremylong/DependencyCheck/blob/main/CHANGELOG.md#version-1210-2025-02-16)

[Successful run](https://github.com/SAP/ai-sdk-java/actions/runs/13365340902)