### PR TITLE
chore: Consolidate OpenAI convenience methods to set tool-choice

### DIFF
--- a/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/OpenAiChatCompletionRequest.java
+++ b/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/OpenAiChatCompletionRequest.java
@@ -2,8 +2,6 @@ package com.sap.ai.sdk.foundationmodels.openai;
 
 import com.google.common.annotations.Beta;
 import com.google.common.collect.Lists;
-import com.sap.ai.sdk.foundationmodels.openai.generated.model.ChatCompletionNamedToolChoice;
-import com.sap.ai.sdk.foundationmodels.openai.generated.model.ChatCompletionNamedToolChoiceFunction;
 import com.sap.ai.sdk.foundationmodels.openai.generated.model.ChatCompletionStreamOptions;
 import com.sap.ai.sdk.foundationmodels.openai.generated.model.ChatCompletionTool;
 import com.sap.ai.sdk.foundationmodels.openai.generated.model.ChatCompletionToolChoiceOption;
@@ -253,48 +251,25 @@ public class OpenAiChatCompletionRequest {
   }
 
   /**
-   * Only message generation will be performed without calling any tool.
+   * Define the model behavior towards calling functions.
    *
+   * <p>Example:
+   *
+   * <ul>
+   *   <li><code>.withToolChoice(OpenAiToolChoice.NONE)</code>
+   *   <li><code>.withToolChoice(OpenAiToolChoice.OPTIONAL)</code>
+   *   <li><code>.withToolChoice(OpenAiToolChoice.REQUIRED)</code>
+   *   <li><code>.withToolChoice(OpenAiToolChoice.function("fibonacci")</code>
+   * </ul>
+   *
+   * @param choice the generic tool choice.
    * @return the current OpenAiChatCompletionRequest instance.
    */
   @Nonnull
-  public OpenAiChatCompletionRequest withToolChoiceNone() {
-    return this.withToolChoice(ChatCompletionToolChoiceOption.create("none"));
-  }
-
-  /**
-   * The model may decide whether to call a (one or more) tool.
-   *
-   * @return the current OpenAiChatCompletionRequest instance.
-   */
-  @Nonnull
-  public OpenAiChatCompletionRequest withToolChoiceOptional() {
-    return this.withToolChoice(ChatCompletionToolChoiceOption.create("auto"));
-  }
-
-  /**
-   * The model must call one or more tools as part of its processing.
-   *
-   * @return the current OpenAiChatCompletionRequest instance.
-   */
-  @Nonnull
-  public OpenAiChatCompletionRequest withToolChoiceRequired() {
-    return this.withToolChoice(ChatCompletionToolChoiceOption.create("required"));
-  }
-
-  /**
-   * The model must call the function specified by {@code functionName}.
-   *
-   * @param functionName the name of the function that must be called.
-   * @return the current OpenAiChatCompletionRequest instance.
-   */
-  @Nonnull
-  public OpenAiChatCompletionRequest withToolChoiceFunction(@Nonnull final String functionName) {
-    return this.withToolChoice(
-        ChatCompletionToolChoiceOption.create(
-            new ChatCompletionNamedToolChoice()
-                .type(ChatCompletionNamedToolChoice.TypeEnum.FUNCTION)
-                .function(new ChatCompletionNamedToolChoiceFunction().name(functionName))));
+  @Tolerate
+  public OpenAiChatCompletionRequest withToolChoice(@Nonnull final OpenAiToolChoice choice) {
+    final ChatCompletionToolChoiceOption option = choice.toolChoice.get();
+    return this.withToolChoice(option);
   }
 
   /**

--- a/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/OpenAiChatCompletionRequest.java
+++ b/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/OpenAiChatCompletionRequest.java
@@ -268,8 +268,7 @@ public class OpenAiChatCompletionRequest {
   @Nonnull
   @Tolerate
   public OpenAiChatCompletionRequest withToolChoice(@Nonnull final OpenAiToolChoice choice) {
-    final ChatCompletionToolChoiceOption option = choice.toolChoice.get();
-    return this.withToolChoice(option);
+    return this.withToolChoice(choice.toolChoice);
   }
 
   /**

--- a/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/OpenAiToolChoice.java
+++ b/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/OpenAiToolChoice.java
@@ -1,0 +1,47 @@
+package com.sap.ai.sdk.foundationmodels.openai;
+
+import com.sap.ai.sdk.foundationmodels.openai.generated.model.ChatCompletionNamedToolChoice;
+import com.sap.ai.sdk.foundationmodels.openai.generated.model.ChatCompletionNamedToolChoiceFunction;
+import com.sap.ai.sdk.foundationmodels.openai.generated.model.ChatCompletionToolChoiceOption;
+import java.util.function.Supplier;
+import javax.annotation.Nonnull;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * OpenAi ToolChoice to specify whether to call which tool.
+ *
+ * @since 1.4.0
+ */
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class OpenAiToolChoice {
+  @Nonnull final Supplier<? extends ChatCompletionToolChoiceOption> toolChoice;
+
+  /** Only message generation will be performed without calling any tool. */
+  public static final OpenAiToolChoice NONE =
+      new OpenAiToolChoice(() -> ChatCompletionToolChoiceOption.create("none"));
+
+  /** The model may decide whether to call a (one or more) tool. */
+  public static final OpenAiToolChoice OPTIONAL =
+      new OpenAiToolChoice(() -> ChatCompletionToolChoiceOption.create("auto"));
+
+  /** The model must call one or more tools as part of its processing. */
+  public static final OpenAiToolChoice REQUIRED =
+      new OpenAiToolChoice(() -> ChatCompletionToolChoiceOption.create("required"));
+
+  /**
+   * The model must call the function specified by {@code functionName}.
+   *
+   * @param functionName the name of the function that must be called.
+   * @return the OpenAI tool choice.
+   */
+  @Nonnull
+  public static OpenAiToolChoice function(@Nonnull final String functionName) {
+    return new OpenAiToolChoice(
+        () ->
+            ChatCompletionToolChoiceOption.create(
+                new ChatCompletionNamedToolChoice()
+                    .type(ChatCompletionNamedToolChoice.TypeEnum.FUNCTION)
+                    .function(new ChatCompletionNamedToolChoiceFunction().name(functionName))));
+  }
+}

--- a/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/OpenAiToolChoice.java
+++ b/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/OpenAiToolChoice.java
@@ -3,7 +3,6 @@ package com.sap.ai.sdk.foundationmodels.openai;
 import com.sap.ai.sdk.foundationmodels.openai.generated.model.ChatCompletionNamedToolChoice;
 import com.sap.ai.sdk.foundationmodels.openai.generated.model.ChatCompletionNamedToolChoiceFunction;
 import com.sap.ai.sdk.foundationmodels.openai.generated.model.ChatCompletionToolChoiceOption;
-import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -15,19 +14,19 @@ import lombok.RequiredArgsConstructor;
  */
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class OpenAiToolChoice {
-  @Nonnull final Supplier<? extends ChatCompletionToolChoiceOption> toolChoice;
+  @Nonnull final ChatCompletionToolChoiceOption toolChoice;
 
   /** Only message generation will be performed without calling any tool. */
   public static final OpenAiToolChoice NONE =
-      new OpenAiToolChoice(() -> ChatCompletionToolChoiceOption.create("none"));
+      new OpenAiToolChoice(ChatCompletionToolChoiceOption.create("none"));
 
   /** The model may decide whether to call a (one or more) tool. */
   public static final OpenAiToolChoice OPTIONAL =
-      new OpenAiToolChoice(() -> ChatCompletionToolChoiceOption.create("auto"));
+      new OpenAiToolChoice(ChatCompletionToolChoiceOption.create("auto"));
 
   /** The model must call one or more tools as part of its processing. */
   public static final OpenAiToolChoice REQUIRED =
-      new OpenAiToolChoice(() -> ChatCompletionToolChoiceOption.create("required"));
+      new OpenAiToolChoice(ChatCompletionToolChoiceOption.create("required"));
 
   /**
    * The model must call the function specified by {@code functionName}.
@@ -38,10 +37,9 @@ public class OpenAiToolChoice {
   @Nonnull
   public static OpenAiToolChoice function(@Nonnull final String functionName) {
     return new OpenAiToolChoice(
-        () ->
-            ChatCompletionToolChoiceOption.create(
-                new ChatCompletionNamedToolChoice()
-                    .type(ChatCompletionNamedToolChoice.TypeEnum.FUNCTION)
-                    .function(new ChatCompletionNamedToolChoiceFunction().name(functionName))));
+        ChatCompletionToolChoiceOption.create(
+            new ChatCompletionNamedToolChoice()
+                .type(ChatCompletionNamedToolChoice.TypeEnum.FUNCTION)
+                .function(new ChatCompletionNamedToolChoiceFunction().name(functionName))));
   }
 }

--- a/foundation-models/openai/src/test/java/com/sap/ai/sdk/foundationmodels/openai/OpenAiChatCompletionRequestTest.java
+++ b/foundation-models/openai/src/test/java/com/sap/ai/sdk/foundationmodels/openai/OpenAiChatCompletionRequestTest.java
@@ -50,7 +50,7 @@ class OpenAiChatCompletionRequestTest {
   @Test
   void withToolChoiceNone() {
     OpenAiChatCompletionRequest request =
-        new OpenAiChatCompletionRequest("message").withToolChoiceNone();
+        new OpenAiChatCompletionRequest("message").withToolChoice(OpenAiToolChoice.NONE);
 
     var lowLevelRequest = request.createCreateChatCompletionRequest();
     var choice =
@@ -61,7 +61,7 @@ class OpenAiChatCompletionRequestTest {
   @Test
   void withToolChoiceOptional() {
     OpenAiChatCompletionRequest request =
-        new OpenAiChatCompletionRequest("message").withToolChoiceOptional();
+        new OpenAiChatCompletionRequest("message").withToolChoice(OpenAiToolChoice.OPTIONAL);
 
     var lowLevelRequest = request.createCreateChatCompletionRequest();
     var choice =
@@ -72,7 +72,7 @@ class OpenAiChatCompletionRequestTest {
   @Test
   void withToolChoiceRequired() {
     OpenAiChatCompletionRequest request =
-        new OpenAiChatCompletionRequest("message").withToolChoiceRequired();
+        new OpenAiChatCompletionRequest("message").withToolChoice(OpenAiToolChoice.REQUIRED);
 
     var lowLevelRequest = request.createCreateChatCompletionRequest();
     var choice =
@@ -83,7 +83,8 @@ class OpenAiChatCompletionRequestTest {
   @Test
   void withToolChoiceFunction() {
     OpenAiChatCompletionRequest request =
-        new OpenAiChatCompletionRequest("message").withToolChoiceFunction("functionName");
+        new OpenAiChatCompletionRequest("message")
+            .withToolChoice(OpenAiToolChoice.function("functionName"));
 
     var lowLevelRequest = request.createCreateChatCompletionRequest();
     var choice =

--- a/foundation-models/openai/src/test/java/com/sap/ai/sdk/foundationmodels/openai/OpenAiClientGeneratedTest.java
+++ b/foundation-models/openai/src/test/java/com/sap/ai/sdk/foundationmodels/openai/OpenAiClientGeneratedTest.java
@@ -531,7 +531,7 @@ class OpenAiClientGeneratedTest extends BaseOpenAiClientTest {
         new OpenAiChatCompletionRequest(
                 "A pair of rabbits is placed in a field. Each month, every pair produces one new pair, starting from the second month. How many rabbits will there be after 12 months?")
             .withTools(List.of(tool))
-            .withToolChoiceFunction("fibonacci");
+            .withToolChoice(OpenAiToolChoice.function("fibonacci"));
 
     var response = client.chatCompletion(request).getOriginalResponse();
 

--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/services/OpenAiServiceV2.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/services/OpenAiServiceV2.java
@@ -12,6 +12,7 @@ import com.sap.ai.sdk.foundationmodels.openai.OpenAiChatCompletionResponse;
 import com.sap.ai.sdk.foundationmodels.openai.OpenAiClient;
 import com.sap.ai.sdk.foundationmodels.openai.OpenAiImageItem;
 import com.sap.ai.sdk.foundationmodels.openai.OpenAiMessage;
+import com.sap.ai.sdk.foundationmodels.openai.OpenAiToolChoice;
 import com.sap.ai.sdk.foundationmodels.openai.generated.model.ChatCompletionTool;
 import com.sap.ai.sdk.foundationmodels.openai.generated.model.EmbeddingsCreate200Response;
 import com.sap.ai.sdk.foundationmodels.openai.generated.model.EmbeddingsCreateRequest;
@@ -105,7 +106,7 @@ public class OpenAiServiceV2 {
                 "A pair of rabbits is placed in a field. Each month, every pair produces one new pair, starting from the second month. How many rabbits will there be after %s months?"
                     .formatted(months))
             .withTools(List.of(tool))
-            .withToolChoiceFunction("fibonacci");
+            .withToolChoice(OpenAiToolChoice.function("fibonacci"));
 
     return OpenAiClient.forModel(GPT_35_TURBO).chatCompletion(request);
   }


### PR DESCRIPTION
## Context

Follow up https://github.com/SAP/ai-sdk-java/pull/330#discussion_r1971179098

Please provide a short description of what your change does and why it is needed.

### Feature scope:
 
- [x] Reduce `withToolChoiceNone`, `withToolChoiceOptional`, `withToolChoiceRequired`, `withToolChoiceFunction` into `withToolChoice`

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Aligned changes with the JavaScript SDK~
- [x] ~Documentation updated~
- [x] ~Release notes updated~
