### PR TITLE
chore: [OpenAI] Beta tag on toolChoice conv with equals and hashcode

### DIFF
--- a/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/OpenAiToolChoice.java
+++ b/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/OpenAiToolChoice.java
@@ -1,10 +1,12 @@
 package com.sap.ai.sdk.foundationmodels.openai;
 
+import com.google.common.annotations.Beta;
 import com.sap.ai.sdk.foundationmodels.openai.generated.model.ChatCompletionNamedToolChoice;
 import com.sap.ai.sdk.foundationmodels.openai.generated.model.ChatCompletionNamedToolChoiceFunction;
 import com.sap.ai.sdk.foundationmodels.openai.generated.model.ChatCompletionToolChoiceOption;
 import javax.annotation.Nonnull;
 import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -12,6 +14,8 @@ import lombok.RequiredArgsConstructor;
  *
  * @since 1.4.0
  */
+@Beta
+@EqualsAndHashCode
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class OpenAiToolChoice {
   @Nonnull final ChatCompletionToolChoiceOption toolChoice;


### PR DESCRIPTION
## Context

AI/ai-sdk-java-backlog#203.

Add `@Beta` tag on new convenience and `equals` and `hashCode` for comparison sake.

## Definition of Done

- [x] Functionality scope stated & covered
- [ ] ~Tests cover the scope above~
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Aligned changes with the JavaScript SDK~
- [ ] ~Documentation updated~
- [ ] ~Release notes updated~
