### PR TITLE
spec update fix

### DIFF
--- a/.github/workflows/spec-update.yaml
+++ b/.github/workflows/spec-update.yaml
@@ -93,7 +93,7 @@ jobs:
               ;;
             prompt-registry)
               API_URL="$API_BASE_URL/AI/prompt-registry/contents/src/spec/prompt-registry.yaml?ref=$REF"
-              FILE_PATH='prompt-registry/src/main/resources/spec/prompt-registry.yaml'
+              FILE_PATH='core-services/prompt-registry/src/main/resources/spec/prompt-registry.yaml'
               ;;
           esac
           


### PR DESCRIPTION
## Context

AI/ai-sdk-java-backlog#222.

The spec update script doesn't point to the right directory.
AI Core services have been moved to their own folders in #400 
