### PR TITLE
fix: Disable test regarding model availability

### DIFF
--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/ScenarioTest.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/ScenarioTest.java
@@ -10,12 +10,14 @@ import java.util.List;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 class ScenarioTest {
 
   @Test
   @DisplayName("Declared OpenAI models must match AI Core's available OpenAI models")
   @SneakyThrows
+  @DisabledIfSystemProperty(named = "aicore.landscape", matches = "canary")
   void openAiModelAvailability() {
 
     // Gather AI Core's list of available OpenAI models


### PR DESCRIPTION
## Context

AI/ai-sdk-java-backlog#206 (related)

This PR disables the `openAiModelAvailability` test since the list of models on canary and prod are not identical.

### Feature scope:
 
- [x] disable test
- [x] add reminder in above BLI to re-add the test later

## Definition of Done

- [x] Functionality scope stated & covered
- [ ] ~Tests cover the scope above~
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Aligned changes with the JavaScript SDK~
- [ ] ~Documentation updated~
- [ ] ~Release notes updated~
