### PR TITLE
chore: Fix the prompt registry history test

### DIFF
--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/PromptRegistryTest.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/PromptRegistryTest.java
@@ -78,7 +78,7 @@ public class PromptRegistryTest {
     PromptTemplateListResponse history = controller.history();
     // Bug that doesn't delete prompts fast enough. Should be equal to 2
     assertThat(history.getCount()).isGreaterThanOrEqualTo(2);
-    assertThat(history.getResources()).hasSizeGreaterThan(2);
+    assertThat(history.getResources()).hasSizeGreaterThanOrEqualTo(2);
 
     // cleanup
     List<PromptTemplateDeleteResponse> deletedTemplate = controller.deleteTemplate();


### PR DESCRIPTION
## Context

The fix in https://github.com/SAP/ai-sdk-java/pull/411 was not correct. When trying to avoid flakyness in the history test, I changed it from `= 2` to `>2` in that PR, but it should be `>=2`.