### PR TITLE
chore: Fix e2e tests because of new filter messages

### DIFF
--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OrchestrationService.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OrchestrationService.java
@@ -163,7 +163,8 @@ public class OrchestrationService {
   public OrchestrationChatResponse inputFiltering(@Nonnull final AzureFilterThreshold policy)
       throws OrchestrationClientException {
     val prompt =
-        new OrchestrationPrompt("'We shall spill blood tonight', said the operation in-charge.");
+        new OrchestrationPrompt(
+            "Please rephrase the following sentence for me: 'We shall spill blood tonight', said the operator in-charge.");
     val filterConfig =
         new AzureContentFilter().hate(policy).selfHarm(policy).sexual(policy).violence(policy);
 

--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
@@ -241,7 +241,7 @@ class OrchestrationTest {
     assertThat(response.getContent()).isNotEmpty();
 
     var filterResult = response.getOriginalResponse().getModuleResults().getInputFiltering();
-    assertThat(filterResult.getMessage()).contains("passed");
+    assertThat(filterResult.getMessage()).contains("skipped");
   }
 
   @Test
@@ -284,7 +284,7 @@ class OrchestrationTest {
     assertThat(response.getContent()).isNotEmpty();
 
     var filterResult = response.getOriginalResponse().getModuleResults().getInputFiltering();
-    assertThat(filterResult.getMessage()).contains("passed");
+    assertThat(filterResult.getMessage()).contains("skipped");
   }
 
   @Test
@@ -415,7 +415,7 @@ class OrchestrationTest {
     assertThatThrownBy(() -> client.streamChatCompletion(prompt, configWithMasking))
         .isInstanceOf(OrchestrationClientException.class)
         .hasMessageContaining("status 400 Bad Request")
-        .hasMessageContaining("'type': 'sap_data_privacy_integration', 'method': 'anonymization'");
+        .hasMessageContaining("'unknown_default_open_api' is not one of");
   }
 
   @Test

--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/SpringAiOrchestrationTest.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/SpringAiOrchestrationTest.java
@@ -86,7 +86,7 @@ class SpringAiOrchestrationTest {
             .getOriginalResponse()
             .getModuleResults()
             .getInputFiltering();
-    assertThat(filterResult.getMessage()).contains("passed");
+    assertThat(filterResult.getMessage()).contains("skipped");
   }
 
   @Test


### PR DESCRIPTION
## Context

Small fix to make [e2e test](https://github.com/SAP/ai-sdk-java/actions/runs/15891824090/job/44815637303) run through again.
