### PR TITLE
docs: [OpenAI] Minor fix - version of latest tool features in javadoc

### DIFF
--- a/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/OpenAiChatCompletionRequest.java
+++ b/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/OpenAiChatCompletionRequest.java
@@ -126,13 +126,12 @@ public class OpenAiChatCompletionRequest {
   /**
    * Tools the model may invoke during chat completion (metadata only).
    *
-   * <p>Prefer {@link #withToolsExecutable} for registering executable tools.
+   * <p>Use {@link #withToolsExecutable} for registering executable tools.
    */
   @Nullable List<ChatCompletionTool> tools;
 
   /**
-   * Tools the model may invoke during chat completion that are also executable at runtime of the
-   * application.
+   * Tools the model may invoke during chat completion that are also executable at application runtime.
    *
    * @since 1.8.0
    */

--- a/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/OpenAiChatCompletionRequest.java
+++ b/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/OpenAiChatCompletionRequest.java
@@ -123,13 +123,18 @@ public class OpenAiChatCompletionRequest {
   /** Response format for the completion. */
   @Nullable CreateChatCompletionRequestAllOfResponseFormat responseFormat;
 
-  /** List of tools that the model may invoke during the completion. */
+  /**
+   * Tools the model may invoke during chat completion (metadata only).
+   *
+   * <p>Prefer {@link #withToolsExecutable} for registering executable tools.
+   */
   @Nullable List<ChatCompletionTool> tools;
 
   /**
-   * List of tools that are executable at runtime of the application.
+   * Tools the model may invoke during chat completion that are also executable at runtime of the
+   * application.
    *
-   * @since 1.7.0
+   * @since 1.8.0
    */
   @Getter(value = AccessLevel.PACKAGE)
   @Nullable

--- a/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/OpenAiChatCompletionResponse.java
+++ b/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/OpenAiChatCompletionResponse.java
@@ -108,6 +108,7 @@ public class OpenAiChatCompletionResponse {
    *
    * @return the list of tool messages that were serialized for the computed results. Empty list if
    *     no tools were called.
+   * @since 1.8.0
    */
   @Nonnull
   public List<OpenAiToolMessage> executeTools() {

--- a/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/OpenAiTool.java
+++ b/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/OpenAiTool.java
@@ -39,7 +39,7 @@ import lombok.extern.slf4j.Slf4j;
  * function's request structure.
  *
  * @see <a href="https://platform.openai.com/docs/guides/gpt/function-calling"/>OpenAI Function
- * @since 1.7.0
+ * @since 1.8.0
  */
 @Slf4j
 @Beta
@@ -157,8 +157,9 @@ public class OpenAiTool {
   }
 
   /**
-   * Executes the given tool calls with the provided tools and returns the results as a list of
-   * {@link OpenAiToolMessage} containing execution results encoded as JSON string.
+   * Executes all tool calls specified in the given assistant message using the provided list of
+   * tools. Returns the results as a list of {@link OpenAiToolMessage} containing execution results
+   * encoded as JSON string.
    *
    * @param tools the list of tools to execute
    * @param msg the assistant message containing a list of tool calls with arguments
@@ -179,8 +180,8 @@ public class OpenAiTool {
   }
 
   /**
-   * Executes the given tool calls with the provided tools and returns the results as a list of
-   * {@link OpenAiToolMessage} containing execution results encoded as JSON string.
+   * Executes all function tool calls present in the given assistant message using the provided list
+   * of tools. Returns a map associating each executed function call with its result.
    *
    * @param tools the list of tools to execute
    * @param msg the assistant message containing a list of tool calls with arguments


### PR DESCRIPTION
## Context

The sdk version 1.7 was released before the tool definition, call parsing and execution features were added. Therefore, update the `@since` tag to 1.8.

Some javadoc modified for better comparability and correctness.

## Definition of Done

- [x] Functionality scope stated & covered
- [ ] ~Tests cover the scope above~
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Aligned changes with the JavaScript SDK~
- [ ] [Documentation](https://github.com/SAP/ai-sdk/tree/main/docs-java) updated
- [ ] ~Release notes updated~
