### PR TITLE
chore: [DevOps] Update Cloud SDK to 5.17.0

### DIFF
--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiApiError.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiApiError.java
@@ -219,16 +219,36 @@ public class AiApiError
   /**
    * Get the value of an unrecognizable property of this {@link AiApiError} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("AiApiError has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiApiError} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (code != null) declaredFields.put("code", code);
+    if (message != null) declaredFields.put("message", message);
+    if (requestId != null) declaredFields.put("requestId", requestId);
+    if (target != null) declaredFields.put("target", target);
+    if (details != null) declaredFields.put("details", details);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiApiErrorWithId.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiApiErrorWithId.java
@@ -117,16 +117,33 @@ public class AiApiErrorWithId
   /**
    * Get the value of an unrecognizable property of this {@link AiApiErrorWithId} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("AiApiErrorWithId has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiApiErrorWithId} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (error != null) declaredFields.put("error", error);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiArtifact.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiArtifact.java
@@ -546,16 +546,43 @@ public class AiArtifact
   /**
    * Get the value of an unrecognizable property of this {@link AiArtifact} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("AiArtifact has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiArtifact} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (labels != null) declaredFields.put("labels", labels);
+    if (name != null) declaredFields.put("name", name);
+    if (kind != null) declaredFields.put("kind", kind);
+    if (url != null) declaredFields.put("url", url);
+    if (description != null) declaredFields.put("description", description);
+    if (id != null) declaredFields.put("id", id);
+    if (scenarioId != null) declaredFields.put("scenarioId", scenarioId);
+    if (configurationId != null) declaredFields.put("configurationId", configurationId);
+    if (executionId != null) declaredFields.put("executionId", executionId);
+    if (createdAt != null) declaredFields.put("createdAt", createdAt);
+    if (modifiedAt != null) declaredFields.put("modifiedAt", modifiedAt);
+    if (scenario != null) declaredFields.put("scenario", scenario);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiArtifactArgumentBinding.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiArtifactArgumentBinding.java
@@ -118,17 +118,34 @@ public class AiArtifactArgumentBinding
   /**
    * Get the value of an unrecognizable property of this {@link AiArtifactArgumentBinding} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiArtifactArgumentBinding has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiArtifactArgumentBinding} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (key != null) declaredFields.put("key", key);
+    if (artifactId != null) declaredFields.put("artifactId", artifactId);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiArtifactCreationResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiArtifactCreationResponse.java
@@ -153,17 +153,35 @@ public class AiArtifactCreationResponse
    * Get the value of an unrecognizable property of this {@link AiArtifactCreationResponse}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiArtifactCreationResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiArtifactCreationResponse} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (message != null) declaredFields.put("message", message);
+    if (url != null) declaredFields.put("url", url);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiArtifactList.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiArtifactList.java
@@ -135,16 +135,33 @@ public class AiArtifactList
   /**
    * Get the value of an unrecognizable property of this {@link AiArtifactList} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("AiArtifactList has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiArtifactList} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (count != null) declaredFields.put("count", count);
+    if (resources != null) declaredFields.put("resources", resources);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiArtifactPostData.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiArtifactPostData.java
@@ -341,16 +341,37 @@ public class AiArtifactPostData
   /**
    * Get the value of an unrecognizable property of this {@link AiArtifactPostData} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("AiArtifactPostData has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiArtifactPostData} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (labels != null) declaredFields.put("labels", labels);
+    if (name != null) declaredFields.put("name", name);
+    if (kind != null) declaredFields.put("kind", kind);
+    if (url != null) declaredFields.put("url", url);
+    if (description != null) declaredFields.put("description", description);
+    if (scenarioId != null) declaredFields.put("scenarioId", scenarioId);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiConfiguration.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiConfiguration.java
@@ -363,16 +363,40 @@ public class AiConfiguration
   /**
    * Get the value of an unrecognizable property of this {@link AiConfiguration} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("AiConfiguration has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiConfiguration} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (name != null) declaredFields.put("name", name);
+    if (executableId != null) declaredFields.put("executableId", executableId);
+    if (scenarioId != null) declaredFields.put("scenarioId", scenarioId);
+    if (parameterBindings != null) declaredFields.put("parameterBindings", parameterBindings);
+    if (inputArtifactBindings != null)
+      declaredFields.put("inputArtifactBindings", inputArtifactBindings);
+    if (id != null) declaredFields.put("id", id);
+    if (createdAt != null) declaredFields.put("createdAt", createdAt);
+    if (scenario != null) declaredFields.put("scenario", scenario);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiConfigurationBaseData.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiConfigurationBaseData.java
@@ -263,17 +263,38 @@ public class AiConfigurationBaseData
   /**
    * Get the value of an unrecognizable property of this {@link AiConfigurationBaseData} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiConfigurationBaseData has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiConfigurationBaseData} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (name != null) declaredFields.put("name", name);
+    if (executableId != null) declaredFields.put("executableId", executableId);
+    if (scenarioId != null) declaredFields.put("scenarioId", scenarioId);
+    if (parameterBindings != null) declaredFields.put("parameterBindings", parameterBindings);
+    if (inputArtifactBindings != null)
+      declaredFields.put("inputArtifactBindings", inputArtifactBindings);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiConfigurationCreationResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiConfigurationCreationResponse.java
@@ -120,17 +120,34 @@ public class AiConfigurationCreationResponse
    * Get the value of an unrecognizable property of this {@link AiConfigurationCreationResponse}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiConfigurationCreationResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiConfigurationCreationResponse} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (message != null) declaredFields.put("message", message);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiConfigurationList.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiConfigurationList.java
@@ -135,17 +135,34 @@ public class AiConfigurationList
   /**
    * Get the value of an unrecognizable property of this {@link AiConfigurationList} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiConfigurationList has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiConfigurationList} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (count != null) declaredFields.put("count", count);
+    if (resources != null) declaredFields.put("resources", resources);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiDeployment.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiDeployment.java
@@ -799,16 +799,50 @@ public class AiDeployment
   /**
    * Get the value of an unrecognizable property of this {@link AiDeployment} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("AiDeployment has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiDeployment} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (deploymentUrl != null) declaredFields.put("deploymentUrl", deploymentUrl);
+    if (configurationId != null) declaredFields.put("configurationId", configurationId);
+    if (configurationName != null) declaredFields.put("configurationName", configurationName);
+    if (executableId != null) declaredFields.put("executableId", executableId);
+    if (scenarioId != null) declaredFields.put("scenarioId", scenarioId);
+    if (status != null) declaredFields.put("status", status);
+    if (statusMessage != null) declaredFields.put("statusMessage", statusMessage);
+    if (targetStatus != null) declaredFields.put("targetStatus", targetStatus);
+    if (lastOperation != null) declaredFields.put("lastOperation", lastOperation);
+    if (latestRunningConfigurationId != null)
+      declaredFields.put("latestRunningConfigurationId", latestRunningConfigurationId);
+    if (ttl != null) declaredFields.put("ttl", ttl);
+    if (details != null) declaredFields.put("details", details);
+    if (createdAt != null) declaredFields.put("createdAt", createdAt);
+    if (modifiedAt != null) declaredFields.put("modifiedAt", modifiedAt);
+    if (submissionTime != null) declaredFields.put("submissionTime", submissionTime);
+    if (startTime != null) declaredFields.put("startTime", startTime);
+    if (completionTime != null) declaredFields.put("completionTime", completionTime);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiDeploymentBulkModificationRequest.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiDeploymentBulkModificationRequest.java
@@ -106,17 +106,33 @@ public class AiDeploymentBulkModificationRequest
    * Get the value of an unrecognizable property of this {@link AiDeploymentBulkModificationRequest}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiDeploymentBulkModificationRequest has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiDeploymentBulkModificationRequest} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (deployments != null) declaredFields.put("deployments", deployments);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiDeploymentBulkModificationResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiDeploymentBulkModificationResponse.java
@@ -107,17 +107,33 @@ public class AiDeploymentBulkModificationResponse
    * Get the value of an unrecognizable property of this {@link
    * AiDeploymentBulkModificationResponse} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiDeploymentBulkModificationResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiDeploymentBulkModificationResponse} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (deployments != null) declaredFields.put("deployments", deployments);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiDeploymentCreationRequest.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiDeploymentCreationRequest.java
@@ -123,17 +123,34 @@ public class AiDeploymentCreationRequest
    * Get the value of an unrecognizable property of this {@link AiDeploymentCreationRequest}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiDeploymentCreationRequest has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiDeploymentCreationRequest} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (ttl != null) declaredFields.put("ttl", ttl);
+    if (configurationId != null) declaredFields.put("configurationId", configurationId);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiDeploymentCreationResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiDeploymentCreationResponse.java
@@ -226,17 +226,37 @@ public class AiDeploymentCreationResponse
    * Get the value of an unrecognizable property of this {@link AiDeploymentCreationResponse}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiDeploymentCreationResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiDeploymentCreationResponse} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (message != null) declaredFields.put("message", message);
+    if (deploymentUrl != null) declaredFields.put("deploymentUrl", deploymentUrl);
+    if (status != null) declaredFields.put("status", status);
+    if (ttl != null) declaredFields.put("ttl", ttl);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiDeploymentDeletionResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiDeploymentDeletionResponse.java
@@ -119,17 +119,34 @@ public class AiDeploymentDeletionResponse
    * Get the value of an unrecognizable property of this {@link AiDeploymentDeletionResponse}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiDeploymentDeletionResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiDeploymentDeletionResponse} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (message != null) declaredFields.put("message", message);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiDeploymentDetails.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiDeploymentDetails.java
@@ -120,17 +120,34 @@ public class AiDeploymentDetails
   /**
    * Get the value of an unrecognizable property of this {@link AiDeploymentDetails} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiDeploymentDetails has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiDeploymentDetails} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (scaling != null) declaredFields.put("scaling", scaling);
+    if (resources != null) declaredFields.put("resources", resources);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiDeploymentList.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiDeploymentList.java
@@ -135,16 +135,33 @@ public class AiDeploymentList
   /**
    * Get the value of an unrecognizable property of this {@link AiDeploymentList} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("AiDeploymentList has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiDeploymentList} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (count != null) declaredFields.put("count", count);
+    if (resources != null) declaredFields.put("resources", resources);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiDeploymentModificationRequest.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiDeploymentModificationRequest.java
@@ -125,17 +125,34 @@ public class AiDeploymentModificationRequest
    * Get the value of an unrecognizable property of this {@link AiDeploymentModificationRequest}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiDeploymentModificationRequest has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiDeploymentModificationRequest} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (targetStatus != null) declaredFields.put("targetStatus", targetStatus);
+    if (configurationId != null) declaredFields.put("configurationId", configurationId);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiDeploymentModificationRequestWithIdentifier.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiDeploymentModificationRequestWithIdentifier.java
@@ -185,17 +185,34 @@ public class AiDeploymentModificationRequestWithIdentifier
    * Get the value of an unrecognizable property of this {@link
    * AiDeploymentModificationRequestWithIdentifier} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiDeploymentModificationRequestWithIdentifier has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiDeploymentModificationRequestWithIdentifier}
+   * instance including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (targetStatus != null) declaredFields.put("targetStatus", targetStatus);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiDeploymentModificationResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiDeploymentModificationResponse.java
@@ -120,17 +120,34 @@ public class AiDeploymentModificationResponse
    * Get the value of an unrecognizable property of this {@link AiDeploymentModificationResponse}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiDeploymentModificationResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiDeploymentModificationResponse} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (message != null) declaredFields.put("message", message);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiDeploymentModificationResponseListInner.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiDeploymentModificationResponseListInner.java
@@ -156,17 +156,35 @@ public class AiDeploymentModificationResponseListInner
    * Get the value of an unrecognizable property of this {@link
    * AiDeploymentModificationResponseListInner} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiDeploymentModificationResponseListInner has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiDeploymentModificationResponseListInner}
+   * instance including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (message != null) declaredFields.put("message", message);
+    if (error != null) declaredFields.put("error", error);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiDeploymentResponseWithDetails.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiDeploymentResponseWithDetails.java
@@ -865,17 +865,52 @@ public class AiDeploymentResponseWithDetails
    * Get the value of an unrecognizable property of this {@link AiDeploymentResponseWithDetails}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiDeploymentResponseWithDetails has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiDeploymentResponseWithDetails} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (deploymentUrl != null) declaredFields.put("deploymentUrl", deploymentUrl);
+    if (configurationId != null) declaredFields.put("configurationId", configurationId);
+    if (configurationName != null) declaredFields.put("configurationName", configurationName);
+    if (executableId != null) declaredFields.put("executableId", executableId);
+    if (scenarioId != null) declaredFields.put("scenarioId", scenarioId);
+    if (status != null) declaredFields.put("status", status);
+    if (statusMessage != null) declaredFields.put("statusMessage", statusMessage);
+    if (targetStatus != null) declaredFields.put("targetStatus", targetStatus);
+    if (lastOperation != null) declaredFields.put("lastOperation", lastOperation);
+    if (latestRunningConfigurationId != null)
+      declaredFields.put("latestRunningConfigurationId", latestRunningConfigurationId);
+    if (ttl != null) declaredFields.put("ttl", ttl);
+    if (details != null) declaredFields.put("details", details);
+    if (createdAt != null) declaredFields.put("createdAt", createdAt);
+    if (modifiedAt != null) declaredFields.put("modifiedAt", modifiedAt);
+    if (submissionTime != null) declaredFields.put("submissionTime", submissionTime);
+    if (startTime != null) declaredFields.put("startTime", startTime);
+    if (completionTime != null) declaredFields.put("completionTime", completionTime);
+    if (statusDetails != null) declaredFields.put("statusDetails", statusDetails);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiEnactmentCreationRequest.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiEnactmentCreationRequest.java
@@ -86,17 +86,33 @@ public class AiEnactmentCreationRequest
    * Get the value of an unrecognizable property of this {@link AiEnactmentCreationRequest}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiEnactmentCreationRequest has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiEnactmentCreationRequest} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (configurationId != null) declaredFields.put("configurationId", configurationId);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutable.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutable.java
@@ -525,16 +525,43 @@ public class AiExecutable
   /**
    * Get the value of an unrecognizable property of this {@link AiExecutable} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("AiExecutable has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiExecutable} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (labels != null) declaredFields.put("labels", labels);
+    if (name != null) declaredFields.put("name", name);
+    if (description != null) declaredFields.put("description", description);
+    if (id != null) declaredFields.put("id", id);
+    if (scenarioId != null) declaredFields.put("scenarioId", scenarioId);
+    if (versionId != null) declaredFields.put("versionId", versionId);
+    if (parameters != null) declaredFields.put("parameters", parameters);
+    if (inputArtifacts != null) declaredFields.put("inputArtifacts", inputArtifacts);
+    if (outputArtifacts != null) declaredFields.put("outputArtifacts", outputArtifacts);
+    if (deployable != null) declaredFields.put("deployable", deployable);
+    if (createdAt != null) declaredFields.put("createdAt", createdAt);
+    if (modifiedAt != null) declaredFields.put("modifiedAt", modifiedAt);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutableArtifact.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutableArtifact.java
@@ -202,17 +202,36 @@ public class AiExecutableArtifact
   /**
    * Get the value of an unrecognizable property of this {@link AiExecutableArtifact} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiExecutableArtifact has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiExecutableArtifact} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (name != null) declaredFields.put("name", name);
+    if (kind != null) declaredFields.put("kind", kind);
+    if (description != null) declaredFields.put("description", description);
+    if (labels != null) declaredFields.put("labels", labels);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutableList.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutableList.java
@@ -135,16 +135,33 @@ public class AiExecutableList
   /**
    * Get the value of an unrecognizable property of this {@link AiExecutableList} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("AiExecutableList has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiExecutableList} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (count != null) declaredFields.put("count", count);
+    if (resources != null) declaredFields.put("resources", resources);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutableParameter.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutableParameter.java
@@ -242,17 +242,36 @@ public class AiExecutableParameter
   /**
    * Get the value of an unrecognizable property of this {@link AiExecutableParameter} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiExecutableParameter has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiExecutableParameter} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (name != null) declaredFields.put("name", name);
+    if (description != null) declaredFields.put("description", description);
+    if (_default != null) declaredFields.put("_default", _default);
+    if (type != null) declaredFields.put("type", type);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiExecution.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiExecution.java
@@ -642,16 +642,46 @@ public class AiExecution
   /**
    * Get the value of an unrecognizable property of this {@link AiExecution} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("AiExecution has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiExecution} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (configurationId != null) declaredFields.put("configurationId", configurationId);
+    if (configurationName != null) declaredFields.put("configurationName", configurationName);
+    if (executableId != null) declaredFields.put("executableId", executableId);
+    if (scenarioId != null) declaredFields.put("scenarioId", scenarioId);
+    if (targetStatus != null) declaredFields.put("targetStatus", targetStatus);
+    if (status != null) declaredFields.put("status", status);
+    if (statusMessage != null) declaredFields.put("statusMessage", statusMessage);
+    if (outputArtifacts != null) declaredFields.put("outputArtifacts", outputArtifacts);
+    if (executionScheduleId != null) declaredFields.put("executionScheduleId", executionScheduleId);
+    if (createdAt != null) declaredFields.put("createdAt", createdAt);
+    if (modifiedAt != null) declaredFields.put("modifiedAt", modifiedAt);
+    if (submissionTime != null) declaredFields.put("submissionTime", submissionTime);
+    if (startTime != null) declaredFields.put("startTime", startTime);
+    if (completionTime != null) declaredFields.put("completionTime", completionTime);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionBulkModificationRequest.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionBulkModificationRequest.java
@@ -105,17 +105,33 @@ public class AiExecutionBulkModificationRequest
    * Get the value of an unrecognizable property of this {@link AiExecutionBulkModificationRequest}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiExecutionBulkModificationRequest has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiExecutionBulkModificationRequest} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (executions != null) declaredFields.put("executions", executions);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionBulkModificationResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionBulkModificationResponse.java
@@ -106,17 +106,33 @@ public class AiExecutionBulkModificationResponse
    * Get the value of an unrecognizable property of this {@link AiExecutionBulkModificationResponse}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiExecutionBulkModificationResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiExecutionBulkModificationResponse} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (executions != null) declaredFields.put("executions", executions);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionCreationResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionCreationResponse.java
@@ -154,17 +154,35 @@ public class AiExecutionCreationResponse
    * Get the value of an unrecognizable property of this {@link AiExecutionCreationResponse}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiExecutionCreationResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiExecutionCreationResponse} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (message != null) declaredFields.put("message", message);
+    if (status != null) declaredFields.put("status", status);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionDeletionResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionDeletionResponse.java
@@ -119,17 +119,34 @@ public class AiExecutionDeletionResponse
    * Get the value of an unrecognizable property of this {@link AiExecutionDeletionResponse}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiExecutionDeletionResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiExecutionDeletionResponse} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (message != null) declaredFields.put("message", message);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionList.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionList.java
@@ -135,16 +135,33 @@ public class AiExecutionList
   /**
    * Get the value of an unrecognizable property of this {@link AiExecutionList} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("AiExecutionList has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiExecutionList} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (count != null) declaredFields.put("count", count);
+    if (resources != null) declaredFields.put("resources", resources);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionModificationRequest.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionModificationRequest.java
@@ -146,17 +146,33 @@ public class AiExecutionModificationRequest
    * Get the value of an unrecognizable property of this {@link AiExecutionModificationRequest}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiExecutionModificationRequest has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiExecutionModificationRequest} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (targetStatus != null) declaredFields.put("targetStatus", targetStatus);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionModificationRequestWithIdentifier.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionModificationRequestWithIdentifier.java
@@ -187,17 +187,34 @@ public class AiExecutionModificationRequestWithIdentifier
    * Get the value of an unrecognizable property of this {@link
    * AiExecutionModificationRequestWithIdentifier} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiExecutionModificationRequestWithIdentifier has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiExecutionModificationRequestWithIdentifier}
+   * instance including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (targetStatus != null) declaredFields.put("targetStatus", targetStatus);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionModificationResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionModificationResponse.java
@@ -120,17 +120,34 @@ public class AiExecutionModificationResponse
    * Get the value of an unrecognizable property of this {@link AiExecutionModificationResponse}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiExecutionModificationResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiExecutionModificationResponse} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (message != null) declaredFields.put("message", message);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionModificationResponseListInner.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionModificationResponseListInner.java
@@ -156,17 +156,35 @@ public class AiExecutionModificationResponseListInner
    * Get the value of an unrecognizable property of this {@link
    * AiExecutionModificationResponseListInner} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiExecutionModificationResponseListInner has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiExecutionModificationResponseListInner}
+   * instance including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (message != null) declaredFields.put("message", message);
+    if (error != null) declaredFields.put("error", error);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionResponseWithDetails.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionResponseWithDetails.java
@@ -708,17 +708,48 @@ public class AiExecutionResponseWithDetails
    * Get the value of an unrecognizable property of this {@link AiExecutionResponseWithDetails}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiExecutionResponseWithDetails has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiExecutionResponseWithDetails} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (configurationId != null) declaredFields.put("configurationId", configurationId);
+    if (configurationName != null) declaredFields.put("configurationName", configurationName);
+    if (executableId != null) declaredFields.put("executableId", executableId);
+    if (scenarioId != null) declaredFields.put("scenarioId", scenarioId);
+    if (targetStatus != null) declaredFields.put("targetStatus", targetStatus);
+    if (status != null) declaredFields.put("status", status);
+    if (statusMessage != null) declaredFields.put("statusMessage", statusMessage);
+    if (outputArtifacts != null) declaredFields.put("outputArtifacts", outputArtifacts);
+    if (executionScheduleId != null) declaredFields.put("executionScheduleId", executionScheduleId);
+    if (createdAt != null) declaredFields.put("createdAt", createdAt);
+    if (modifiedAt != null) declaredFields.put("modifiedAt", modifiedAt);
+    if (submissionTime != null) declaredFields.put("submissionTime", submissionTime);
+    if (startTime != null) declaredFields.put("startTime", startTime);
+    if (completionTime != null) declaredFields.put("completionTime", completionTime);
+    if (statusDetails != null) declaredFields.put("statusDetails", statusDetails);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionSchedule.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionSchedule.java
@@ -359,17 +359,41 @@ public class AiExecutionSchedule
   /**
    * Get the value of an unrecognizable property of this {@link AiExecutionSchedule} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiExecutionSchedule has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiExecutionSchedule} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (cron != null) declaredFields.put("cron", cron);
+    if (name != null) declaredFields.put("name", name);
+    if (configurationId != null) declaredFields.put("configurationId", configurationId);
+    if (start != null) declaredFields.put("start", start);
+    if (end != null) declaredFields.put("end", end);
+    if (id != null) declaredFields.put("id", id);
+    if (status != null) declaredFields.put("status", status);
+    if (createdAt != null) declaredFields.put("createdAt", createdAt);
+    if (modifiedAt != null) declaredFields.put("modifiedAt", modifiedAt);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionScheduleCreationData.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionScheduleCreationData.java
@@ -229,17 +229,37 @@ public class AiExecutionScheduleCreationData
    * Get the value of an unrecognizable property of this {@link AiExecutionScheduleCreationData}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiExecutionScheduleCreationData has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiExecutionScheduleCreationData} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (cron != null) declaredFields.put("cron", cron);
+    if (name != null) declaredFields.put("name", name);
+    if (configurationId != null) declaredFields.put("configurationId", configurationId);
+    if (start != null) declaredFields.put("start", start);
+    if (end != null) declaredFields.put("end", end);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionScheduleCreationResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionScheduleCreationResponse.java
@@ -121,17 +121,34 @@ public class AiExecutionScheduleCreationResponse
    * Get the value of an unrecognizable property of this {@link AiExecutionScheduleCreationResponse}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiExecutionScheduleCreationResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiExecutionScheduleCreationResponse} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (message != null) declaredFields.put("message", message);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionScheduleDeletionResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionScheduleDeletionResponse.java
@@ -121,17 +121,34 @@ public class AiExecutionScheduleDeletionResponse
    * Get the value of an unrecognizable property of this {@link AiExecutionScheduleDeletionResponse}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiExecutionScheduleDeletionResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiExecutionScheduleDeletionResponse} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (message != null) declaredFields.put("message", message);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionScheduleList.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionScheduleList.java
@@ -137,17 +137,34 @@ public class AiExecutionScheduleList
   /**
    * Get the value of an unrecognizable property of this {@link AiExecutionScheduleList} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiExecutionScheduleList has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiExecutionScheduleList} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (count != null) declaredFields.put("count", count);
+    if (resources != null) declaredFields.put("resources", resources);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionScheduleModificationRequest.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionScheduleModificationRequest.java
@@ -232,17 +232,37 @@ public class AiExecutionScheduleModificationRequest
    * Get the value of an unrecognizable property of this {@link
    * AiExecutionScheduleModificationRequest} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiExecutionScheduleModificationRequest has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiExecutionScheduleModificationRequest} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (cron != null) declaredFields.put("cron", cron);
+    if (start != null) declaredFields.put("start", start);
+    if (end != null) declaredFields.put("end", end);
+    if (configurationId != null) declaredFields.put("configurationId", configurationId);
+    if (status != null) declaredFields.put("status", status);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionScheduleModificationResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiExecutionScheduleModificationResponse.java
@@ -121,17 +121,34 @@ public class AiExecutionScheduleModificationResponse
    * Get the value of an unrecognizable property of this {@link
    * AiExecutionScheduleModificationResponse} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiExecutionScheduleModificationResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiExecutionScheduleModificationResponse}
+   * instance including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (message != null) declaredFields.put("message", message);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiLabel.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiLabel.java
@@ -117,16 +117,33 @@ public class AiLabel
   /**
    * Get the value of an unrecognizable property of this {@link AiLabel} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("AiLabel has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiLabel} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (key != null) declaredFields.put("key", key);
+    if (value != null) declaredFields.put("value", value);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiLogCommonData.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiLogCommonData.java
@@ -100,16 +100,32 @@ public class AiLogCommonData
   /**
    * Get the value of an unrecognizable property of this {@link AiLogCommonData} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("AiLogCommonData has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiLogCommonData} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (result != null) declaredFields.put("result", result);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiLogCommonResultItem.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiLogCommonResultItem.java
@@ -118,17 +118,34 @@ public class AiLogCommonResultItem
   /**
    * Get the value of an unrecognizable property of this {@link AiLogCommonResultItem} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiLogCommonResultItem has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiLogCommonResultItem} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (timestamp != null) declaredFields.put("timestamp", timestamp);
+    if (msg != null) declaredFields.put("msg", msg);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiModelBaseData.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiModelBaseData.java
@@ -305,16 +305,38 @@ public class AiModelBaseData
   /**
    * Get the value of an unrecognizable property of this {@link AiModelBaseData} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("AiModelBaseData has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiModelBaseData} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (model != null) declaredFields.put("model", model);
+    if (executableId != null) declaredFields.put("executableId", executableId);
+    if (description != null) declaredFields.put("description", description);
+    if (versions != null) declaredFields.put("versions", versions);
+    if (displayName != null) declaredFields.put("displayName", displayName);
+    if (accessType != null) declaredFields.put("accessType", accessType);
+    if (provider != null) declaredFields.put("provider", provider);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiModelList.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiModelList.java
@@ -135,16 +135,33 @@ public class AiModelList
   /**
    * Get the value of an unrecognizable property of this {@link AiModelList} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("AiModelList has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiModelList} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (count != null) declaredFields.put("count", count);
+    if (resources != null) declaredFields.put("resources", resources);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiModelVersion.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiModelVersion.java
@@ -472,16 +472,42 @@ public class AiModelVersion
   /**
    * Get the value of an unrecognizable property of this {@link AiModelVersion} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("AiModelVersion has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiModelVersion} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (name != null) declaredFields.put("name", name);
+    if (isLatest != null) declaredFields.put("isLatest", isLatest);
+    if (deprecated != null) declaredFields.put("deprecated", deprecated);
+    if (retirementDate != null) declaredFields.put("retirementDate", retirementDate);
+    if (contextLength != null) declaredFields.put("contextLength", contextLength);
+    if (inputTypes != null) declaredFields.put("inputTypes", inputTypes);
+    if (capabilities != null) declaredFields.put("capabilities", capabilities);
+    if (metadata != null) declaredFields.put("metadata", metadata);
+    if (cost != null) declaredFields.put("cost", cost);
+    if (suggestedReplacements != null)
+      declaredFields.put("suggestedReplacements", suggestedReplacements);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiParameterArgumentBinding.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiParameterArgumentBinding.java
@@ -118,17 +118,34 @@ public class AiParameterArgumentBinding
    * Get the value of an unrecognizable property of this {@link AiParameterArgumentBinding}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AiParameterArgumentBinding has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiParameterArgumentBinding} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (key != null) declaredFields.put("key", key);
+    if (value != null) declaredFields.put("value", value);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiResourcesDetails.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiResourcesDetails.java
@@ -84,16 +84,32 @@ public class AiResourcesDetails
   /**
    * Get the value of an unrecognizable property of this {@link AiResourcesDetails} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("AiResourcesDetails has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiResourcesDetails} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (backendDetails != null) declaredFields.put("backendDetails", backendDetails);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiScalingDetails.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiScalingDetails.java
@@ -83,16 +83,32 @@ public class AiScalingDetails
   /**
    * Get the value of an unrecognizable property of this {@link AiScalingDetails} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("AiScalingDetails has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiScalingDetails} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (backendDetails != null) declaredFields.put("backendDetails", backendDetails);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiScenario.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiScenario.java
@@ -274,16 +274,37 @@ public class AiScenario
   /**
    * Get the value of an unrecognizable property of this {@link AiScenario} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("AiScenario has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiScenario} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (name != null) declaredFields.put("name", name);
+    if (description != null) declaredFields.put("description", description);
+    if (labels != null) declaredFields.put("labels", labels);
+    if (id != null) declaredFields.put("id", id);
+    if (createdAt != null) declaredFields.put("createdAt", createdAt);
+    if (modifiedAt != null) declaredFields.put("modifiedAt", modifiedAt);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiScenarioLabel.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiScenarioLabel.java
@@ -117,16 +117,33 @@ public class AiScenarioLabel
   /**
    * Get the value of an unrecognizable property of this {@link AiScenarioLabel} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("AiScenarioLabel has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiScenarioLabel} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (key != null) declaredFields.put("key", key);
+    if (value != null) declaredFields.put("value", value);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiScenarioList.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiScenarioList.java
@@ -135,16 +135,33 @@ public class AiScenarioList
   /**
    * Get the value of an unrecognizable property of this {@link AiScenarioList} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("AiScenarioList has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiScenarioList} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (count != null) declaredFields.put("count", count);
+    if (resources != null) declaredFields.put("resources", resources);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiVersion.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiVersion.java
@@ -220,16 +220,36 @@ public class AiVersion
   /**
    * Get the value of an unrecognizable property of this {@link AiVersion} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("AiVersion has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiVersion} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (description != null) declaredFields.put("description", description);
+    if (id != null) declaredFields.put("id", id);
+    if (scenarioId != null) declaredFields.put("scenarioId", scenarioId);
+    if (createdAt != null) declaredFields.put("createdAt", createdAt);
+    if (modifiedAt != null) declaredFields.put("modifiedAt", modifiedAt);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/AiVersionList.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/AiVersionList.java
@@ -135,16 +135,33 @@ public class AiVersionList
   /**
    * Get the value of an unrecognizable property of this {@link AiVersionList} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("AiVersionList has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AiVersionList} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (count != null) declaredFields.put("count", count);
+    if (resources != null) declaredFields.put("resources", resources);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndAllArgoCDApplicationData.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndAllArgoCDApplicationData.java
@@ -140,17 +140,34 @@ public class BckndAllArgoCDApplicationData
    * Get the value of an unrecognizable property of this {@link BckndAllArgoCDApplicationData}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndAllArgoCDApplicationData has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndAllArgoCDApplicationData} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (count != null) declaredFields.put("count", count);
+    if (resources != null) declaredFields.put("resources", resources);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDApplicationBaseData.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDApplicationBaseData.java
@@ -156,17 +156,35 @@ public class BckndArgoCDApplicationBaseData
    * Get the value of an unrecognizable property of this {@link BckndArgoCDApplicationBaseData}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndArgoCDApplicationBaseData has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndArgoCDApplicationBaseData} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (repositoryUrl != null) declaredFields.put("repositoryUrl", repositoryUrl);
+    if (revision != null) declaredFields.put("revision", revision);
+    if (path != null) declaredFields.put("path", path);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDApplicationCreationResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDApplicationCreationResponse.java
@@ -121,17 +121,34 @@ public class BckndArgoCDApplicationCreationResponse
    * Get the value of an unrecognizable property of this {@link
    * BckndArgoCDApplicationCreationResponse} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndArgoCDApplicationCreationResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndArgoCDApplicationCreationResponse} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (message != null) declaredFields.put("message", message);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDApplicationData.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDApplicationData.java
@@ -190,17 +190,36 @@ public class BckndArgoCDApplicationData
    * Get the value of an unrecognizable property of this {@link BckndArgoCDApplicationData}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndArgoCDApplicationData has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndArgoCDApplicationData} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (repositoryUrl != null) declaredFields.put("repositoryUrl", repositoryUrl);
+    if (revision != null) declaredFields.put("revision", revision);
+    if (path != null) declaredFields.put("path", path);
+    if (applicationName != null) declaredFields.put("applicationName", applicationName);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDApplicationDataRepoName.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDApplicationDataRepoName.java
@@ -194,17 +194,36 @@ public class BckndArgoCDApplicationDataRepoName
    * Get the value of an unrecognizable property of this {@link BckndArgoCDApplicationDataRepoName}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndArgoCDApplicationDataRepoName has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndArgoCDApplicationDataRepoName} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (repositoryName != null) declaredFields.put("repositoryName", repositoryName);
+    if (revision != null) declaredFields.put("revision", revision);
+    if (path != null) declaredFields.put("path", path);
+    if (applicationName != null) declaredFields.put("applicationName", applicationName);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDApplicationDeletionResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDApplicationDeletionResponse.java
@@ -121,17 +121,34 @@ public class BckndArgoCDApplicationDeletionResponse
    * Get the value of an unrecognizable property of this {@link
    * BckndArgoCDApplicationDeletionResponse} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndArgoCDApplicationDeletionResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndArgoCDApplicationDeletionResponse} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (message != null) declaredFields.put("message", message);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDApplicationModificationResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDApplicationModificationResponse.java
@@ -122,17 +122,34 @@ public class BckndArgoCDApplicationModificationResponse
    * Get the value of an unrecognizable property of this {@link
    * BckndArgoCDApplicationModificationResponse} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndArgoCDApplicationModificationResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndArgoCDApplicationModificationResponse}
+   * instance including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (message != null) declaredFields.put("message", message);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDApplicationRefreshResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDApplicationRefreshResponse.java
@@ -121,17 +121,34 @@ public class BckndArgoCDApplicationRefreshResponse
    * Get the value of an unrecognizable property of this {@link
    * BckndArgoCDApplicationRefreshResponse} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndArgoCDApplicationRefreshResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndArgoCDApplicationRefreshResponse} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (message != null) declaredFields.put("message", message);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDApplicationStatus.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDApplicationStatus.java
@@ -427,17 +427,42 @@ public class BckndArgoCDApplicationStatus
    * Get the value of an unrecognizable property of this {@link BckndArgoCDApplicationStatus}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndArgoCDApplicationStatus has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndArgoCDApplicationStatus} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (healthStatus != null) declaredFields.put("healthStatus", healthStatus);
+    if (syncStatus != null) declaredFields.put("syncStatus", syncStatus);
+    if (message != null) declaredFields.put("message", message);
+    if (source != null) declaredFields.put("source", source);
+    if (syncFinishedAt != null) declaredFields.put("syncFinishedAt", syncFinishedAt);
+    if (syncStartedAt != null) declaredFields.put("syncStartedAt", syncStartedAt);
+    if (reconciledAt != null) declaredFields.put("reconciledAt", reconciledAt);
+    if (syncResourcesStatus != null) declaredFields.put("syncResourcesStatus", syncResourcesStatus);
+    if (syncRessourcesStatus != null)
+      declaredFields.put("syncRessourcesStatus", syncRessourcesStatus);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDApplicationStatusSource.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDApplicationStatusSource.java
@@ -156,17 +156,35 @@ public class BckndArgoCDApplicationStatusSource
    * Get the value of an unrecognizable property of this {@link BckndArgoCDApplicationStatusSource}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndArgoCDApplicationStatusSource has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndArgoCDApplicationStatusSource} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (repoURL != null) declaredFields.put("repoURL", repoURL);
+    if (path != null) declaredFields.put("path", path);
+    if (revision != null) declaredFields.put("revision", revision);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDApplicationStatusSyncResourcesStatusInner.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDApplicationStatusSyncResourcesStatusInner.java
@@ -201,11 +201,13 @@ public class BckndArgoCDApplicationStatusSyncResourcesStatusInner
    * Get the value of an unrecognizable property of this {@link
    * BckndArgoCDApplicationStatusSyncResourcesStatusInner} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
@@ -214,6 +216,24 @@ public class BckndArgoCDApplicationStatusSyncResourcesStatusInner
               + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link
+   * BckndArgoCDApplicationStatusSyncResourcesStatusInner} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (name != null) declaredFields.put("name", name);
+    if (kind != null) declaredFields.put("kind", kind);
+    if (status != null) declaredFields.put("status", status);
+    if (message != null) declaredFields.put("message", message);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDRepositoryCreationResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDRepositoryCreationResponse.java
@@ -121,17 +121,34 @@ public class BckndArgoCDRepositoryCreationResponse
    * Get the value of an unrecognizable property of this {@link
    * BckndArgoCDRepositoryCreationResponse} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndArgoCDRepositoryCreationResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndArgoCDRepositoryCreationResponse} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (message != null) declaredFields.put("message", message);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDRepositoryCredentials.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDRepositoryCredentials.java
@@ -120,17 +120,34 @@ public class BckndArgoCDRepositoryCredentials
    * Get the value of an unrecognizable property of this {@link BckndArgoCDRepositoryCredentials}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndArgoCDRepositoryCredentials has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndArgoCDRepositoryCredentials} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (username != null) declaredFields.put("username", username);
+    if (password != null) declaredFields.put("password", password);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDRepositoryData.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDRepositoryData.java
@@ -187,17 +187,36 @@ public class BckndArgoCDRepositoryData
   /**
    * Get the value of an unrecognizable property of this {@link BckndArgoCDRepositoryData} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndArgoCDRepositoryData has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndArgoCDRepositoryData} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (name != null) declaredFields.put("name", name);
+    if (url != null) declaredFields.put("url", url);
+    if (username != null) declaredFields.put("username", username);
+    if (password != null) declaredFields.put("password", password);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDRepositoryDataResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDRepositoryDataResponse.java
@@ -141,17 +141,34 @@ public class BckndArgoCDRepositoryDataResponse
    * Get the value of an unrecognizable property of this {@link BckndArgoCDRepositoryDataResponse}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndArgoCDRepositoryDataResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndArgoCDRepositoryDataResponse} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (count != null) declaredFields.put("count", count);
+    if (resources != null) declaredFields.put("resources", resources);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDRepositoryDeletionResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDRepositoryDeletionResponse.java
@@ -121,17 +121,34 @@ public class BckndArgoCDRepositoryDeletionResponse
    * Get the value of an unrecognizable property of this {@link
    * BckndArgoCDRepositoryDeletionResponse} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndArgoCDRepositoryDeletionResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndArgoCDRepositoryDeletionResponse} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (message != null) declaredFields.put("message", message);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDRepositoryDetails.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDRepositoryDetails.java
@@ -216,17 +216,35 @@ public class BckndArgoCDRepositoryDetails
    * Get the value of an unrecognizable property of this {@link BckndArgoCDRepositoryDetails}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndArgoCDRepositoryDetails has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndArgoCDRepositoryDetails} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (name != null) declaredFields.put("name", name);
+    if (url != null) declaredFields.put("url", url);
+    if (status != null) declaredFields.put("status", status);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDRepositoryModificationResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndArgoCDRepositoryModificationResponse.java
@@ -121,17 +121,34 @@ public class BckndArgoCDRepositoryModificationResponse
    * Get the value of an unrecognizable property of this {@link
    * BckndArgoCDRepositoryModificationResponse} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndArgoCDRepositoryModificationResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndArgoCDRepositoryModificationResponse}
+   * instance including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (message != null) declaredFields.put("message", message);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndCommonResourceQuotaResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndCommonResourceQuotaResponse.java
@@ -122,17 +122,34 @@ public class BckndCommonResourceQuotaResponse
    * Get the value of an unrecognizable property of this {@link BckndCommonResourceQuotaResponse}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndCommonResourceQuotaResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndCommonResourceQuotaResponse} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (usage != null) declaredFields.put("usage", usage);
+    if (quota != null) declaredFields.put("quota", quota);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndCommonResourceQuotaResponseQuota.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndCommonResourceQuotaResponseQuota.java
@@ -88,17 +88,33 @@ public class BckndCommonResourceQuotaResponseQuota
    * Get the value of an unrecognizable property of this {@link
    * BckndCommonResourceQuotaResponseQuota} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndCommonResourceQuotaResponseQuota has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndCommonResourceQuotaResponseQuota} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (maxCount != null) declaredFields.put("maxCount", maxCount);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndCommonResourceQuotaResponseUsage.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndCommonResourceQuotaResponseUsage.java
@@ -86,17 +86,33 @@ public class BckndCommonResourceQuotaResponseUsage
    * Get the value of an unrecognizable property of this {@link
    * BckndCommonResourceQuotaResponseUsage} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndCommonResourceQuotaResponseUsage has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndCommonResourceQuotaResponseUsage} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (count != null) declaredFields.put("count", count);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndDeploymentQuota.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndDeploymentQuota.java
@@ -122,17 +122,35 @@ public class BckndDeploymentQuota
   /**
    * Get the value of an unrecognizable property of this {@link BckndDeploymentQuota} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndDeploymentQuota has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndDeploymentQuota} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (maxCount != null) declaredFields.put("maxCount", maxCount);
+    if (maxReplicaPerDeployment != null)
+      declaredFields.put("maxReplicaPerDeployment", maxReplicaPerDeployment);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndDeploymentQuotaItem.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndDeploymentQuotaItem.java
@@ -121,17 +121,34 @@ public class BckndDeploymentQuotaItem
   /**
    * Get the value of an unrecognizable property of this {@link BckndDeploymentQuotaItem} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndDeploymentQuotaItem has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndDeploymentQuotaItem} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (resourcePlanType != null) declaredFields.put("resourcePlanType", resourcePlanType);
+    if (deploymentQuota != null) declaredFields.put("deploymentQuota", deploymentQuota);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndDeploymentResourceQuotaResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndDeploymentResourceQuotaResponse.java
@@ -141,17 +141,34 @@ public class BckndDeploymentResourceQuotaResponse
    * Get the value of an unrecognizable property of this {@link
    * BckndDeploymentResourceQuotaResponse} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndDeploymentResourceQuotaResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndDeploymentResourceQuotaResponse} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (usage != null) declaredFields.put("usage", usage);
+    if (quotas != null) declaredFields.put("quotas", quotas);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndDeploymentUsage.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndDeploymentUsage.java
@@ -135,17 +135,34 @@ public class BckndDeploymentUsage
   /**
    * Get the value of an unrecognizable property of this {@link BckndDeploymentUsage} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndDeploymentUsage has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndDeploymentUsage} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (count != null) declaredFields.put("count", count);
+    if (items != null) declaredFields.put("items", items);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndError.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndError.java
@@ -219,16 +219,36 @@ public class BckndError
   /**
    * Get the value of an unrecognizable property of this {@link BckndError} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("BckndError has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndError} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (code != null) declaredFields.put("code", code);
+    if (message != null) declaredFields.put("message", message);
+    if (requestId != null) declaredFields.put("requestId", requestId);
+    if (target != null) declaredFields.put("target", target);
+    if (details != null) declaredFields.put("details", details);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndErrorResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndErrorResponse.java
@@ -83,16 +83,32 @@ public class BckndErrorResponse
   /**
    * Get the value of an unrecognizable property of this {@link BckndErrorResponse} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("BckndErrorResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndErrorResponse} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (error != null) declaredFields.put("error", error);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndEvent.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndEvent.java
@@ -339,16 +339,36 @@ public class BckndEvent
   /**
    * Get the value of an unrecognizable property of this {@link BckndEvent} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("BckndEvent has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndEvent} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (tenantId != null) declaredFields.put("tenantId", tenantId);
+    if (action != null) declaredFields.put("action", action);
+    if (state != null) declaredFields.put("state", state);
+    if (description != null) declaredFields.put("description", description);
+    if (createdAt != null) declaredFields.put("createdAt", createdAt);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndExecutableResourceQuotaResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndExecutableResourceQuotaResponse.java
@@ -123,17 +123,34 @@ public class BckndExecutableResourceQuotaResponse
    * Get the value of an unrecognizable property of this {@link
    * BckndExecutableResourceQuotaResponse} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndExecutableResourceQuotaResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndExecutableResourceQuotaResponse} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (usage != null) declaredFields.put("usage", usage);
+    if (quota != null) declaredFields.put("quota", quota);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndExecutableResourceQuotaResponseQuota.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndExecutableResourceQuotaResponseQuota.java
@@ -131,17 +131,36 @@ public class BckndExecutableResourceQuotaResponseQuota
    * Get the value of an unrecognizable property of this {@link
    * BckndExecutableResourceQuotaResponseQuota} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndExecutableResourceQuotaResponseQuota has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndExecutableResourceQuotaResponseQuota}
+   * instance including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (servingTemplateMaxCount != null)
+      declaredFields.put("servingTemplateMaxCount", servingTemplateMaxCount);
+    if (workflowTemplateMaxCount != null)
+      declaredFields.put("workflowTemplateMaxCount", workflowTemplateMaxCount);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndExecutableResourceQuotaResponseUsage.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndExecutableResourceQuotaResponseUsage.java
@@ -131,17 +131,36 @@ public class BckndExecutableResourceQuotaResponseUsage
    * Get the value of an unrecognizable property of this {@link
    * BckndExecutableResourceQuotaResponseUsage} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndExecutableResourceQuotaResponseUsage has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndExecutableResourceQuotaResponseUsage}
+   * instance including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (servingTemplateCount != null)
+      declaredFields.put("servingTemplateCount", servingTemplateCount);
+    if (workflowTemplateCount != null)
+      declaredFields.put("workflowTemplateCount", workflowTemplateCount);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndExtendedService.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndExtendedService.java
@@ -410,17 +410,40 @@ public class BckndExtendedService
   /**
    * Get the value of an unrecognizable property of this {@link BckndExtendedService} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndExtendedService has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndExtendedService} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (name != null) declaredFields.put("name", name);
+    if (description != null) declaredFields.put("description", description);
+    if (url != null) declaredFields.put("url", url);
+    if (brokerSecret != null) declaredFields.put("brokerSecret", brokerSecret);
+    if (capabilities != null) declaredFields.put("capabilities", capabilities);
+    if (serviceCatalog != null) declaredFields.put("serviceCatalog", serviceCatalog);
+    if (status != null) declaredFields.put("status", status);
+    if (statusMessage != null) declaredFields.put("statusMessage", statusMessage);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndGenericSecretDataResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndGenericSecretDataResponse.java
@@ -120,17 +120,34 @@ public class BckndGenericSecretDataResponse
    * Get the value of an unrecognizable property of this {@link BckndGenericSecretDataResponse}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndGenericSecretDataResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndGenericSecretDataResponse} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (message != null) declaredFields.put("message", message);
+    if (name != null) declaredFields.put("name", name);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndGenericSecretDetails.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndGenericSecretDetails.java
@@ -178,17 +178,36 @@ public class BckndGenericSecretDetails
   /**
    * Get the value of an unrecognizable property of this {@link BckndGenericSecretDetails} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndGenericSecretDetails has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndGenericSecretDetails} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (name != null) declaredFields.put("name", name);
+    if (createdAt != null) declaredFields.put("createdAt", createdAt);
+    if (resourceGroupSecretsSyncStatus != null)
+      declaredFields.put("resourceGroupSecretsSyncStatus", resourceGroupSecretsSyncStatus);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndGenericSecretLabel.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndGenericSecretLabel.java
@@ -117,17 +117,34 @@ public class BckndGenericSecretLabel
   /**
    * Get the value of an unrecognizable property of this {@link BckndGenericSecretLabel} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndGenericSecretLabel has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndGenericSecretLabel} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (key != null) declaredFields.put("key", key);
+    if (value != null) declaredFields.put("value", value);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndGenericSecretPatchBody.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndGenericSecretPatchBody.java
@@ -99,17 +99,33 @@ public class BckndGenericSecretPatchBody
    * Get the value of an unrecognizable property of this {@link BckndGenericSecretPatchBody}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndGenericSecretPatchBody has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndGenericSecretPatchBody} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (data != null) declaredFields.put("data", data);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndGenericSecretPostBody.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndGenericSecretPostBody.java
@@ -186,17 +186,35 @@ public class BckndGenericSecretPostBody
    * Get the value of an unrecognizable property of this {@link BckndGenericSecretPostBody}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndGenericSecretPostBody has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndGenericSecretPostBody} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (name != null) declaredFields.put("name", name);
+    if (data != null) declaredFields.put("data", data);
+    if (labels != null) declaredFields.put("labels", labels);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndInternalResourceGroup.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndInternalResourceGroup.java
@@ -431,17 +431,40 @@ public class BckndInternalResourceGroup
    * Get the value of an unrecognizable property of this {@link BckndInternalResourceGroup}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndInternalResourceGroup has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndInternalResourceGroup} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (resourceGroupId != null) declaredFields.put("resourceGroupId", resourceGroupId);
+    if (tenantId != null) declaredFields.put("tenantId", tenantId);
+    if (zoneId != null) declaredFields.put("zoneId", zoneId);
+    if (createdAt != null) declaredFields.put("createdAt", createdAt);
+    if (labels != null) declaredFields.put("labels", labels);
+    if (status != null) declaredFields.put("status", status);
+    if (statusMessage != null) declaredFields.put("statusMessage", statusMessage);
+    if (annotations != null) declaredFields.put("annotations", annotations);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndInternalResourceGroupAnnotation.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndInternalResourceGroupAnnotation.java
@@ -121,17 +121,34 @@ public class BckndInternalResourceGroupAnnotation
    * Get the value of an unrecognizable property of this {@link
    * BckndInternalResourceGroupAnnotation} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndInternalResourceGroupAnnotation has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndInternalResourceGroupAnnotation} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (key != null) declaredFields.put("key", key);
+    if (value != null) declaredFields.put("value", value);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndInternalResourceGroupLabel.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndInternalResourceGroupLabel.java
@@ -120,17 +120,34 @@ public class BckndInternalResourceGroupLabel
    * Get the value of an unrecognizable property of this {@link BckndInternalResourceGroupLabel}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndInternalResourceGroupLabel has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndInternalResourceGroupLabel} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (key != null) declaredFields.put("key", key);
+    if (value != null) declaredFields.put("value", value);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndListGenericSecretsResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndListGenericSecretsResponse.java
@@ -143,17 +143,34 @@ public class BckndListGenericSecretsResponse
    * Get the value of an unrecognizable property of this {@link BckndListGenericSecretsResponse}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndListGenericSecretsResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndListGenericSecretsResponse} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (count != null) declaredFields.put("count", count);
+    if (resources != null) declaredFields.put("resources", resources);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndResourceGetResourcePlansValue.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndResourceGetResourcePlansValue.java
@@ -122,17 +122,34 @@ public class BckndResourceGetResourcePlansValue
    * Get the value of an unrecognizable property of this {@link BckndResourceGetResourcePlansValue}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndResourceGetResourcePlansValue has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndResourceGetResourcePlansValue} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (provisioned != null) declaredFields.put("provisioned", provisioned);
+    if (requested != null) declaredFields.put("requested", requested);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndResourceGetResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndResourceGetResponse.java
@@ -102,17 +102,33 @@ public class BckndResourceGetResponse
   /**
    * Get the value of an unrecognizable property of this {@link BckndResourceGetResponse} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndResourceGetResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndResourceGetResponse} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (resourcePlans != null) declaredFields.put("resourcePlans", resourcePlans);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndResourceGroup.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndResourceGroup.java
@@ -368,16 +368,38 @@ public class BckndResourceGroup
   /**
    * Get the value of an unrecognizable property of this {@link BckndResourceGroup} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("BckndResourceGroup has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndResourceGroup} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (resourceGroupId != null) declaredFields.put("resourceGroupId", resourceGroupId);
+    if (tenantId != null) declaredFields.put("tenantId", tenantId);
+    if (zoneId != null) declaredFields.put("zoneId", zoneId);
+    if (createdAt != null) declaredFields.put("createdAt", createdAt);
+    if (labels != null) declaredFields.put("labels", labels);
+    if (status != null) declaredFields.put("status", status);
+    if (statusMessage != null) declaredFields.put("statusMessage", statusMessage);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndResourceGroupBase.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndResourceGroupBase.java
@@ -152,17 +152,35 @@ public class BckndResourceGroupBase
   /**
    * Get the value of an unrecognizable property of this {@link BckndResourceGroupBase} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndResourceGroupBase has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndResourceGroupBase} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (resourceGroupId != null) declaredFields.put("resourceGroupId", resourceGroupId);
+    if (tenantId != null) declaredFields.put("tenantId", tenantId);
+    if (zoneId != null) declaredFields.put("zoneId", zoneId);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndResourceGroupDeletionResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndResourceGroupDeletionResponse.java
@@ -121,17 +121,34 @@ public class BckndResourceGroupDeletionResponse
    * Get the value of an unrecognizable property of this {@link BckndResourceGroupDeletionResponse}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndResourceGroupDeletionResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndResourceGroupDeletionResponse} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (message != null) declaredFields.put("message", message);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndResourceGroupLabel.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndResourceGroupLabel.java
@@ -117,17 +117,34 @@ public class BckndResourceGroupLabel
   /**
    * Get the value of an unrecognizable property of this {@link BckndResourceGroupLabel} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndResourceGroupLabel has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndResourceGroupLabel} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (key != null) declaredFields.put("key", key);
+    if (value != null) declaredFields.put("value", value);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndResourceGroupList.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndResourceGroupList.java
@@ -135,17 +135,34 @@ public class BckndResourceGroupList
   /**
    * Get the value of an unrecognizable property of this {@link BckndResourceGroupList} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndResourceGroupList has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndResourceGroupList} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (count != null) declaredFields.put("count", count);
+    if (resources != null) declaredFields.put("resources", resources);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndResourceGroupPatchRequest.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndResourceGroupPatchRequest.java
@@ -104,17 +104,33 @@ public class BckndResourceGroupPatchRequest
    * Get the value of an unrecognizable property of this {@link BckndResourceGroupPatchRequest}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndResourceGroupPatchRequest has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndResourceGroupPatchRequest} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (labels != null) declaredFields.put("labels", labels);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndResourceGroupsPostRequest.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndResourceGroupsPostRequest.java
@@ -140,17 +140,34 @@ public class BckndResourceGroupsPostRequest
    * Get the value of an unrecognizable property of this {@link BckndResourceGroupsPostRequest}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndResourceGroupsPostRequest has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndResourceGroupsPostRequest} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (resourceGroupId != null) declaredFields.put("resourceGroupId", resourceGroupId);
+    if (labels != null) declaredFields.put("labels", labels);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndResourcePatchBody.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndResourcePatchBody.java
@@ -104,17 +104,33 @@ public class BckndResourcePatchBody
   /**
    * Get the value of an unrecognizable property of this {@link BckndResourcePatchBody} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndResourcePatchBody has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndResourcePatchBody} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (resourcePlans != null) declaredFields.put("resourcePlans", resourcePlans);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndResourcePatchNodes.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndResourcePatchNodes.java
@@ -117,17 +117,34 @@ public class BckndResourcePatchNodes
   /**
    * Get the value of an unrecognizable property of this {@link BckndResourcePatchNodes} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndResourcePatchNodes has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndResourcePatchNodes} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (name != null) declaredFields.put("name", name);
+    if (request != null) declaredFields.put("request", request);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndResourcePatchResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndResourcePatchResponse.java
@@ -85,17 +85,33 @@ public class BckndResourcePatchResponse
    * Get the value of an unrecognizable property of this {@link BckndResourcePatchResponse}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndResourcePatchResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndResourcePatchResponse} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (message != null) declaredFields.put("message", message);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndService.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndService.java
@@ -284,16 +284,36 @@ public class BckndService
   /**
    * Get the value of an unrecognizable property of this {@link BckndService} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("BckndService has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndService} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (name != null) declaredFields.put("name", name);
+    if (description != null) declaredFields.put("description", description);
+    if (url != null) declaredFields.put("url", url);
+    if (status != null) declaredFields.put("status", status);
+    if (statusMessage != null) declaredFields.put("statusMessage", statusMessage);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndServiceBrokerSecret.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndServiceBrokerSecret.java
@@ -153,17 +153,35 @@ public class BckndServiceBrokerSecret
   /**
    * Get the value of an unrecognizable property of this {@link BckndServiceBrokerSecret} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndServiceBrokerSecret has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndServiceBrokerSecret} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (name != null) declaredFields.put("name", name);
+    if (passwordKeyRef != null) declaredFields.put("passwordKeyRef", passwordKeyRef);
+    if (usernameKeyRef != null) declaredFields.put("usernameKeyRef", usernameKeyRef);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndServiceCapabilities.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndServiceCapabilities.java
@@ -117,17 +117,34 @@ public class BckndServiceCapabilities
   /**
    * Get the value of an unrecognizable property of this {@link BckndServiceCapabilities} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndServiceCapabilities has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndServiceCapabilities} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (logs != null) declaredFields.put("logs", logs);
+    if (basic != null) declaredFields.put("basic", basic);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndServiceCapabilitiesBasic.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndServiceCapabilitiesBasic.java
@@ -208,17 +208,36 @@ public class BckndServiceCapabilitiesBasic
    * Get the value of an unrecognizable property of this {@link BckndServiceCapabilitiesBasic}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndServiceCapabilitiesBasic has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndServiceCapabilitiesBasic} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (staticDeployments != null) declaredFields.put("staticDeployments", staticDeployments);
+    if (userDeployments != null) declaredFields.put("userDeployments", userDeployments);
+    if (createExecutions != null) declaredFields.put("createExecutions", createExecutions);
+    if (multitenant != null) declaredFields.put("multitenant", multitenant);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndServiceCapabilitiesLogs.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndServiceCapabilitiesLogs.java
@@ -120,17 +120,34 @@ public class BckndServiceCapabilitiesLogs
    * Get the value of an unrecognizable property of this {@link BckndServiceCapabilitiesLogs}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndServiceCapabilitiesLogs has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndServiceCapabilitiesLogs} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (deployments != null) declaredFields.put("deployments", deployments);
+    if (executions != null) declaredFields.put("executions", executions);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndServiceList.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndServiceList.java
@@ -135,16 +135,33 @@ public class BckndServiceList
   /**
    * Get the value of an unrecognizable property of this {@link BckndServiceList} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("BckndServiceList has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndServiceList} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (count != null) declaredFields.put("count", count);
+    if (resources != null) declaredFields.put("resources", resources);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndServiceServiceCatalogItem.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndServiceServiceCatalogItem.java
@@ -126,17 +126,34 @@ public class BckndServiceServiceCatalogItem
    * Get the value of an unrecognizable property of this {@link BckndServiceServiceCatalogItem}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndServiceServiceCatalogItem has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndServiceServiceCatalogItem} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (extendCatalog != null) declaredFields.put("extendCatalog", extendCatalog);
+    if (extendCredentials != null) declaredFields.put("extendCredentials", extendCredentials);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndServiceServiceCatalogItemExtendCatalog.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndServiceServiceCatalogItemExtendCatalog.java
@@ -248,17 +248,37 @@ public class BckndServiceServiceCatalogItemExtendCatalog
    * Get the value of an unrecognizable property of this {@link
    * BckndServiceServiceCatalogItemExtendCatalog} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndServiceServiceCatalogItemExtendCatalog has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndServiceServiceCatalogItemExtendCatalog}
+   * instance including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (bindable != null) declaredFields.put("bindable", bindable);
+    if (description != null) declaredFields.put("description", description);
+    if (id != null) declaredFields.put("id", id);
+    if (name != null) declaredFields.put("name", name);
+    if (plans != null) declaredFields.put("plans", plans);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndServiceServiceCatalogItemExtendCredentials.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndServiceServiceCatalogItemExtendCredentials.java
@@ -89,17 +89,33 @@ public class BckndServiceServiceCatalogItemExtendCredentials
    * Get the value of an unrecognizable property of this {@link
    * BckndServiceServiceCatalogItemExtendCredentials} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndServiceServiceCatalogItemExtendCredentials has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndServiceServiceCatalogItemExtendCredentials}
+   * instance including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (shared != null) declaredFields.put("shared", shared);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndServiceServiceCatalogItemExtendCredentialsShared.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndServiceServiceCatalogItemExtendCredentialsShared.java
@@ -95,11 +95,13 @@ public class BckndServiceServiceCatalogItemExtendCredentialsShared
    * Get the value of an unrecognizable property of this {@link
    * BckndServiceServiceCatalogItemExtendCredentialsShared} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
@@ -108,6 +110,21 @@ public class BckndServiceServiceCatalogItemExtendCredentialsShared
               + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link
+   * BckndServiceServiceCatalogItemExtendCredentialsShared} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (serviceUrls != null) declaredFields.put("serviceUrls", serviceUrls);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndServiceServiceCatalogItemExtendCredentialsSharedServiceUrls.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndServiceServiceCatalogItemExtendCredentialsSharedServiceUrls.java
@@ -93,11 +93,13 @@ public class BckndServiceServiceCatalogItemExtendCredentialsSharedServiceUrls
    * Get the value of an unrecognizable property of this {@link
    * BckndServiceServiceCatalogItemExtendCredentialsSharedServiceUrls} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
@@ -106,6 +108,21 @@ public class BckndServiceServiceCatalogItemExtendCredentialsSharedServiceUrls
               + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link
+   * BckndServiceServiceCatalogItemExtendCredentialsSharedServiceUrls} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (AI_API_URL != null) declaredFields.put("AI_API_URL", AI_API_URL);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndServiceServicePlanItem.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndServiceServicePlanItem.java
@@ -223,17 +223,37 @@ public class BckndServiceServicePlanItem
    * Get the value of an unrecognizable property of this {@link BckndServiceServicePlanItem}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndServiceServicePlanItem has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndServiceServicePlanItem} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (description != null) declaredFields.put("description", description);
+    if (free != null) declaredFields.put("free", free);
+    if (id != null) declaredFields.put("id", id);
+    if (name != null) declaredFields.put("name", name);
+    if (metadata != null) declaredFields.put("metadata", metadata);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndServiceServicePlanItemMetadata.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndServiceServicePlanItemMetadata.java
@@ -169,17 +169,33 @@ public class BckndServiceServicePlanItemMetadata
    * Get the value of an unrecognizable property of this {@link BckndServiceServicePlanItemMetadata}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndServiceServicePlanItemMetadata has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndServiceServicePlanItemMetadata} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (supportedPlatforms != null) declaredFields.put("supportedPlatforms", supportedPlatforms);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndTenant.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndTenant.java
@@ -185,16 +185,35 @@ public class BckndTenant
   /**
    * Get the value of an unrecognizable property of this {@link BckndTenant} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("BckndTenant has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndTenant} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (tenantId != null) declaredFields.put("tenantId", tenantId);
+    if (zoneId != null) declaredFields.put("zoneId", zoneId);
+    if (realSubaccountId != null) declaredFields.put("realSubaccountId", realSubaccountId);
+    if (servicePlan != null) declaredFields.put("servicePlan", servicePlan);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndUsageResourcePlanItem.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndUsageResourcePlanItem.java
@@ -159,17 +159,36 @@ public class BckndUsageResourcePlanItem
    * Get the value of an unrecognizable property of this {@link BckndUsageResourcePlanItem}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndUsageResourcePlanItem has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndUsageResourcePlanItem} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (resourcePlanType != null) declaredFields.put("resourcePlanType", resourcePlanType);
+    if (configuredMaxReplicas != null)
+      declaredFields.put("configuredMaxReplicas", configuredMaxReplicas);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BcknddockerRegistrySecretCreationResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BcknddockerRegistrySecretCreationResponse.java
@@ -86,17 +86,33 @@ public class BcknddockerRegistrySecretCreationResponse
    * Get the value of an unrecognizable property of this {@link
    * BcknddockerRegistrySecretCreationResponse} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BcknddockerRegistrySecretCreationResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BcknddockerRegistrySecretCreationResponse}
+   * instance including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (message != null) declaredFields.put("message", message);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BcknddockerRegistrySecretDeletionResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BcknddockerRegistrySecretDeletionResponse.java
@@ -121,17 +121,34 @@ public class BcknddockerRegistrySecretDeletionResponse
    * Get the value of an unrecognizable property of this {@link
    * BcknddockerRegistrySecretDeletionResponse} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BcknddockerRegistrySecretDeletionResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BcknddockerRegistrySecretDeletionResponse}
+   * instance including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (message != null) declaredFields.put("message", message);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BcknddockerRegistrySecretModificationResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BcknddockerRegistrySecretModificationResponse.java
@@ -122,17 +122,34 @@ public class BcknddockerRegistrySecretModificationResponse
    * Get the value of an unrecognizable property of this {@link
    * BcknddockerRegistrySecretModificationResponse} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BcknddockerRegistrySecretModificationResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BcknddockerRegistrySecretModificationResponse}
+   * instance including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (message != null) declaredFields.put("message", message);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BcknddockerRegistrySecretStatus.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BcknddockerRegistrySecretStatus.java
@@ -88,17 +88,33 @@ public class BcknddockerRegistrySecretStatus
    * Get the value of an unrecognizable property of this {@link BcknddockerRegistrySecretStatus}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BcknddockerRegistrySecretStatus has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BcknddockerRegistrySecretStatus} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (name != null) declaredFields.put("name", name);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BcknddockerRegistrySecretStatusResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BcknddockerRegistrySecretStatusResponse.java
@@ -145,17 +145,34 @@ public class BcknddockerRegistrySecretStatusResponse
    * Get the value of an unrecognizable property of this {@link
    * BcknddockerRegistrySecretStatusResponse} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BcknddockerRegistrySecretStatusResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BcknddockerRegistrySecretStatusResponse}
+   * instance including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (count != null) declaredFields.put("count", count);
+    if (resources != null) declaredFields.put("resources", resources);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BcknddockerRegistrySecretWithSensitiveDataRequest.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BcknddockerRegistrySecretWithSensitiveDataRequest.java
@@ -89,11 +89,13 @@ public class BcknddockerRegistrySecretWithSensitiveDataRequest
    * Get the value of an unrecognizable property of this {@link
    * BcknddockerRegistrySecretWithSensitiveDataRequest} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
@@ -102,6 +104,20 @@ public class BcknddockerRegistrySecretWithSensitiveDataRequest
               + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link
+   * BcknddockerRegistrySecretWithSensitiveDataRequest} instance including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (data != null) declaredFields.put("data", data);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BcknddockerRegistrySecretWithSensitiveDataRequestData.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BcknddockerRegistrySecretWithSensitiveDataRequestData.java
@@ -90,11 +90,13 @@ public class BcknddockerRegistrySecretWithSensitiveDataRequestData
    * Get the value of an unrecognizable property of this {@link
    * BcknddockerRegistrySecretWithSensitiveDataRequestData} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
@@ -103,6 +105,21 @@ public class BcknddockerRegistrySecretWithSensitiveDataRequestData
               + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link
+   * BcknddockerRegistrySecretWithSensitiveDataRequestData} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (dockerconfigjson != null) declaredFields.put("dockerconfigjson", dockerconfigjson);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndobjectStoreSecretCreationResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndobjectStoreSecretCreationResponse.java
@@ -86,17 +86,33 @@ public class BckndobjectStoreSecretCreationResponse
    * Get the value of an unrecognizable property of this {@link
    * BckndobjectStoreSecretCreationResponse} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndobjectStoreSecretCreationResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndobjectStoreSecretCreationResponse} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (message != null) declaredFields.put("message", message);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndobjectStoreSecretDeletionResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndobjectStoreSecretDeletionResponse.java
@@ -121,17 +121,34 @@ public class BckndobjectStoreSecretDeletionResponse
    * Get the value of an unrecognizable property of this {@link
    * BckndobjectStoreSecretDeletionResponse} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndobjectStoreSecretDeletionResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndobjectStoreSecretDeletionResponse} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (message != null) declaredFields.put("message", message);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndobjectStoreSecretModificationResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndobjectStoreSecretModificationResponse.java
@@ -122,17 +122,34 @@ public class BckndobjectStoreSecretModificationResponse
    * Get the value of an unrecognizable property of this {@link
    * BckndobjectStoreSecretModificationResponse} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndobjectStoreSecretModificationResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndobjectStoreSecretModificationResponse}
+   * instance including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (message != null) declaredFields.put("message", message);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndobjectStoreSecretStatus.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndobjectStoreSecretStatus.java
@@ -124,17 +124,34 @@ public class BckndobjectStoreSecretStatus
    * Get the value of an unrecognizable property of this {@link BckndobjectStoreSecretStatus}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndobjectStoreSecretStatus has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndobjectStoreSecretStatus} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (metadata != null) declaredFields.put("metadata", metadata);
+    if (name != null) declaredFields.put("name", name);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndobjectStoreSecretStatusMetadata.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndobjectStoreSecretStatusMetadata.java
@@ -616,17 +616,61 @@ public class BckndobjectStoreSecretStatusMetadata
    * Get the value of an unrecognizable property of this {@link
    * BckndobjectStoreSecretStatusMetadata} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndobjectStoreSecretStatusMetadata has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndobjectStoreSecretStatusMetadata} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (servingKubeflowOrgS3Usehttps != null)
+      declaredFields.put("servingKubeflowOrgS3Usehttps", servingKubeflowOrgS3Usehttps);
+    if (servingKubeflowOrgS3Verifyssl != null)
+      declaredFields.put("servingKubeflowOrgS3Verifyssl", servingKubeflowOrgS3Verifyssl);
+    if (servingKubeflowOrgS3Endpoint != null)
+      declaredFields.put("servingKubeflowOrgS3Endpoint", servingKubeflowOrgS3Endpoint);
+    if (servingKubeflowOrgS3Region != null)
+      declaredFields.put("servingKubeflowOrgS3Region", servingKubeflowOrgS3Region);
+    if (storageAiSapComType != null) declaredFields.put("storageAiSapComType", storageAiSapComType);
+    if (storageAiSapComBucket != null)
+      declaredFields.put("storageAiSapComBucket", storageAiSapComBucket);
+    if (storageAiSapComEndpoint != null)
+      declaredFields.put("storageAiSapComEndpoint", storageAiSapComEndpoint);
+    if (storageAiSapComRegion != null)
+      declaredFields.put("storageAiSapComRegion", storageAiSapComRegion);
+    if (storageAiSapComPathPrefix != null)
+      declaredFields.put("storageAiSapComPathPrefix", storageAiSapComPathPrefix);
+    if (storageAiSapComHdfsNameNode != null)
+      declaredFields.put("storageAiSapComHdfsNameNode", storageAiSapComHdfsNameNode);
+    if (storageAiSapComHeaders != null)
+      declaredFields.put("storageAiSapComHeaders", storageAiSapComHeaders);
+    if (storageAiSapComContainerUri != null)
+      declaredFields.put("storageAiSapComContainerUri", storageAiSapComContainerUri);
+    if (storageAiSapComSubscriptionId != null)
+      declaredFields.put("storageAiSapComSubscriptionId", storageAiSapComSubscriptionId);
+    if (storageAiSapComTenantId != null)
+      declaredFields.put("storageAiSapComTenantId", storageAiSapComTenantId);
+    if (storageAiSapComProjectId != null)
+      declaredFields.put("storageAiSapComProjectId", storageAiSapComProjectId);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndobjectStoreSecretStatusResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndobjectStoreSecretStatusResponse.java
@@ -144,17 +144,34 @@ public class BckndobjectStoreSecretStatusResponse
    * Get the value of an unrecognizable property of this {@link
    * BckndobjectStoreSecretStatusResponse} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndobjectStoreSecretStatusResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndobjectStoreSecretStatusResponse} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (count != null) declaredFields.put("count", count);
+    if (resources != null) declaredFields.put("resources", resources);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndobjectStoreSecretWithSensitiveDataRequest.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndobjectStoreSecretWithSensitiveDataRequest.java
@@ -377,17 +377,41 @@ public class BckndobjectStoreSecretWithSensitiveDataRequest
    * Get the value of an unrecognizable property of this {@link
    * BckndobjectStoreSecretWithSensitiveDataRequest} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "BckndobjectStoreSecretWithSensitiveDataRequest has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link BckndobjectStoreSecretWithSensitiveDataRequest}
+   * instance including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (name != null) declaredFields.put("name", name);
+    if (type != null) declaredFields.put("type", type);
+    if (bucket != null) declaredFields.put("bucket", bucket);
+    if (endpoint != null) declaredFields.put("endpoint", endpoint);
+    if (region != null) declaredFields.put("region", region);
+    if (pathPrefix != null) declaredFields.put("pathPrefix", pathPrefix);
+    if (verifyssl != null) declaredFields.put("verifyssl", verifyssl);
+    if (usehttps != null) declaredFields.put("usehttps", usehttps);
+    if (data != null) declaredFields.put("data", data);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/BckndobjectStoreSecretWithSensitiveDataRequestForPostCall.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/BckndobjectStoreSecretWithSensitiveDataRequestForPostCall.java
@@ -405,11 +405,13 @@ public class BckndobjectStoreSecretWithSensitiveDataRequestForPostCall
    * Get the value of an unrecognizable property of this {@link
    * BckndobjectStoreSecretWithSensitiveDataRequestForPostCall} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
@@ -418,6 +420,29 @@ public class BckndobjectStoreSecretWithSensitiveDataRequestForPostCall
               + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link
+   * BckndobjectStoreSecretWithSensitiveDataRequestForPostCall} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (name != null) declaredFields.put("name", name);
+    if (type != null) declaredFields.put("type", type);
+    if (bucket != null) declaredFields.put("bucket", bucket);
+    if (endpoint != null) declaredFields.put("endpoint", endpoint);
+    if (region != null) declaredFields.put("region", region);
+    if (pathPrefix != null) declaredFields.put("pathPrefix", pathPrefix);
+    if (verifyssl != null) declaredFields.put("verifyssl", verifyssl);
+    if (usehttps != null) declaredFields.put("usehttps", usehttps);
+    if (data != null) declaredFields.put("data", data);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/DSetError.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/DSetError.java
@@ -235,16 +235,36 @@ public class DSetError
   /**
    * Get the value of an unrecognizable property of this {@link DSetError} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("DSetError has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link DSetError} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (code != null) declaredFields.put("code", code);
+    if (message != null) declaredFields.put("message", message);
+    if (target != null) declaredFields.put("target", target);
+    if (requestId != null) declaredFields.put("requestId", requestId);
+    if (details != null) declaredFields.put("details", details);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/DSetErrorDetailsInner.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/DSetErrorDetailsInner.java
@@ -117,17 +117,34 @@ public class DSetErrorDetailsInner
   /**
    * Get the value of an unrecognizable property of this {@link DSetErrorDetailsInner} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "DSetErrorDetailsInner has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link DSetErrorDetailsInner} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (code != null) declaredFields.put("code", code);
+    if (message != null) declaredFields.put("message", message);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/DSetFileCreationResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/DSetFileCreationResponse.java
@@ -117,17 +117,34 @@ public class DSetFileCreationResponse
   /**
    * Get the value of an unrecognizable property of this {@link DSetFileCreationResponse} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "DSetFileCreationResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link DSetFileCreationResponse} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (message != null) declaredFields.put("message", message);
+    if (url != null) declaredFields.put("url", url);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/InlineObject.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/InlineObject.java
@@ -83,16 +83,32 @@ public class InlineObject
   /**
    * Get the value of an unrecognizable property of this {@link InlineObject} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("InlineObject has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link InlineObject} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (error != null) declaredFields.put("error", error);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/InlineObject1.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/InlineObject1.java
@@ -83,16 +83,32 @@ public class InlineObject1
   /**
    * Get the value of an unrecognizable property of this {@link InlineObject1} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("InlineObject1 has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link InlineObject1} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (error != null) declaredFields.put("error", error);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/InlineObject2.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/InlineObject2.java
@@ -83,16 +83,32 @@ public class InlineObject2
   /**
    * Get the value of an unrecognizable property of this {@link InlineObject2} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("InlineObject2 has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link InlineObject2} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (error != null) declaredFields.put("error", error);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/InlineObject3.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/InlineObject3.java
@@ -83,16 +83,32 @@ public class InlineObject3
   /**
    * Get the value of an unrecognizable property of this {@link InlineObject3} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("InlineObject3 has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link InlineObject3} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (error != null) declaredFields.put("error", error);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/InlineObject4.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/InlineObject4.java
@@ -83,16 +83,32 @@ public class InlineObject4
   /**
    * Get the value of an unrecognizable property of this {@link InlineObject4} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("InlineObject4 has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link InlineObject4} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (error != null) declaredFields.put("error", error);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/KpiApiError.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/KpiApiError.java
@@ -219,16 +219,36 @@ public class KpiApiError
   /**
    * Get the value of an unrecognizable property of this {@link KpiApiError} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("KpiApiError has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link KpiApiError} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (code != null) declaredFields.put("code", code);
+    if (message != null) declaredFields.put("message", message);
+    if (requestId != null) declaredFields.put("requestId", requestId);
+    if (target != null) declaredFields.put("target", target);
+    if (details != null) declaredFields.put("details", details);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/KpiResultRowItem.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/KpiResultRowItem.java
@@ -48,16 +48,31 @@ public class KpiResultRowItem
   /**
    * Get the value of an unrecognizable property of this {@link KpiResultRowItem} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("KpiResultRowItem has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link KpiResultRowItem} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/KpiResultSet.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/KpiResultSet.java
@@ -114,16 +114,33 @@ public class KpiResultSet
   /**
    * Get the value of an unrecognizable property of this {@link KpiResultSet} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("KpiResultSet has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link KpiResultSet} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (header != null) declaredFields.put("header", header);
+    if (rows != null) declaredFields.put("rows", rows);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/KubesubmitV4ApplicationsCreateRequest.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/KubesubmitV4ApplicationsCreateRequest.java
@@ -231,17 +231,37 @@ public class KubesubmitV4ApplicationsCreateRequest
    * Get the value of an unrecognizable property of this {@link
    * KubesubmitV4ApplicationsCreateRequest} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "KubesubmitV4ApplicationsCreateRequest has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link KubesubmitV4ApplicationsCreateRequest} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (repositoryUrl != null) declaredFields.put("repositoryUrl", repositoryUrl);
+    if (revision != null) declaredFields.put("revision", revision);
+    if (path != null) declaredFields.put("path", path);
+    if (applicationName != null) declaredFields.put("applicationName", applicationName);
+    if (repositoryName != null) declaredFields.put("repositoryName", repositoryName);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/KubesubmitV4DockerRegistrySecretsCreateRequest.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/KubesubmitV4DockerRegistrySecretsCreateRequest.java
@@ -122,17 +122,34 @@ public class KubesubmitV4DockerRegistrySecretsCreateRequest
    * Get the value of an unrecognizable property of this {@link
    * KubesubmitV4DockerRegistrySecretsCreateRequest} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "KubesubmitV4DockerRegistrySecretsCreateRequest has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link KubesubmitV4DockerRegistrySecretsCreateRequest}
+   * instance including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (data != null) declaredFields.put("data", data);
+    if (name != null) declaredFields.put("name", name);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/MetaAPIVersion.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/MetaAPIVersion.java
@@ -151,16 +151,34 @@ public class MetaAPIVersion
   /**
    * Get the value of an unrecognizable property of this {@link MetaAPIVersion} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("MetaAPIVersion has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link MetaAPIVersion} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (versionId != null) declaredFields.put("versionId", versionId);
+    if (url != null) declaredFields.put("url", url);
+    if (description != null) declaredFields.put("description", description);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/MetaAiApi.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/MetaAiApi.java
@@ -157,16 +157,34 @@ public class MetaAiApi
   /**
    * Get the value of an unrecognizable property of this {@link MetaAiApi} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("MetaAiApi has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link MetaAiApi} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (version != null) declaredFields.put("version", version);
+    if (capabilities != null) declaredFields.put("capabilities", capabilities);
+    if (limits != null) declaredFields.put("limits", limits);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/MetaAiApiCapabilities.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/MetaAiApiCapabilities.java
@@ -380,17 +380,42 @@ public class MetaAiApiCapabilities
   /**
    * Get the value of an unrecognizable property of this {@link MetaAiApiCapabilities} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "MetaAiApiCapabilities has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link MetaAiApiCapabilities} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (multitenant != null) declaredFields.put("multitenant", multitenant);
+    if (shareable != null) declaredFields.put("shareable", shareable);
+    if (staticDeployments != null) declaredFields.put("staticDeployments", staticDeployments);
+    if (userDeployments != null) declaredFields.put("userDeployments", userDeployments);
+    if (userExecutions != null) declaredFields.put("userExecutions", userExecutions);
+    if (timeToLiveDeployments != null)
+      declaredFields.put("timeToLiveDeployments", timeToLiveDeployments);
+    if (executionSchedules != null) declaredFields.put("executionSchedules", executionSchedules);
+    if (logs != null) declaredFields.put("logs", logs);
+    if (bulkUpdates != null) declaredFields.put("bulkUpdates", bulkUpdates);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/MetaAiApiCapabilitiesBulkUpdates.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/MetaAiApiCapabilitiesBulkUpdates.java
@@ -123,17 +123,34 @@ public class MetaAiApiCapabilitiesBulkUpdates
    * Get the value of an unrecognizable property of this {@link MetaAiApiCapabilitiesBulkUpdates}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "MetaAiApiCapabilitiesBulkUpdates has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link MetaAiApiCapabilitiesBulkUpdates} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (executions != null) declaredFields.put("executions", executions);
+    if (deployments != null) declaredFields.put("deployments", deployments);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/MetaAiApiCapabilitiesLogs.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/MetaAiApiCapabilitiesLogs.java
@@ -119,17 +119,34 @@ public class MetaAiApiCapabilitiesLogs
   /**
    * Get the value of an unrecognizable property of this {@link MetaAiApiCapabilitiesLogs} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "MetaAiApiCapabilitiesLogs has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link MetaAiApiCapabilitiesLogs} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (executions != null) declaredFields.put("executions", executions);
+    if (deployments != null) declaredFields.put("deployments", deployments);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/MetaAiApiLimits.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/MetaAiApiLimits.java
@@ -155,16 +155,35 @@ public class MetaAiApiLimits
   /**
    * Get the value of an unrecognizable property of this {@link MetaAiApiLimits} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("MetaAiApiLimits has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link MetaAiApiLimits} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (executions != null) declaredFields.put("executions", executions);
+    if (deployments != null) declaredFields.put("deployments", deployments);
+    if (timeToLiveDeployments != null)
+      declaredFields.put("timeToLiveDeployments", timeToLiveDeployments);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/MetaAiApiLimitsDeployments.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/MetaAiApiLimitsDeployments.java
@@ -88,17 +88,33 @@ public class MetaAiApiLimitsDeployments
    * Get the value of an unrecognizable property of this {@link MetaAiApiLimitsDeployments}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "MetaAiApiLimitsDeployments has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link MetaAiApiLimitsDeployments} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (maxRunningCount != null) declaredFields.put("maxRunningCount", maxRunningCount);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/MetaAiApiLimitsExecutions.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/MetaAiApiLimitsExecutions.java
@@ -86,17 +86,33 @@ public class MetaAiApiLimitsExecutions
   /**
    * Get the value of an unrecognizable property of this {@link MetaAiApiLimitsExecutions} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "MetaAiApiLimitsExecutions has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link MetaAiApiLimitsExecutions} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (maxRunningCount != null) declaredFields.put("maxRunningCount", maxRunningCount);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/MetaAiApiLimitsTimeToLiveDeployments.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/MetaAiApiLimitsTimeToLiveDeployments.java
@@ -121,17 +121,34 @@ public class MetaAiApiLimitsTimeToLiveDeployments
    * Get the value of an unrecognizable property of this {@link
    * MetaAiApiLimitsTimeToLiveDeployments} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "MetaAiApiLimitsTimeToLiveDeployments has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link MetaAiApiLimitsTimeToLiveDeployments} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (minimum != null) declaredFields.put("minimum", minimum);
+    if (maximum != null) declaredFields.put("maximum", maximum);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/MetaApiError.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/MetaApiError.java
@@ -219,16 +219,36 @@ public class MetaApiError
   /**
    * Get the value of an unrecognizable property of this {@link MetaApiError} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("MetaApiError has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link MetaApiError} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (code != null) declaredFields.put("code", code);
+    if (message != null) declaredFields.put("message", message);
+    if (requestId != null) declaredFields.put("requestId", requestId);
+    if (target != null) declaredFields.put("target", target);
+    if (details != null) declaredFields.put("details", details);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/MetaCapabilities.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/MetaCapabilities.java
@@ -221,16 +221,36 @@ public class MetaCapabilities
   /**
    * Get the value of an unrecognizable property of this {@link MetaCapabilities} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("MetaCapabilities has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link MetaCapabilities} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (runtimeIdentifier != null) declaredFields.put("runtimeIdentifier", runtimeIdentifier);
+    if (runtimeApiVersion != null) declaredFields.put("runtimeApiVersion", runtimeApiVersion);
+    if (description != null) declaredFields.put("description", description);
+    if (aiApi != null) declaredFields.put("aiApi", aiApi);
+    if (extensions != null) declaredFields.put("extensions", extensions);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/MetaExtensions.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/MetaExtensions.java
@@ -185,16 +185,35 @@ public class MetaExtensions
   /**
    * Get the value of an unrecognizable property of this {@link MetaExtensions} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("MetaExtensions has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link MetaExtensions} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (analytics != null) declaredFields.put("analytics", analytics);
+    if (resourceGroups != null) declaredFields.put("resourceGroups", resourceGroups);
+    if (dataset != null) declaredFields.put("dataset", dataset);
+    if (metrics != null) declaredFields.put("metrics", metrics);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/MetaExtensionsAnalytics.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/MetaExtensionsAnalytics.java
@@ -83,17 +83,33 @@ public class MetaExtensionsAnalytics
   /**
    * Get the value of an unrecognizable property of this {@link MetaExtensionsAnalytics} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "MetaExtensionsAnalytics has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link MetaExtensionsAnalytics} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (version != null) declaredFields.put("version", version);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/MetaExtensionsDataset.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/MetaExtensionsDataset.java
@@ -153,17 +153,35 @@ public class MetaExtensionsDataset
   /**
    * Get the value of an unrecognizable property of this {@link MetaExtensionsDataset} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "MetaExtensionsDataset has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link MetaExtensionsDataset} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (version != null) declaredFields.put("version", version);
+    if (capabilities != null) declaredFields.put("capabilities", capabilities);
+    if (limits != null) declaredFields.put("limits", limits);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/MetaExtensionsDatasetCapabilities.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/MetaExtensionsDatasetCapabilities.java
@@ -156,17 +156,35 @@ public class MetaExtensionsDatasetCapabilities
    * Get the value of an unrecognizable property of this {@link MetaExtensionsDatasetCapabilities}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "MetaExtensionsDatasetCapabilities has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link MetaExtensionsDatasetCapabilities} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (upload != null) declaredFields.put("upload", upload);
+    if (download != null) declaredFields.put("download", download);
+    if (delete != null) declaredFields.put("delete", delete);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/MetaExtensionsDatasetLimits.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/MetaExtensionsDatasetLimits.java
@@ -182,17 +182,36 @@ public class MetaExtensionsDatasetLimits
    * Get the value of an unrecognizable property of this {@link MetaExtensionsDatasetLimits}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "MetaExtensionsDatasetLimits has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link MetaExtensionsDatasetLimits} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (maxUploadFileSize != null) declaredFields.put("maxUploadFileSize", maxUploadFileSize);
+    if (maxFilesPerDataset != null) declaredFields.put("maxFilesPerDataset", maxFilesPerDataset);
+    if (acceptedContentTypes != null)
+      declaredFields.put("acceptedContentTypes", acceptedContentTypes);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/MetaExtensionsMetrics.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/MetaExtensionsMetrics.java
@@ -119,17 +119,34 @@ public class MetaExtensionsMetrics
   /**
    * Get the value of an unrecognizable property of this {@link MetaExtensionsMetrics} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "MetaExtensionsMetrics has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link MetaExtensionsMetrics} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (version != null) declaredFields.put("version", version);
+    if (capabilities != null) declaredFields.put("capabilities", capabilities);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/MetaExtensionsMetricsCapabilities.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/MetaExtensionsMetricsCapabilities.java
@@ -88,17 +88,33 @@ public class MetaExtensionsMetricsCapabilities
    * Get the value of an unrecognizable property of this {@link MetaExtensionsMetricsCapabilities}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "MetaExtensionsMetricsCapabilities has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link MetaExtensionsMetricsCapabilities} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (extendedResults != null) declaredFields.put("extendedResults", extendedResults);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/RTAArtifact.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/RTAArtifact.java
@@ -375,16 +375,38 @@ public class RTAArtifact
   /**
    * Get the value of an unrecognizable property of this {@link RTAArtifact} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("RTAArtifact has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link RTAArtifact} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (name != null) declaredFields.put("name", name);
+    if (executionId != null) declaredFields.put("executionId", executionId);
+    if (url != null) declaredFields.put("url", url);
+    if (signature != null) declaredFields.put("signature", signature);
+    if (kind != null) declaredFields.put("kind", kind);
+    if (labels != null) declaredFields.put("labels", labels);
+    if (createdAt != null) declaredFields.put("createdAt", createdAt);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/RTAArtifactLabel.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/RTAArtifactLabel.java
@@ -117,16 +117,33 @@ public class RTAArtifactLabel
   /**
    * Get the value of an unrecognizable property of this {@link RTAArtifactLabel} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("RTAArtifactLabel has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link RTAArtifactLabel} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (key != null) declaredFields.put("key", key);
+    if (value != null) declaredFields.put("value", value);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/RTABackendDetails.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/RTABackendDetails.java
@@ -83,16 +83,32 @@ public class RTABackendDetails
   /**
    * Get the value of an unrecognizable property of this {@link RTABackendDetails} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("RTABackendDetails has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link RTABackendDetails} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (backendDetails != null) declaredFields.put("backendDetails", backendDetails);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/RTADeployment.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/RTADeployment.java
@@ -605,16 +605,44 @@ public class RTADeployment
   /**
    * Get the value of an unrecognizable property of this {@link RTADeployment} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("RTADeployment has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link RTADeployment} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (scenarioId != null) declaredFields.put("scenarioId", scenarioId);
+    if (executableId != null) declaredFields.put("executableId", executableId);
+    if (id != null) declaredFields.put("id", id);
+    if (deploymentUrl != null) declaredFields.put("deploymentUrl", deploymentUrl);
+    if (latestRunningTargetId != null)
+      declaredFields.put("latestRunningTargetId", latestRunningTargetId);
+    if (targetId != null) declaredFields.put("targetId", targetId);
+    if (ttl != null) declaredFields.put("ttl", ttl);
+    if (status != null) declaredFields.put("status", status);
+    if (statusMessage != null) declaredFields.put("statusMessage", statusMessage);
+    if (lastOperation != null) declaredFields.put("lastOperation", lastOperation);
+    if (createdAt != null) declaredFields.put("createdAt", createdAt);
+    if (modifiedAt != null) declaredFields.put("modifiedAt", modifiedAt);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/RTADeploymentDetails.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/RTADeploymentDetails.java
@@ -117,17 +117,34 @@ public class RTADeploymentDetails
   /**
    * Get the value of an unrecognizable property of this {@link RTADeploymentDetails} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "RTADeploymentDetails has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link RTADeploymentDetails} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (scaling != null) declaredFields.put("scaling", scaling);
+    if (resources != null) declaredFields.put("resources", resources);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/RTAError.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/RTAError.java
@@ -219,16 +219,36 @@ public class RTAError
   /**
    * Get the value of an unrecognizable property of this {@link RTAError} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("RTAError has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link RTAError} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (code != null) declaredFields.put("code", code);
+    if (message != null) declaredFields.put("message", message);
+    if (requestId != null) declaredFields.put("requestId", requestId);
+    if (target != null) declaredFields.put("target", target);
+    if (details != null) declaredFields.put("details", details);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/RTAErrorResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/RTAErrorResponse.java
@@ -83,16 +83,32 @@ public class RTAErrorResponse
   /**
    * Get the value of an unrecognizable property of this {@link RTAErrorResponse} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("RTAErrorResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link RTAErrorResponse} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (error != null) declaredFields.put("error", error);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/RTAExecutable.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/RTAExecutable.java
@@ -494,16 +494,42 @@ public class RTAExecutable
   /**
    * Get the value of an unrecognizable property of this {@link RTAExecutable} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("RTAExecutable has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link RTAExecutable} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (name != null) declaredFields.put("name", name);
+    if (description != null) declaredFields.put("description", description);
+    if (scenarioId != null) declaredFields.put("scenarioId", scenarioId);
+    if (inputArtifacts != null) declaredFields.put("inputArtifacts", inputArtifacts);
+    if (outputArtifacts != null) declaredFields.put("outputArtifacts", outputArtifacts);
+    if (parameters != null) declaredFields.put("parameters", parameters);
+    if (deployable != null) declaredFields.put("deployable", deployable);
+    if (labels != null) declaredFields.put("labels", labels);
+    if (createdAt != null) declaredFields.put("createdAt", createdAt);
+    if (modifiedAt != null) declaredFields.put("modifiedAt", modifiedAt);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/RTAExecutableArgumentBinding.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/RTAExecutableArgumentBinding.java
@@ -119,17 +119,34 @@ public class RTAExecutableArgumentBinding
    * Get the value of an unrecognizable property of this {@link RTAExecutableArgumentBinding}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "RTAExecutableArgumentBinding has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link RTAExecutableArgumentBinding} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (key != null) declaredFields.put("key", key);
+    if (value != null) declaredFields.put("value", value);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/RTAExecutableArtifact.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/RTAExecutableArtifact.java
@@ -203,17 +203,36 @@ public class RTAExecutableArtifact
   /**
    * Get the value of an unrecognizable property of this {@link RTAExecutableArtifact} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "RTAExecutableArtifact has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link RTAExecutableArtifact} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (name != null) declaredFields.put("name", name);
+    if (description != null) declaredFields.put("description", description);
+    if (kind != null) declaredFields.put("kind", kind);
+    if (labels != null) declaredFields.put("labels", labels);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/RTAExecutableParameter.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/RTAExecutableParameter.java
@@ -242,17 +242,36 @@ public class RTAExecutableParameter
   /**
    * Get the value of an unrecognizable property of this {@link RTAExecutableParameter} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "RTAExecutableParameter has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link RTAExecutableParameter} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (name != null) declaredFields.put("name", name);
+    if (description != null) declaredFields.put("description", description);
+    if (_default != null) declaredFields.put("_default", _default);
+    if (type != null) declaredFields.put("type", type);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/RTAExecution.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/RTAExecution.java
@@ -464,16 +464,41 @@ public class RTAExecution
   /**
    * Get the value of an unrecognizable property of this {@link RTAExecution} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("RTAExecution has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link RTAExecution} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (scenarioId != null) declaredFields.put("scenarioId", scenarioId);
+    if (executableId != null) declaredFields.put("executableId", executableId);
+    if (id != null) declaredFields.put("id", id);
+    if (status != null) declaredFields.put("status", status);
+    if (statusMessage != null) declaredFields.put("statusMessage", statusMessage);
+    if (submissionTimestamp != null) declaredFields.put("submissionTimestamp", submissionTimestamp);
+    if (startTimestamp != null) declaredFields.put("startTimestamp", startTimestamp);
+    if (finishTimestamp != null) declaredFields.put("finishTimestamp", finishTimestamp);
+    if (createdAt != null) declaredFields.put("createdAt", createdAt);
+    if (modifiedAt != null) declaredFields.put("modifiedAt", modifiedAt);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/RTAInputArtifactArgumentBinding.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/RTAInputArtifactArgumentBinding.java
@@ -160,17 +160,35 @@ public class RTAInputArtifactArgumentBinding
    * Get the value of an unrecognizable property of this {@link RTAInputArtifactArgumentBinding}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "RTAInputArtifactArgumentBinding has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link RTAInputArtifactArgumentBinding} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (name != null) declaredFields.put("name", name);
+    if (url != null) declaredFields.put("url", url);
+    if (signature != null) declaredFields.put("signature", signature);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/RTALabel.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/RTALabel.java
@@ -117,16 +117,33 @@ public class RTALabel
   /**
    * Get the value of an unrecognizable property of this {@link RTALabel} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("RTALabel has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link RTALabel} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (key != null) declaredFields.put("key", key);
+    if (value != null) declaredFields.put("value", value);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/RTALogCommonData.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/RTALogCommonData.java
@@ -100,16 +100,32 @@ public class RTALogCommonData
   /**
    * Get the value of an unrecognizable property of this {@link RTALogCommonData} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("RTALogCommonData has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link RTALogCommonData} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (result != null) declaredFields.put("result", result);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/RTALogCommonResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/RTALogCommonResponse.java
@@ -83,17 +83,33 @@ public class RTALogCommonResponse
   /**
    * Get the value of an unrecognizable property of this {@link RTALogCommonResponse} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "RTALogCommonResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link RTALogCommonResponse} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (data != null) declaredFields.put("data", data);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/RTALogCommonResultItem.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/RTALogCommonResultItem.java
@@ -118,17 +118,34 @@ public class RTALogCommonResultItem
   /**
    * Get the value of an unrecognizable property of this {@link RTALogCommonResultItem} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "RTALogCommonResultItem has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link RTALogCommonResultItem} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (timestamp != null) declaredFields.put("timestamp", timestamp);
+    if (msg != null) declaredFields.put("msg", msg);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/RTAModelBaseData.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/RTAModelBaseData.java
@@ -305,16 +305,38 @@ public class RTAModelBaseData
   /**
    * Get the value of an unrecognizable property of this {@link RTAModelBaseData} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("RTAModelBaseData has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link RTAModelBaseData} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (model != null) declaredFields.put("model", model);
+    if (executableId != null) declaredFields.put("executableId", executableId);
+    if (description != null) declaredFields.put("description", description);
+    if (versions != null) declaredFields.put("versions", versions);
+    if (displayName != null) declaredFields.put("displayName", displayName);
+    if (accessType != null) declaredFields.put("accessType", accessType);
+    if (provider != null) declaredFields.put("provider", provider);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/RTAModelVersion.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/RTAModelVersion.java
@@ -472,16 +472,42 @@ public class RTAModelVersion
   /**
    * Get the value of an unrecognizable property of this {@link RTAModelVersion} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("RTAModelVersion has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link RTAModelVersion} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (name != null) declaredFields.put("name", name);
+    if (isLatest != null) declaredFields.put("isLatest", isLatest);
+    if (deprecated != null) declaredFields.put("deprecated", deprecated);
+    if (retirementDate != null) declaredFields.put("retirementDate", retirementDate);
+    if (contextLength != null) declaredFields.put("contextLength", contextLength);
+    if (inputTypes != null) declaredFields.put("inputTypes", inputTypes);
+    if (capabilities != null) declaredFields.put("capabilities", capabilities);
+    if (metadata != null) declaredFields.put("metadata", metadata);
+    if (cost != null) declaredFields.put("cost", cost);
+    if (suggestedReplacements != null)
+      declaredFields.put("suggestedReplacements", suggestedReplacements);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/RTAOutputArtifactArgumentBinding.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/RTAOutputArtifactArgumentBinding.java
@@ -125,17 +125,34 @@ public class RTAOutputArtifactArgumentBinding
    * Get the value of an unrecognizable property of this {@link RTAOutputArtifactArgumentBinding}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "RTAOutputArtifactArgumentBinding has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link RTAOutputArtifactArgumentBinding} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (name != null) declaredFields.put("name", name);
+    if (url != null) declaredFields.put("url", url);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/RTAScenario.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/RTAScenario.java
@@ -271,16 +271,37 @@ public class RTAScenario
   /**
    * Get the value of an unrecognizable property of this {@link RTAScenario} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("RTAScenario has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link RTAScenario} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (name != null) declaredFields.put("name", name);
+    if (description != null) declaredFields.put("description", description);
+    if (labels != null) declaredFields.put("labels", labels);
+    if (createdAt != null) declaredFields.put("createdAt", createdAt);
+    if (modifiedAt != null) declaredFields.put("modifiedAt", modifiedAt);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/TrckApiError.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/TrckApiError.java
@@ -236,16 +236,36 @@ public class TrckApiError
   /**
    * Get the value of an unrecognizable property of this {@link TrckApiError} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("TrckApiError has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link TrckApiError} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (code != null) declaredFields.put("code", code);
+    if (message != null) declaredFields.put("message", message);
+    if (requestId != null) declaredFields.put("requestId", requestId);
+    if (target != null) declaredFields.put("target", target);
+    if (details != null) declaredFields.put("details", details);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/TrckCustomInfoObject.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/TrckCustomInfoObject.java
@@ -120,17 +120,34 @@ public class TrckCustomInfoObject
   /**
    * Get the value of an unrecognizable property of this {@link TrckCustomInfoObject} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "TrckCustomInfoObject has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link TrckCustomInfoObject} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (name != null) declaredFields.put("name", name);
+    if (value != null) declaredFields.put("value", value);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/TrckDeleteMetricsResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/TrckDeleteMetricsResponse.java
@@ -118,17 +118,34 @@ public class TrckDeleteMetricsResponse
   /**
    * Get the value of an unrecognizable property of this {@link TrckDeleteMetricsResponse} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "TrckDeleteMetricsResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link TrckDeleteMetricsResponse} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (message != null) declaredFields.put("message", message);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/TrckDetailsErrorResponse.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/TrckDetailsErrorResponse.java
@@ -117,17 +117,34 @@ public class TrckDetailsErrorResponse
   /**
    * Get the value of an unrecognizable property of this {@link TrckDetailsErrorResponse} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "TrckDetailsErrorResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link TrckDetailsErrorResponse} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (code != null) declaredFields.put("code", code);
+    if (message != null) declaredFields.put("message", message);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/TrckExecutionId.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/TrckExecutionId.java
@@ -48,16 +48,31 @@ public class TrckExecutionId
   /**
    * Get the value of an unrecognizable property of this {@link TrckExecutionId} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("TrckExecutionId has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link TrckExecutionId} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/TrckGetMetric.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/TrckGetMetric.java
@@ -244,16 +244,36 @@ public class TrckGetMetric
   /**
    * Get the value of an unrecognizable property of this {@link TrckGetMetric} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("TrckGetMetric has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link TrckGetMetric} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (name != null) declaredFields.put("name", name);
+    if (value != null) declaredFields.put("value", value);
+    if (timestamp != null) declaredFields.put("timestamp", timestamp);
+    if (step != null) declaredFields.put("step", step);
+    if (labels != null) declaredFields.put("labels", labels);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/TrckGetMetricResource.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/TrckGetMetricResource.java
@@ -234,17 +234,36 @@ public class TrckGetMetricResource
   /**
    * Get the value of an unrecognizable property of this {@link TrckGetMetricResource} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "TrckGetMetricResource has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link TrckGetMetricResource} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (executionId != null) declaredFields.put("executionId", executionId);
+    if (metrics != null) declaredFields.put("metrics", metrics);
+    if (tags != null) declaredFields.put("tags", tags);
+    if (customInfo != null) declaredFields.put("customInfo", customInfo);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/TrckGetMetricResourceList.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/TrckGetMetricResourceList.java
@@ -137,17 +137,34 @@ public class TrckGetMetricResourceList
   /**
    * Get the value of an unrecognizable property of this {@link TrckGetMetricResourceList} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "TrckGetMetricResourceList has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link TrckGetMetricResourceList} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (count != null) declaredFields.put("count", count);
+    if (resources != null) declaredFields.put("resources", resources);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/TrckLabel.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/TrckLabel.java
@@ -122,16 +122,33 @@ public class TrckLabel
   /**
    * Get the value of an unrecognizable property of this {@link TrckLabel} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("TrckLabel has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link TrckLabel} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (name != null) declaredFields.put("name", name);
+    if (value != null) declaredFields.put("value", value);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/TrckMetric.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/TrckMetric.java
@@ -244,16 +244,36 @@ public class TrckMetric
   /**
    * Get the value of an unrecognizable property of this {@link TrckMetric} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("TrckMetric has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link TrckMetric} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (name != null) declaredFields.put("name", name);
+    if (value != null) declaredFields.put("value", value);
+    if (timestamp != null) declaredFields.put("timestamp", timestamp);
+    if (step != null) declaredFields.put("step", step);
+    if (labels != null) declaredFields.put("labels", labels);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/TrckMetricResource.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/TrckMetricResource.java
@@ -232,16 +232,35 @@ public class TrckMetricResource
   /**
    * Get the value of an unrecognizable property of this {@link TrckMetricResource} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("TrckMetricResource has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link TrckMetricResource} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (executionId != null) declaredFields.put("executionId", executionId);
+    if (metrics != null) declaredFields.put("metrics", metrics);
+    if (tags != null) declaredFields.put("tags", tags);
+    if (customInfo != null) declaredFields.put("customInfo", customInfo);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/TrckTag.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/TrckTag.java
@@ -117,16 +117,33 @@ public class TrckTag
   /**
    * Get the value of an unrecognizable property of this {@link TrckTag} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("TrckTag has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link TrckTag} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (name != null) declaredFields.put("name", name);
+    if (value != null) declaredFields.put("value", value);
+    return declaredFields;
   }
 
   /**

--- a/core/src/main/java/com/sap/ai/sdk/core/model/TrckTagName.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/model/TrckTagName.java
@@ -48,16 +48,31 @@ public class TrckTagName
   /**
    * Get the value of an unrecognizable property of this {@link TrckTagName} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("TrckTagName has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link TrckTagName} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    return declaredFields;
   }
 
   /**

--- a/core/src/test/java/com/sap/ai/sdk/core/client/DeploymentUnitTest.java
+++ b/core/src/test/java/com/sap/ai/sdk/core/client/DeploymentUnitTest.java
@@ -220,7 +220,7 @@ class DeploymentUnitTest extends WireMockTestServer {
     assertThat(deployment).isNotNull();
     assertThat(deployment.getId()).isEqualTo("d5b764fe55b3e87c");
     // targetStatus is not in the generated client
-    assertThat(deployment.getCustomField("targetStatus")).isEqualTo("DELETED");
+    assertThat(deployment.toMap().get("targetStatus")).isEqualTo("DELETED");
   }
 
   @Test
@@ -271,10 +271,10 @@ class DeploymentUnitTest extends WireMockTestServer {
         .isEqualTo(
             "https://api.ai.intprod-eu12.eu-central-1.aws.ml.hana.ondemand.com/v2/inference/deployments/db1d64d9f06be467");
     assertThat(deployment.getDetails().getResources().getBackendDetails()).isEqualTo(Map.of());
-    assertThat(deployment.getDetails().getResources().getCustomField("backend_details"))
+    assertThat(deployment.getDetails().getResources().toMap().get("backend_details"))
         .isEqualTo(Map.of());
     assertThat(deployment.getDetails().getScaling().getBackendDetails()).isEqualTo(Map.of());
-    assertThat(deployment.getDetails().getScaling().getCustomField("backend_details"))
+    assertThat(deployment.getDetails().getScaling().toMap().get("backend_details"))
         .isEqualTo(Map.of());
     assertThat(deployment.getId()).isEqualTo("db1d64d9f06be467");
     assertThat(deployment.getLastOperation())
@@ -383,8 +383,8 @@ class DeploymentUnitTest extends WireMockTestServer {
         .isEqualTo(
             "INFO:root:Copying contents of s3://hcp-8b6797d5-fc66-4fde-bdcf-0800987e1837/i749902/e529e8bd58740bc9/classifier-model-output to local");
     // `container` and `pod` are not defined in spec
-    assertThat(rtaLogCommonResultItem.getCustomField("container")).isEqualTo("storage-initializer");
-    assertThat(rtaLogCommonResultItem.getCustomField("pod"))
+    assertThat(rtaLogCommonResultItem.toMap().get("container")).isEqualTo("storage-initializer");
+    assertThat(rtaLogCommonResultItem.toMap().get("pod"))
         .isEqualTo("d058d4774af7edfb-predictor-00001-deployment-74fbb96d88-bqlqb");
   }
 

--- a/core/src/test/java/com/sap/ai/sdk/core/client/ExecutionUnitTest.java
+++ b/core/src/test/java/com/sap/ai/sdk/core/client/ExecutionUnitTest.java
@@ -136,7 +136,7 @@ class ExecutionUnitTest extends WireMockTestServer {
     assertThat(execution).isNotNull();
     assertThat(execution.getId()).isEqualTo("eab289226fe981da");
     assertThat(execution.getMessage()).isEqualTo("AiExecution acknowledged");
-    assertThat(execution.getCustomField("url")).isEqualTo("ai://default/eab289226fe981da");
+    assertThat(execution.toMap().get("url")).isEqualTo("ai://default/eab289226fe981da");
 
     wireMockServer.verify(
         postRequestedFor(urlPathEqualTo("/v2/lm/executions"))
@@ -246,7 +246,7 @@ class ExecutionUnitTest extends WireMockTestServer {
     assertThat(execution.getId()).isEqualTo("e529e8bd58740bc9");
     assertThat(execution.getMessage()).isEqualTo("Deletion scheduled");
     // targetStatus is not in the generated client.
-    assertThat(execution.getCustomField("targetStatus")).isEqualTo("DELETED");
+    assertThat(execution.toMap().get("targetStatus")).isEqualTo("DELETED");
   }
 
   @Test
@@ -339,8 +339,8 @@ class ExecutionUnitTest extends WireMockTestServer {
         .isEqualTo(
             "time=\"2024-09-18T13:19:40.527Z\" level=info msg=\"Starting Workflow Executor\" version=v3.5.4+960af33.dirty");
     // `container` and `pod` properties are not defined in spec.
-    assertThat(rtaLogCommonResultItem.getCustomField("container")).isEqualTo("init");
-    assertThat(rtaLogCommonResultItem.getCustomField("pod")).isEqualTo("ee467bea5af28adb");
+    assertThat(rtaLogCommonResultItem.toMap().get("container")).isEqualTo("init");
+    assertThat(rtaLogCommonResultItem.toMap().get("pod")).isEqualTo("ee467bea5af28adb");
   }
 
   @Test

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationChatCompletionDelta.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationChatCompletionDelta.java
@@ -25,7 +25,7 @@ public class OrchestrationChatCompletionDelta extends CompletionPostResponse
         // A delta only contains one choice with a variable index
         && choices.get(0).getIndex() == 0) {
 
-      final var message = (Map<String, Object>) choices.get(0).getCustomField("delta");
+      final var message = (Map<String, Object>) choices.get(0).toMap().get("delta");
       // Avoid the second delta: "choices":[{"delta":{"content":"","role":"assistant"}}]
       if (message != null && message.get("content") != null) {
         return message.get("content").toString();

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/AzureContentSafety.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/AzureContentSafety.java
@@ -185,16 +185,35 @@ public class AzureContentSafety
   /**
    * Get the value of an unrecognizable property of this {@link AzureContentSafety} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("AzureContentSafety has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AzureContentSafety} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (hate != null) declaredFields.put("hate", hate);
+    if (selfHarm != null) declaredFields.put("selfHarm", selfHarm);
+    if (sexual != null) declaredFields.put("sexual", sexual);
+    if (violence != null) declaredFields.put("violence", violence);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/AzureContentSafetyFilterConfig.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/AzureContentSafetyFilterConfig.java
@@ -176,17 +176,34 @@ public class AzureContentSafetyFilterConfig implements FilterConfig
    * Get the value of an unrecognizable property of this {@link AzureContentSafetyFilterConfig}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "AzureContentSafetyFilterConfig has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link AzureContentSafetyFilterConfig} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (type != null) declaredFields.put("type", type);
+    if (config != null) declaredFields.put("config", config);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ChatCompletionTool.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ChatCompletionTool.java
@@ -173,16 +173,33 @@ public class ChatCompletionTool
   /**
    * Get the value of an unrecognizable property of this {@link ChatCompletionTool} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("ChatCompletionTool has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link ChatCompletionTool} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (type != null) declaredFields.put("type", type);
+    if (function != null) declaredFields.put("function", function);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ChatDelta.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ChatDelta.java
@@ -202,16 +202,35 @@ public class ChatDelta
   /**
    * Get the value of an unrecognizable property of this {@link ChatDelta} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("ChatDelta has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link ChatDelta} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (role != null) declaredFields.put("role", role);
+    if (content != null) declaredFields.put("content", content);
+    if (refusal != null) declaredFields.put("refusal", refusal);
+    if (toolCalls != null) declaredFields.put("toolCalls", toolCalls);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/CompletionPostRequest.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/CompletionPostRequest.java
@@ -195,17 +195,35 @@ public class CompletionPostRequest
   /**
    * Get the value of an unrecognizable property of this {@link CompletionPostRequest} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "CompletionPostRequest has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link CompletionPostRequest} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (orchestrationConfig != null) declaredFields.put("orchestrationConfig", orchestrationConfig);
+    if (inputParams != null) declaredFields.put("inputParams", inputParams);
+    if (messagesHistory != null) declaredFields.put("messagesHistory", messagesHistory);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/CompletionPostResponse.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/CompletionPostResponse.java
@@ -155,17 +155,35 @@ public class CompletionPostResponse
   /**
    * Get the value of an unrecognizable property of this {@link CompletionPostResponse} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "CompletionPostResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link CompletionPostResponse} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (requestId != null) declaredFields.put("requestId", requestId);
+    if (moduleResults != null) declaredFields.put("moduleResults", moduleResults);
+    if (orchestrationResult != null) declaredFields.put("orchestrationResult", orchestrationResult);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/CompletionPostResponseStreaming.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/CompletionPostResponseStreaming.java
@@ -161,17 +161,35 @@ public class CompletionPostResponseStreaming
    * Get the value of an unrecognizable property of this {@link CompletionPostResponseStreaming}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "CompletionPostResponseStreaming has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link CompletionPostResponseStreaming} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (requestId != null) declaredFields.put("requestId", requestId);
+    if (moduleResults != null) declaredFields.put("moduleResults", moduleResults);
+    if (orchestrationResult != null) declaredFields.put("orchestrationResult", orchestrationResult);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/DPIConfig.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/DPIConfig.java
@@ -367,16 +367,36 @@ public class DPIConfig implements MaskingProviderConfig
   /**
    * Get the value of an unrecognizable property of this {@link DPIConfig} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("DPIConfig has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link DPIConfig} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (type != null) declaredFields.put("type", type);
+    if (method != null) declaredFields.put("method", method);
+    if (entities != null) declaredFields.put("entities", entities);
+    if (allowlist != null) declaredFields.put("allowlist", allowlist);
+    if (maskGroundingInput != null) declaredFields.put("maskGroundingInput", maskGroundingInput);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/DPIConfigMaskGroundingInput.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/DPIConfigMaskGroundingInput.java
@@ -88,17 +88,33 @@ public class DPIConfigMaskGroundingInput
    * Get the value of an unrecognizable property of this {@link DPIConfigMaskGroundingInput}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "DPIConfigMaskGroundingInput has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link DPIConfigMaskGroundingInput} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (enabled != null) declaredFields.put("enabled", enabled);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/DPIEntityConfig.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/DPIEntityConfig.java
@@ -83,16 +83,32 @@ public class DPIEntityConfig
   /**
    * Get the value of an unrecognizable property of this {@link DPIEntityConfig} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("DPIEntityConfig has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link DPIEntityConfig} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (type != null) declaredFields.put("type", type);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/DocumentGroundingFilter.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/DocumentGroundingFilter.java
@@ -379,17 +379,40 @@ public class DocumentGroundingFilter implements GroundingModuleConfigConfigFilte
   /**
    * Get the value of an unrecognizable property of this {@link DocumentGroundingFilter} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "DocumentGroundingFilter has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link DocumentGroundingFilter} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (searchConfig != null) declaredFields.put("searchConfig", searchConfig);
+    if (dataRepositories != null) declaredFields.put("dataRepositories", dataRepositories);
+    if (dataRepositoryType != null) declaredFields.put("dataRepositoryType", dataRepositoryType);
+    if (dataRepositoryMetadata != null)
+      declaredFields.put("dataRepositoryMetadata", dataRepositoryMetadata);
+    if (documentMetadata != null) declaredFields.put("documentMetadata", documentMetadata);
+    if (chunkMetadata != null) declaredFields.put("chunkMetadata", chunkMetadata);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ErrorResponse.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ErrorResponse.java
@@ -219,16 +219,36 @@ public class ErrorResponse
   /**
    * Get the value of an unrecognizable property of this {@link ErrorResponse} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("ErrorResponse has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link ErrorResponse} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (requestId != null) declaredFields.put("requestId", requestId);
+    if (code != null) declaredFields.put("code", code);
+    if (message != null) declaredFields.put("message", message);
+    if (location != null) declaredFields.put("location", location);
+    if (moduleResults != null) declaredFields.put("moduleResults", moduleResults);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/FilteringModuleConfig.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/FilteringModuleConfig.java
@@ -117,17 +117,34 @@ public class FilteringModuleConfig
   /**
    * Get the value of an unrecognizable property of this {@link FilteringModuleConfig} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "FilteringModuleConfig has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link FilteringModuleConfig} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (input != null) declaredFields.put("input", input);
+    if (output != null) declaredFields.put("output", output);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/FilteringStreamOptions.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/FilteringStreamOptions.java
@@ -86,17 +86,33 @@ public class FilteringStreamOptions
   /**
    * Get the value of an unrecognizable property of this {@link FilteringStreamOptions} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "FilteringStreamOptions has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link FilteringStreamOptions} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (overlap != null) declaredFields.put("overlap", overlap);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/FunctionObject.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/FunctionObject.java
@@ -231,16 +231,35 @@ public class FunctionObject
   /**
    * Get the value of an unrecognizable property of this {@link FunctionObject} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("FunctionObject has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link FunctionObject} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (description != null) declaredFields.put("description", description);
+    if (name != null) declaredFields.put("name", name);
+    if (parameters != null) declaredFields.put("parameters", parameters);
+    if (strict != null) declaredFields.put("strict", strict);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/GenericModuleResult.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/GenericModuleResult.java
@@ -117,17 +117,34 @@ public class GenericModuleResult
   /**
    * Get the value of an unrecognizable property of this {@link GenericModuleResult} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "GenericModuleResult has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link GenericModuleResult} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (message != null) declaredFields.put("message", message);
+    if (data != null) declaredFields.put("data", data);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/GlobalStreamOptions.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/GlobalStreamOptions.java
@@ -85,17 +85,33 @@ public class GlobalStreamOptions
   /**
    * Get the value of an unrecognizable property of this {@link GlobalStreamOptions} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "GlobalStreamOptions has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link GlobalStreamOptions} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (chunkSize != null) declaredFields.put("chunkSize", chunkSize);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/GroundingFilterSearchConfiguration.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/GroundingFilterSearchConfiguration.java
@@ -133,17 +133,34 @@ public class GroundingFilterSearchConfiguration
    * Get the value of an unrecognizable property of this {@link GroundingFilterSearchConfiguration}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "GroundingFilterSearchConfiguration has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link GroundingFilterSearchConfiguration} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (maxChunkCount != null) declaredFields.put("maxChunkCount", maxChunkCount);
+    if (maxDocumentCount != null) declaredFields.put("maxDocumentCount", maxDocumentCount);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/GroundingModuleConfig.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/GroundingModuleConfig.java
@@ -173,17 +173,34 @@ public class GroundingModuleConfig
   /**
    * Get the value of an unrecognizable property of this {@link GroundingModuleConfig} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "GroundingModuleConfig has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link GroundingModuleConfig} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (type != null) declaredFields.put("type", type);
+    if (config != null) declaredFields.put("config", config);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/GroundingModuleConfigConfig.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/GroundingModuleConfigConfig.java
@@ -241,17 +241,36 @@ public class GroundingModuleConfigConfig
    * Get the value of an unrecognizable property of this {@link GroundingModuleConfigConfig}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "GroundingModuleConfigConfig has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link GroundingModuleConfigConfig} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (filters != null) declaredFields.put("filters", filters);
+    if (inputParams != null) declaredFields.put("inputParams", inputParams);
+    if (outputParam != null) declaredFields.put("outputParam", outputParam);
+    if (metadataParams != null) declaredFields.put("metadataParams", metadataParams);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ImageContent.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ImageContent.java
@@ -173,16 +173,33 @@ public class ImageContent implements MultiChatMessageContent
   /**
    * Get the value of an unrecognizable property of this {@link ImageContent} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("ImageContent has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link ImageContent} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (type != null) declaredFields.put("type", type);
+    if (imageUrl != null) declaredFields.put("imageUrl", imageUrl);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ImageContentImageUrl.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ImageContentImageUrl.java
@@ -117,17 +117,34 @@ public class ImageContentImageUrl
   /**
    * Get the value of an unrecognizable property of this {@link ImageContentImageUrl} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "ImageContentImageUrl has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link ImageContentImageUrl} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (url != null) declaredFields.put("url", url);
+    if (detail != null) declaredFields.put("detail", detail);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/InputFilteringConfig.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/InputFilteringConfig.java
@@ -104,17 +104,33 @@ public class InputFilteringConfig
   /**
    * Get the value of an unrecognizable property of this {@link InputFilteringConfig} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "InputFilteringConfig has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link InputFilteringConfig} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (filters != null) declaredFields.put("filters", filters);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/KeyValueListPair.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/KeyValueListPair.java
@@ -135,16 +135,33 @@ public class KeyValueListPair
   /**
    * Get the value of an unrecognizable property of this {@link KeyValueListPair} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("KeyValueListPair has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link KeyValueListPair} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (key != null) declaredFields.put("key", key);
+    if (value != null) declaredFields.put("value", value);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/LLMChoice.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/LLMChoice.java
@@ -214,16 +214,35 @@ public class LLMChoice implements ModuleResultsOutputUnmaskingInner
   /**
    * Get the value of an unrecognizable property of this {@link LLMChoice} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("LLMChoice has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link LLMChoice} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (index != null) declaredFields.put("index", index);
+    if (message != null) declaredFields.put("message", message);
+    if (logprobs != null) declaredFields.put("logprobs", logprobs);
+    if (finishReason != null) declaredFields.put("finishReason", finishReason);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/LLMChoiceStreaming.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/LLMChoiceStreaming.java
@@ -205,16 +205,35 @@ public class LLMChoiceStreaming implements ModuleResultsOutputUnmaskingInner
   /**
    * Get the value of an unrecognizable property of this {@link LLMChoiceStreaming} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("LLMChoiceStreaming has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link LLMChoiceStreaming} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (index != null) declaredFields.put("index", index);
+    if (delta != null) declaredFields.put("delta", delta);
+    if (logprobs != null) declaredFields.put("logprobs", logprobs);
+    if (finishReason != null) declaredFields.put("finishReason", finishReason);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/LLMModuleConfig.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/LLMModuleConfig.java
@@ -169,16 +169,34 @@ public class LLMModuleConfig
   /**
    * Get the value of an unrecognizable property of this {@link LLMModuleConfig} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("LLMModuleConfig has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link LLMModuleConfig} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (modelName != null) declaredFields.put("modelName", modelName);
+    if (modelParams != null) declaredFields.put("modelParams", modelParams);
+    if (modelVersion != null) declaredFields.put("modelVersion", modelVersion);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/LLMModuleResultStreaming.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/LLMModuleResultStreaming.java
@@ -307,17 +307,39 @@ public class LLMModuleResultStreaming implements LLMModuleResult
   /**
    * Get the value of an unrecognizable property of this {@link LLMModuleResultStreaming} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "LLMModuleResultStreaming has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link LLMModuleResultStreaming} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (_object != null) declaredFields.put("_object", _object);
+    if (created != null) declaredFields.put("created", created);
+    if (model != null) declaredFields.put("model", model);
+    if (systemFingerprint != null) declaredFields.put("systemFingerprint", systemFingerprint);
+    if (choices != null) declaredFields.put("choices", choices);
+    if (usage != null) declaredFields.put("usage", usage);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/LLMModuleResultSynchronous.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/LLMModuleResultSynchronous.java
@@ -311,17 +311,39 @@ public class LLMModuleResultSynchronous implements LLMModuleResult
    * Get the value of an unrecognizable property of this {@link LLMModuleResultSynchronous}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "LLMModuleResultSynchronous has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link LLMModuleResultSynchronous} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (_object != null) declaredFields.put("_object", _object);
+    if (created != null) declaredFields.put("created", created);
+    if (model != null) declaredFields.put("model", model);
+    if (systemFingerprint != null) declaredFields.put("systemFingerprint", systemFingerprint);
+    if (choices != null) declaredFields.put("choices", choices);
+    if (usage != null) declaredFields.put("usage", usage);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/LlamaGuard38b.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/LlamaGuard38b.java
@@ -528,16 +528,48 @@ public class LlamaGuard38b
   /**
    * Get the value of an unrecognizable property of this {@link LlamaGuard38b} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("LlamaGuard38b has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link LlamaGuard38b} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (violentCrimes != null) declaredFields.put("violentCrimes", violentCrimes);
+    if (nonViolentCrimes != null) declaredFields.put("nonViolentCrimes", nonViolentCrimes);
+    if (sexCrimes != null) declaredFields.put("sexCrimes", sexCrimes);
+    if (childExploitation != null) declaredFields.put("childExploitation", childExploitation);
+    if (defamation != null) declaredFields.put("defamation", defamation);
+    if (specializedAdvice != null) declaredFields.put("specializedAdvice", specializedAdvice);
+    if (privacy != null) declaredFields.put("privacy", privacy);
+    if (intellectualProperty != null)
+      declaredFields.put("intellectualProperty", intellectualProperty);
+    if (indiscriminateWeapons != null)
+      declaredFields.put("indiscriminateWeapons", indiscriminateWeapons);
+    if (hate != null) declaredFields.put("hate", hate);
+    if (selfHarm != null) declaredFields.put("selfHarm", selfHarm);
+    if (sexualContent != null) declaredFields.put("sexualContent", sexualContent);
+    if (elections != null) declaredFields.put("elections", elections);
+    if (codeInterpreterAbuse != null)
+      declaredFields.put("codeInterpreterAbuse", codeInterpreterAbuse);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/LlamaGuard38bFilterConfig.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/LlamaGuard38bFilterConfig.java
@@ -173,17 +173,34 @@ public class LlamaGuard38bFilterConfig implements FilterConfig
   /**
    * Get the value of an unrecognizable property of this {@link LlamaGuard38bFilterConfig} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "LlamaGuard38bFilterConfig has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link LlamaGuard38bFilterConfig} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (type != null) declaredFields.put("type", type);
+    if (config != null) declaredFields.put("config", config);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/MaskingModuleConfig.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/MaskingModuleConfig.java
@@ -104,17 +104,33 @@ public class MaskingModuleConfig
   /**
    * Get the value of an unrecognizable property of this {@link MaskingModuleConfig} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "MaskingModuleConfig has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link MaskingModuleConfig} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (maskingProviders != null) declaredFields.put("maskingProviders", maskingProviders);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ModuleConfigs.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ModuleConfigs.java
@@ -231,16 +231,39 @@ public class ModuleConfigs
   /**
    * Get the value of an unrecognizable property of this {@link ModuleConfigs} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("ModuleConfigs has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link ModuleConfigs} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (llmModuleConfig != null) declaredFields.put("llmModuleConfig", llmModuleConfig);
+    if (templatingModuleConfig != null)
+      declaredFields.put("templatingModuleConfig", templatingModuleConfig);
+    if (filteringModuleConfig != null)
+      declaredFields.put("filteringModuleConfig", filteringModuleConfig);
+    if (maskingModuleConfig != null) declaredFields.put("maskingModuleConfig", maskingModuleConfig);
+    if (groundingModuleConfig != null)
+      declaredFields.put("groundingModuleConfig", groundingModuleConfig);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ModuleResults.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ModuleResults.java
@@ -322,16 +322,38 @@ public class ModuleResults
   /**
    * Get the value of an unrecognizable property of this {@link ModuleResults} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("ModuleResults has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link ModuleResults} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (grounding != null) declaredFields.put("grounding", grounding);
+    if (templating != null) declaredFields.put("templating", templating);
+    if (inputMasking != null) declaredFields.put("inputMasking", inputMasking);
+    if (inputFiltering != null) declaredFields.put("inputFiltering", inputFiltering);
+    if (llm != null) declaredFields.put("llm", llm);
+    if (outputFiltering != null) declaredFields.put("outputFiltering", outputFiltering);
+    if (outputUnmasking != null) declaredFields.put("outputUnmasking", outputUnmasking);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/MultiChatMessage.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/MultiChatMessage.java
@@ -135,16 +135,33 @@ public class MultiChatMessage implements ChatMessage
   /**
    * Get the value of an unrecognizable property of this {@link MultiChatMessage} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("MultiChatMessage has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link MultiChatMessage} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (role != null) declaredFields.put("role", role);
+    if (content != null) declaredFields.put("content", content);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/OrchestrationConfig.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/OrchestrationConfig.java
@@ -155,17 +155,36 @@ public class OrchestrationConfig
   /**
    * Get the value of an unrecognizable property of this {@link OrchestrationConfig} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "OrchestrationConfig has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link OrchestrationConfig} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (moduleConfigurations != null)
+      declaredFields.put("moduleConfigurations", moduleConfigurations);
+    if (stream != null) declaredFields.put("stream", stream);
+    if (streamOptions != null) declaredFields.put("streamOptions", streamOptions);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/OutputFilteringConfig.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/OutputFilteringConfig.java
@@ -139,17 +139,34 @@ public class OutputFilteringConfig
   /**
    * Get the value of an unrecognizable property of this {@link OutputFilteringConfig} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "OutputFilteringConfig has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link OutputFilteringConfig} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (filters != null) declaredFields.put("filters", filters);
+    if (streamOptions != null) declaredFields.put("streamOptions", streamOptions);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ResponseChatMessage.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ResponseChatMessage.java
@@ -203,17 +203,36 @@ public class ResponseChatMessage
   /**
    * Get the value of an unrecognizable property of this {@link ResponseChatMessage} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "ResponseChatMessage has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link ResponseChatMessage} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (role != null) declaredFields.put("role", role);
+    if (content != null) declaredFields.put("content", content);
+    if (refusal != null) declaredFields.put("refusal", refusal);
+    if (toolCalls != null) declaredFields.put("toolCalls", toolCalls);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ResponseFormatJsonObject.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ResponseFormatJsonObject.java
@@ -139,17 +139,33 @@ public class ResponseFormatJsonObject implements TemplateResponseFormat
   /**
    * Get the value of an unrecognizable property of this {@link ResponseFormatJsonObject} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "ResponseFormatJsonObject has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link ResponseFormatJsonObject} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (type != null) declaredFields.put("type", type);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ResponseFormatJsonSchema.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ResponseFormatJsonSchema.java
@@ -175,17 +175,34 @@ public class ResponseFormatJsonSchema implements TemplateResponseFormat
   /**
    * Get the value of an unrecognizable property of this {@link ResponseFormatJsonSchema} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "ResponseFormatJsonSchema has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link ResponseFormatJsonSchema} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (type != null) declaredFields.put("type", type);
+    if (jsonSchema != null) declaredFields.put("jsonSchema", jsonSchema);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ResponseFormatJsonSchemaJsonSchema.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ResponseFormatJsonSchemaJsonSchema.java
@@ -227,17 +227,36 @@ public class ResponseFormatJsonSchemaJsonSchema
    * Get the value of an unrecognizable property of this {@link ResponseFormatJsonSchemaJsonSchema}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "ResponseFormatJsonSchemaJsonSchema has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link ResponseFormatJsonSchemaJsonSchema} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (description != null) declaredFields.put("description", description);
+    if (name != null) declaredFields.put("name", name);
+    if (schema != null) declaredFields.put("schema", schema);
+    if (strict != null) declaredFields.put("strict", strict);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ResponseFormatText.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ResponseFormatText.java
@@ -139,16 +139,32 @@ public class ResponseFormatText implements TemplateResponseFormat
   /**
    * Get the value of an unrecognizable property of this {@link ResponseFormatText} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("ResponseFormatText has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link ResponseFormatText} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (type != null) declaredFields.put("type", type);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ResponseMessageToolCall.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ResponseMessageToolCall.java
@@ -207,17 +207,35 @@ public class ResponseMessageToolCall
   /**
    * Get the value of an unrecognizable property of this {@link ResponseMessageToolCall} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "ResponseMessageToolCall has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link ResponseMessageToolCall} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    if (type != null) declaredFields.put("type", type);
+    if (function != null) declaredFields.put("function", function);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ResponseMessageToolCallFunction.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ResponseMessageToolCallFunction.java
@@ -128,17 +128,34 @@ public class ResponseMessageToolCallFunction
    * Get the value of an unrecognizable property of this {@link ResponseMessageToolCallFunction}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "ResponseMessageToolCallFunction has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link ResponseMessageToolCallFunction} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (name != null) declaredFields.put("name", name);
+    if (arguments != null) declaredFields.put("arguments", arguments);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/SearchDocumentKeyValueListPair.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/SearchDocumentKeyValueListPair.java
@@ -190,17 +190,35 @@ public class SearchDocumentKeyValueListPair
    * Get the value of an unrecognizable property of this {@link SearchDocumentKeyValueListPair}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "SearchDocumentKeyValueListPair has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link SearchDocumentKeyValueListPair} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (key != null) declaredFields.put("key", key);
+    if (value != null) declaredFields.put("value", value);
+    if (selectMode != null) declaredFields.put("selectMode", selectMode);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/SingleChatMessage.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/SingleChatMessage.java
@@ -117,16 +117,33 @@ public class SingleChatMessage implements ChatMessage
   /**
    * Get the value of an unrecognizable property of this {@link SingleChatMessage} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("SingleChatMessage has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link SingleChatMessage} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (role != null) declaredFields.put("role", role);
+    if (content != null) declaredFields.put("content", content);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/Template.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/Template.java
@@ -245,16 +245,35 @@ public class Template implements TemplatingModuleConfig
   /**
    * Get the value of an unrecognizable property of this {@link Template} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("Template has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link Template} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (template != null) declaredFields.put("template", template);
+    if (defaults != null) declaredFields.put("defaults", defaults);
+    if (responseFormat != null) declaredFields.put("responseFormat", responseFormat);
+    if (tools != null) declaredFields.put("tools", tools);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/TemplateRef.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/TemplateRef.java
@@ -83,16 +83,32 @@ public class TemplateRef implements TemplatingModuleConfig
   /**
    * Get the value of an unrecognizable property of this {@link TemplateRef} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("TemplateRef has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link TemplateRef} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (templateRef != null) declaredFields.put("templateRef", templateRef);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/TemplateRefByID.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/TemplateRefByID.java
@@ -83,16 +83,32 @@ public class TemplateRefByID implements TemplateRefTemplateRef
   /**
    * Get the value of an unrecognizable property of this {@link TemplateRefByID} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("TemplateRefByID has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link TemplateRefByID} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (id != null) declaredFields.put("id", id);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/TemplateRefByScenarioNameVersion.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/TemplateRefByScenarioNameVersion.java
@@ -155,17 +155,35 @@ public class TemplateRefByScenarioNameVersion implements TemplateRefTemplateRef
    * Get the value of an unrecognizable property of this {@link TemplateRefByScenarioNameVersion}
    * instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "TemplateRefByScenarioNameVersion has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link TemplateRefByScenarioNameVersion} instance
+   * including unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (scenario != null) declaredFields.put("scenario", scenario);
+    if (name != null) declaredFields.put("name", name);
+    if (version != null) declaredFields.put("version", version);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/TextContent.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/TextContent.java
@@ -173,16 +173,33 @@ public class TextContent implements MultiChatMessageContent
   /**
    * Get the value of an unrecognizable property of this {@link TextContent} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("TextContent has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link TextContent} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (type != null) declaredFields.put("type", type);
+    if (text != null) declaredFields.put("text", text);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/TokenUsage.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/TokenUsage.java
@@ -151,16 +151,34 @@ public class TokenUsage
   /**
    * Get the value of an unrecognizable property of this {@link TokenUsage} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("TokenUsage has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link TokenUsage} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (completionTokens != null) declaredFields.put("completionTokens", completionTokens);
+    if (promptTokens != null) declaredFields.put("promptTokens", promptTokens);
+    if (totalTokens != null) declaredFields.put("totalTokens", totalTokens);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ToolCallChunk.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ToolCallChunk.java
@@ -241,16 +241,35 @@ public class ToolCallChunk
   /**
    * Get the value of an unrecognizable property of this {@link ToolCallChunk} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException("ToolCallChunk has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link ToolCallChunk} instance including unrecognized
+   * properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (index != null) declaredFields.put("index", index);
+    if (id != null) declaredFields.put("id", id);
+    if (type != null) declaredFields.put("type", type);
+    if (function != null) declaredFields.put("function", function);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ToolCallChunkFunction.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/ToolCallChunkFunction.java
@@ -125,17 +125,34 @@ public class ToolCallChunkFunction
   /**
    * Get the value of an unrecognizable property of this {@link ToolCallChunkFunction} instance.
    *
+   * @deprecated Use {@link #toMap()} instead.
    * @param name The name of the property
    * @return The value of the property
    * @throws NoSuchElementException If no property with the given name could be found.
    */
   @Nullable
+  @Deprecated
   public Object getCustomField(@Nonnull final String name) throws NoSuchElementException {
     if (!cloudSdkCustomFields.containsKey(name)) {
       throw new NoSuchElementException(
           "ToolCallChunkFunction has no field with name '" + name + "'.");
     }
     return cloudSdkCustomFields.get(name);
+  }
+
+  /**
+   * Get the value of all properties of this {@link ToolCallChunkFunction} instance including
+   * unrecognized properties.
+   *
+   * @return The map of all properties
+   */
+  @JsonIgnore
+  @Nonnull
+  public Map<String, Object> toMap() {
+    final Map<String, Object> declaredFields = new LinkedHashMap<>(cloudSdkCustomFields);
+    if (name != null) declaredFields.put("name", name);
+    if (arguments != null) declaredFields.put("arguments", arguments);
+    return declaredFields;
   }
 
   /**

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/spring/OrchestrationSpringChatDelta.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/spring/OrchestrationSpringChatDelta.java
@@ -51,7 +51,7 @@ public class OrchestrationSpringChatDelta extends ChatResponse {
 
   @Nonnull
   private static String getContent(@Nonnull final LLMChoice choice) {
-    return choice.getCustomField("delta") instanceof Map<?, ?> delta
+    return choice.toMap().get("delta") instanceof Map<?, ?> delta
             && delta.get("content") instanceof String content
         ? content
         : "";

--- a/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
+++ b/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
@@ -634,9 +634,9 @@ class OrchestrationUnitTest {
         final var choices0 = result0.getChoices().get(0);
         assertThat(choices0.getIndex()).isEqualTo(0);
         assertThat(choices0.getFinishReason()).isEmpty();
-        assertThat(choices0.getCustomField("delta")).isNotNull();
+        assertThat(choices0.toMap().get("delta")).isNotNull();
         // this should be getDelta(), only when the result is of type LLMModuleResultStreaming
-        final var message0 = (Map<String, Object>) choices0.getCustomField("delta");
+        final var message0 = (Map<String, Object>) choices0.toMap().get("delta");
         assertThat(message0.get("role")).isEqualTo("");
         assertThat(message0.get("content")).isEqualTo("");
         final var templating = deltaList.get(0).getModuleResults().getTemplating();
@@ -657,8 +657,8 @@ class OrchestrationUnitTest {
         final var choices1 = result1.getChoices().get(0);
         assertThat(choices1.getIndex()).isEqualTo(0);
         assertThat(choices1.getFinishReason()).isEmpty();
-        assertThat(choices1.getCustomField("delta")).isNotNull();
-        final var message1 = (Map<String, Object>) choices1.getCustomField("delta");
+        assertThat(choices1.toMap().get("delta")).isNotNull();
+        final var message1 = (Map<String, Object>) choices1.toMap().get("delta");
         assertThat(message1.get("role")).isEqualTo("assistant");
         assertThat(message1.get("content")).isEqualTo("Sure");
 
@@ -673,8 +673,8 @@ class OrchestrationUnitTest {
         assertThat(choices2.getIndex()).isEqualTo(0);
         assertThat(choices2.getFinishReason()).isEqualTo("stop");
         // this should be getDelta(), only when the result is of type LLMModuleResultStreaming
-        assertThat(choices2.getCustomField("delta")).isNotNull();
-        final var message2 = (Map<String, Object>) choices2.getCustomField("delta");
+        assertThat(choices2.toMap().get("delta")).isNotNull();
+        final var message2 = (Map<String, Object>) choices2.toMap().get("delta");
         assertThat(message2.get("role")).isEqualTo("assistant");
         assertThat(message2.get("content")).isEqualTo("!");
       }

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <maven.compiler.proc>full</maven.compiler.proc>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cloud-sdk.version>5.17.0-SNAPSHOT</cloud-sdk.version>
+    <cloud-sdk.version>5.17.0</cloud-sdk.version>
     <junit-jupiter.version>5.11.4</junit-jupiter.version>
     <wiremock.version>3.12.0</wiremock.version>
     <assertj-core.version>3.27.3</assertj-core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <maven.compiler.proc>full</maven.compiler.proc>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cloud-sdk.version>5.16.0</cloud-sdk.version>
+    <cloud-sdk.version>5.17.0-SNAPSHOT</cloud-sdk.version>
     <junit-jupiter.version>5.11.4</junit-jupiter.version>
     <wiremock.version>3.12.0</wiremock.version>
     <assertj-core.version>3.27.3</assertj-core.version>


### PR DESCRIPTION
## Context

AI/ai-sdk-java-backlog#165.

Preview for [feat: [OpenAPI] Add toMap() and deprecate getCustomField(String)](https://github.com/SAP/cloud-sdk-java/pull/723#top)
The OpenAI client has not been regenerated, the generator plugin and spec are missing.

### Feature scope:
 
- [x] Regenerated clients and updated deprecated code usage

## Definition of Done

- [x] Functionality scope stated & covered
- [ ] ~Tests cover the scope above~
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Aligned changes with the JavaScript SDK~
- [ ] ~Documentation updated~
- [ ] ~Release notes updated~
