### PR TITLE
chore: (Grounding) Disable failing E2E test

### DIFF
--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/GroundingTest.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/GroundingTest.java
@@ -15,6 +15,7 @@ import com.sap.cloud.sdk.services.openapi.core.OpenApiResponse;
 import java.time.format.TextStyle;
 import java.util.Locale;
 import java.util.UUID;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class GroundingTest {
@@ -54,6 +55,7 @@ class GroundingTest {
   }
 
   @Test
+  @Disabled("Temporary disabled because of an unresolved minor bug") // SAP/ai-sdk-java-backlog#232
   void testCreateDeleteCollection() {
     final var controller = new GroundingController();
 


### PR DESCRIPTION
## Context

It's been over a week since I reported the issue.
Grounding team does not seem to be capable to fix it in timely manner.
We'd appreciate being able to release again. Therefore, let's disable the failing test. Until they figured it out.

Created follow-up here:
https://github.com/SAP/ai-sdk-java-backlog/issues/232

## Definition of Done

- [x] Functionality scope stated & covered
- [x] ~Tests cover the scope above~
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Aligned changes with the JavaScript SDK~
- [x] ~[Documentation](https://github.com/SAP/ai-sdk/tree/main/docs-java) updated~
- [x] ~Release notes updated~
