### PR TITLE
chore: [DevOps] enforce Spring AI optional

### DIFF
--- a/orchestration/pom.xml
+++ b/orchestration/pom.xml
@@ -132,6 +132,11 @@
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.javaparser</groupId>
+      <artifactId>javaparser-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/orchestration/src/test/java/com/sap/ai/sdk/orchestration/spring/ImportCheckTest.java
+++ b/orchestration/src/test/java/com/sap/ai/sdk/orchestration/spring/ImportCheckTest.java
@@ -1,0 +1,63 @@
+package com.sap.ai.sdk.orchestration.spring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.javaparser.JavaParser;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.val;
+import org.junit.jupiter.api.Test;
+
+public class ImportCheckTest {
+
+  @Test
+  public void testSpringAIOptional() throws IOException {
+    String springAI = "org.springframework.ai";
+    checkImports("com/sap/ai/sdk/orchestration", springAI, false);
+    checkImports("com/sap/ai/sdk/orchestration/spring", springAI, true);
+  }
+
+  private void checkImports(String packagePath, String imports, boolean shouldContain)
+      throws IOException {
+    List<File> javaFiles = getJavaFiles(packagePath);
+
+    boolean hasImport = false;
+    for (File file : javaFiles) {
+      val result = new JavaParser().parse(file).getResult();
+      assertThat(result).isPresent();
+
+      hasImport =
+          hasImport
+              || result.get().getImports().stream()
+                  .anyMatch(importDecl -> importDecl.getNameAsString().startsWith(imports));
+
+      if (!shouldContain) {
+        assertFalse(
+            hasImport, "File " + file.getName() + " contains a prohibited import: " + imports);
+      }
+    }
+
+    if (shouldContain) {
+      assertTrue(hasImport, "Orchestration Spring should contain Spring AI imports");
+    }
+  }
+
+  private List<File> getJavaFiles(String packagePath) throws IOException {
+    Path orchestrationPackage = Paths.get("src/main/java", packagePath);
+    try (Stream<Path> files = Files.list(orchestrationPackage)) {
+      return files
+          .filter(Files::isRegularFile)
+          .map(java.nio.file.Path::toFile)
+          .filter(file -> file.getName().endsWith(".java"))
+          .collect(Collectors.toList());
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -415,7 +415,7 @@
             <configuration>
               <rules>
                 <bannedDependencies>
-                  <message>Spring AI should be optional</message>
+                  <message>Spring AI dependencies should be optional</message>
                   <includes>
                     <include>org.springframework.ai:*</include>
                   </includes>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
     <reactor-core.version>3.6.12</reactor-core.version>
     <dotenv-java.version>3.1.0</dotenv-java.version>
     <mockito.version>5.15.2</mockito.version>
+    <javaparser.version>3.26.3</javaparser.version>
     <!-- conflicts resolution -->
     <micrometer.version>1.14.2</micrometer.version>
     <json.version>20250107</json.version>
@@ -183,6 +184,12 @@
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>${mockito.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.github.javaparser</groupId>
+        <artifactId>javaparser-core</artifactId>
+        <version>${javaparser.version}</version>
         <scope>test</scope>
       </dependency>
       <!-- Modules BoM -->
@@ -396,6 +403,22 @@
                   <excludes>
                     <exclude>junit:junit</exclude>
                   </excludes>
+                </bannedDependencies>
+              </rules>
+            </configuration>
+          </execution>
+          <execution>
+            <id>enforce-spring-ai-optional</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <bannedDependencies>
+                  <message>Spring AI should be optional</message>
+                  <includes>
+                    <include>org.springframework.ai:*</include>
+                  </includes>
                 </bannedDependencies>
               </rules>
             </configuration>


### PR DESCRIPTION
## Context

AI/ai-sdk-java-backlog#180.

Currently, we might by accident use Spring AI within any Orchestration class without noticing.
Using Spring AI within any class not under a .spring package should lead to a compile or test or e2e test failure.

### Feature scope:
 
- [x] Added enforcer rule
- [x] Added unit test

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Aligned changes with the JavaScript SDK~
- [ ] ~Documentation updated~
- [ ] ~Release notes updated~
