### PR TITLE
feat: [Orchestration] Added support for transforming a JSON output in to an entity

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -13,7 +13,7 @@
 
 ### ✨ New Functionality
 
--
+- [Orchestration] Added support for [transforming a JSON output into an entity](https://sap.github.io/ai-sdk/docs/java/orchestration/chat-completion#json_schema)
 
 ### 📈 Improvements
 

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationChatResponse.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationChatResponse.java
@@ -139,7 +139,7 @@ public class OrchestrationChatResponse {
       return new ObjectMapper().readValue(getContent(), type);
     } catch (InvalidDefinitionException e) {
       throw new OrchestrationClientException(
-          "Failed to deserialize the JSON content. Please make sure to use the correct class and that the class has a no-args constructor and it is static: "
+          "Failed to deserialize the JSON content. Please make sure to use the correct class and that the class has a no-args constructor or is static: "
               + e.getMessage()
               + "\nJSON content: "
               + getContent(),

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationChatResponse.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationChatResponse.java
@@ -129,6 +129,7 @@ public class OrchestrationChatResponse {
             .getMessage()
             .getRefusal();
     if (refusal != null) {
+      // https://platform.openai.com/docs/guides/structured-outputs?api-mode=responses#refusals
       throw new OrchestrationClientException(
           "The model refused to answer the question: " + refusal);
     }

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationChatResponse.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationChatResponse.java
@@ -4,6 +4,7 @@ import static lombok.AccessLevel.PACKAGE;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
 import com.sap.ai.sdk.orchestration.model.AssistantChatMessage;
 import com.sap.ai.sdk.orchestration.model.ChatMessage;
 import com.sap.ai.sdk.orchestration.model.ChatMessageContent;
@@ -119,9 +120,11 @@ public class OrchestrationChatResponse {
    * @param type the class type to deserialize the JSON content into.
    * @return the deserialized entity of type T.
    * @param <T> the type of the entity to deserialize to.
+   * @throws OrchestrationClientException if the model refused to answer the question or if the
+   *     content
    */
   @Nonnull
-  public <T> T entity(@Nonnull final Class<T> type) throws OrchestrationClientException {
+  public <T> T asEntity(@Nonnull final Class<T> type) throws OrchestrationClientException {
     final String refusal =
         ((LLMModuleResultSynchronous) getOriginalResponse().getOrchestrationResult())
             .getChoices()
@@ -129,16 +132,24 @@ public class OrchestrationChatResponse {
             .getMessage()
             .getRefusal();
     if (refusal != null) {
-      // https://platform.openai.com/docs/guides/structured-outputs?api-mode=responses#refusals
       throw new OrchestrationClientException(
           "The model refused to answer the question: " + refusal);
     }
     try {
       return new ObjectMapper().readValue(getContent(), type);
+    } catch (InvalidDefinitionException e) {
+      throw new OrchestrationClientException(
+          "Failed to deserialize the JSON content. Please make sure to use the correct class and that the class has a no-args constructor or is static: "
+              + e.getMessage()
+              + "\nJSON content: "
+              + getContent(),
+          e);
     } catch (JsonProcessingException e) {
       throw new OrchestrationClientException(
-          "Failed to deserialize the JSON content, please configure an OrchestrationTemplate with format set to JSON schema into your OrchestrationModuleConfig"
-              + e.getMessage(),
+          "Failed to deserialize the JSON content. Please configure an OrchestrationTemplate with format set to JSON schema into your OrchestrationModuleConfig: "
+              + e.getMessage()
+              + "\nJSON content: "
+              + getContent(),
           e);
     }
   }

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationChatResponse.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationChatResponse.java
@@ -121,8 +121,8 @@ public class OrchestrationChatResponse {
    * @param <T> the type of the entity to deserialize to.
    */
   @Nonnull
-  public <T> T entity(@Nonnull final Class<T> type) {
-    String refusal =
+  public <T> T entity(@Nonnull final Class<T> type) throws OrchestrationClientException {
+    final String refusal =
         ((LLMModuleResultSynchronous) getOriginalResponse().getOrchestrationResult())
             .getChoices()
             .get(0)

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationChatResponse.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationChatResponse.java
@@ -122,11 +122,23 @@ public class OrchestrationChatResponse {
    */
   @Nonnull
   public <T> T entity(@Nonnull final Class<T> type) {
+    String refusal =
+        ((LLMModuleResultSynchronous) getOriginalResponse().getOrchestrationResult())
+            .getChoices()
+            .get(0)
+            .getMessage()
+            .getRefusal();
+    if (refusal != null) {
+      throw new OrchestrationClientException(
+          "The model refused to answer the question: " + refusal);
+    }
     try {
       return new ObjectMapper().readValue(getContent(), type);
     } catch (JsonProcessingException e) {
       throw new OrchestrationClientException(
-          "Failed to deserialize the JSON content: " + e.getMessage(), e);
+          "Failed to deserialize the JSON content, please configure an OrchestrationTemplate with format set to JSON schema into your OrchestrationModuleConfig"
+              + e.getMessage(),
+          e);
     }
   }
 }

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationChatResponse.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationChatResponse.java
@@ -2,6 +2,8 @@ package com.sap.ai.sdk.orchestration;
 
 import static lombok.AccessLevel.PACKAGE;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sap.ai.sdk.orchestration.model.AssistantChatMessage;
 import com.sap.ai.sdk.orchestration.model.ChatMessage;
 import com.sap.ai.sdk.orchestration.model.ChatMessageContent;
@@ -106,5 +108,25 @@ public class OrchestrationChatResponse {
     return ((LLMModuleResultSynchronous) originalResponse.getOrchestrationResult())
         .getChoices()
         .get(0);
+  }
+
+  /**
+   * Transform a JSON response into an entity of the given type.
+   *
+   * <p>This is possible on a request with a {@link OrchestrationTemplate#withJsonSchemaResponse}
+   * configured into {@link OrchestrationModuleConfig#withTemplateConfig}.
+   *
+   * @param type the class type to deserialize the JSON content into.
+   * @return the deserialized entity of type T.
+   * @param <T> the type of the entity to deserialize to.
+   */
+  @Nonnull
+  public <T> T entity(@Nonnull final Class<T> type) {
+    try {
+      return new ObjectMapper().readValue(getContent(), type);
+    } catch (JsonProcessingException e) {
+      throw new OrchestrationClientException(
+          "Failed to deserialize the JSON content: " + e.getMessage(), e);
+    }
   }
 }

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationChatResponse.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationChatResponse.java
@@ -139,7 +139,7 @@ public class OrchestrationChatResponse {
       return new ObjectMapper().readValue(getContent(), type);
     } catch (InvalidDefinitionException e) {
       throw new OrchestrationClientException(
-          "Failed to deserialize the JSON content. Please make sure to use the correct class and that the class has a no-args constructor or is static: "
+          "Failed to deserialize the JSON content. Please make sure to use the correct class and that the class has a no-args constructor and it is static: "
               + e.getMessage()
               + "\nJSON content: "
               + getContent(),

--- a/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
+++ b/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
@@ -879,7 +879,7 @@ class OrchestrationUnitTest {
     assertThatThrownBy(() -> response.asEntity(TranslationNotStaticNoConstructor.class))
         .isInstanceOf(OrchestrationClientException.class)
         .hasMessageContaining(
-            "Please make sure to use the correct class and that the class has a no-args constructor or is static")
+            "Please make sure to use the correct class and that the class has a no-args constructor and it is static")
         .hasMessageContaining("JSON content: {\"translation\":\"Apfel\",\"language\":\"German\"}");
 
     // ------------- good use -------------

--- a/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
+++ b/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
@@ -879,7 +879,7 @@ class OrchestrationUnitTest {
     assertThatThrownBy(() -> response.asEntity(TranslationNotStaticNoConstructor.class))
         .isInstanceOf(OrchestrationClientException.class)
         .hasMessageContaining(
-            "Please make sure to use the correct class and that the class has a no-args constructor and it is static")
+            "Please make sure to use the correct class and that the class has a no-args constructor or is static")
         .hasMessageContaining("JSON content: {\"translation\":\"Apfel\",\"language\":\"German\"}");
 
     // ------------- good use -------------

--- a/orchestration/src/test/resources/__files/errorJsonSchemaResponse.json
+++ b/orchestration/src/test/resources/__files/errorJsonSchemaResponse.json
@@ -1,0 +1,59 @@
+{
+  "request_id": "0759f249-a261-4cb7-99d5-ea6eae2c141c",
+  "module_results": {
+    "templating": [
+      {
+        "role": "user",
+        "content": "Whats 'apple' in German?"
+      },
+      {
+        "role": "system",
+        "content": "You are a language translator."
+      }
+    ],
+    "llm": {
+      "id": "chatcmpl-AzmCw5QZBi6zQkJPQhvsyjW4Fe90c",
+      "object": "chat.completion",
+      "created": 1739286682,
+      "model": "gpt-4o-mini-2024-07-18",
+      "system_fingerprint": "fp_f3927aa00d",
+      "choices": [
+        {
+          "index": 0,
+          "message": {
+            "type": "refusal",
+            "refusal": "I'm sorry, I cannot assist with that request."
+          },
+          "finish_reason": "stop"
+        }
+      ],
+      "usage": {
+        "completion_tokens": 10,
+        "prompt_tokens": 68,
+        "total_tokens": 78
+      }
+    }
+  },
+  "orchestration_result": {
+    "id": "chatcmpl-AzmCw5QZBi6zQkJPQhvsyjW4Fe90c",
+    "object": "chat.completion",
+    "created": 1739286682,
+    "model": "gpt-4o-mini-2024-07-18",
+    "system_fingerprint": "fp_f3927aa00d",
+    "choices": [
+      {
+        "index": 0,
+        "message": {
+          "type": "refusal",
+          "refusal": "I'm sorry, I cannot assist with that request."
+        },
+        "finish_reason": "stop"
+      }
+    ],
+    "usage": {
+      "completion_tokens": 10,
+      "prompt_tokens": 68,
+      "total_tokens": 78
+    }
+  }
+}

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/OrchestrationController.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/OrchestrationController.java
@@ -239,11 +239,7 @@ class OrchestrationController {
   @Nonnull
   Object responseFormatJsonSchema(
       @RequestParam(value = "format", required = false) final String format) {
-    final var response = service.responseFormatJsonSchema("apple");
-    if ("json".equals(format)) {
-      return response;
-    }
-    return response.getContent();
+    return service.responseFormatJsonSchema("apple");
   }
 
   @GetMapping("/responseFormatJsonObject")

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OrchestrationService.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OrchestrationService.java
@@ -383,22 +383,27 @@ public class OrchestrationService {
   }
 
   /**
+   * A simple record to demonstrate the response format feature of the orchestration service.
+   *
+   * @param translation the translated text
+   * @param language the language of the translation
+   */
+  public record Translation(
+      @JsonProperty(required = true) String translation,
+      @JsonProperty(required = true) String language) {}
+
+  /**
    * Chat request to OpenAI through the Orchestration service using response format with JSON
    * schema.
    *
+   * @param word the word to translate
+   * @return the assistant response object
    * @link <a
    *     href="https://help.sap.com/docs/sap-ai-core/sap-ai-core-service-guide/structured-output">SAP
    *     AI Core: Orchestration - Structured Output</a>
-   * @param word the word to translate
-   * @return the assistant response object
    */
   @Nonnull
-  public OrchestrationChatResponse responseFormatJsonSchema(@Nonnull final String word) {
-    //    Example class
-    record Translation(
-        @JsonProperty(required = true) String translation,
-        @JsonProperty(required = true) String language) {}
-
+  public Translation responseFormatJsonSchema(@Nonnull final String word) {
     val schema =
         ResponseJsonSchema.fromType(Translation.class)
             .withDescription("Output schema for language translation.")
@@ -411,7 +416,7 @@ public class OrchestrationService {
             Message.user("Whats '%s' in German?".formatted(word)),
             Message.system("You are a language translator."));
 
-    return client.chatCompletion(prompt, configWithResponseSchema);
+    return client.chatCompletion(prompt, configWithResponseSchema).entity(Translation.class);
   }
 
   /**

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OrchestrationService.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OrchestrationService.java
@@ -416,7 +416,7 @@ public class OrchestrationService {
             Message.user("Whats '%s' in German?".formatted(word)),
             Message.system("You are a language translator."));
 
-    return client.chatCompletion(prompt, configWithResponseSchema).entity(Translation.class);
+    return client.chatCompletion(prompt, configWithResponseSchema).asEntity(Translation.class);
   }
 
   /**

--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.sap.ai.sdk.app.services.OrchestrationService;
+import com.sap.ai.sdk.app.services.OrchestrationService.Translation;
 import com.sap.ai.sdk.orchestration.AzureContentFilter;
 import com.sap.ai.sdk.orchestration.AzureFilterThreshold;
 import com.sap.ai.sdk.orchestration.DpiMasking;
@@ -317,9 +318,9 @@ class OrchestrationTest {
 
   @Test
   void testResponseFormatJsonSchema() {
-    val result = service.responseFormatJsonSchema("apple").getOriginalResponse();
-    val choices = ((LLMModuleResultSynchronous) result.getOrchestrationResult()).getChoices();
-    assertThat(choices.get(0).getMessage().getContent()).isNotEmpty();
+    Translation translation = service.responseFormatJsonSchema("apple");
+    assertThat(translation.translation()).isNotEmpty();
+    assertThat(translation.language()).isNotEmpty();
   }
 
   @Test


### PR DESCRIPTION
## Context

AI/ai-sdk-java-backlog#254.

Currently, users have to manually parse a string as JSON into their class. Users can now let the AI SDK do the parsing.

### Feature scope:
 
- [x] Added `OrchestrationChatResponse.entity(Class)`

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] Error handling created / updated & covered by the tests above
- [ ] ~Aligned changes with the JavaScript SDK~
- [x] [Documentation](https://github.com/SAP/ai-sdk/tree/main/docs-java) updated https://github.com/SAP/ai-sdk/pull/119
- [x] Release notes updated
