### PR TITLE
fix: [Orchestration] duplicated properties

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -30,4 +30,4 @@
 
 ### 🐛 Fixed Issues
 
-- [Orchestration] Fixed duplicate properties, Anthropic Claude chat completions are now working.
+- [Orchestration] Resolved duplicate JSON property issue, enabling Anthropic Claude chat completions.

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -30,4 +30,4 @@
 
 ### 🐛 Fixed Issues
 
--
+- [Orchestration] Fixed duplicate properties, Anthropic Claude chat completions are now working.

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/JacksonMixins.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/JacksonMixins.java
@@ -2,6 +2,7 @@ package com.sap.ai.sdk.orchestration;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.sap.ai.sdk.orchestration.model.LLMChoice;
 import com.sap.ai.sdk.orchestration.model.LLMModuleResultSynchronous;
@@ -20,12 +21,9 @@ final class JacksonMixins {
   @JsonDeserialize(as = LLMChoice.class)
   interface ModuleResultsOutputUnmaskingInnerMixIn {}
 
-  @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
-  interface NoneTypeInfoMixin {}
-
   @JsonTypeInfo(
       use = JsonTypeInfo.Id.NAME,
-      include = JsonTypeInfo.As.PROPERTY,
+      include = As.EXISTING_PROPERTY,
       property = "type",
       visible = true)
   @JsonSubTypes({
@@ -43,7 +41,7 @@ final class JacksonMixins {
 
   @JsonTypeInfo(
       use = JsonTypeInfo.Id.NAME,
-      include = JsonTypeInfo.As.PROPERTY,
+      include = As.EXISTING_PROPERTY,
       property = "role",
       visible = true)
   @JsonSubTypes({

--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
@@ -382,7 +382,7 @@ class OrchestrationTest {
   void testStreamingErrorHandlingTemplate() {
     val template = Message.user("Bad template: {{?language!@#$}}");
     val templatingConfig =
-        TemplateConfig.create().withTemplate(List.of(template.createChatMessage()));
+        TemplateConfig.create().withMessages(template);
     val configWithTemplate = config.withTemplateConfig(templatingConfig);
     val inputParams = Map.of("language", "German");
     val prompt = new OrchestrationPrompt(inputParams);

--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
@@ -381,8 +381,7 @@ class OrchestrationTest {
   @Test
   void testStreamingErrorHandlingTemplate() {
     val template = Message.user("Bad template: {{?language!@#$}}");
-    val templatingConfig =
-        TemplateConfig.create().withMessages(template);
+    val templatingConfig = TemplateConfig.create().withMessages(template);
     val configWithTemplate = config.withTemplateConfig(templatingConfig);
     val inputParams = Map.of("language", "German");
     val prompt = new OrchestrationPrompt(inputParams);


### PR DESCRIPTION
## Context

AI/ai-sdk-java-backlog#278.
Fixes #474 

Fixed duplicate properties, Anthropic Claude chat completions are now working.
⚠️This is only manually e2e tested since verify does not check for duplicate **equal** `key:values`

### Feature scope:
 
- [x] No duplicate keys on serialization
- [x] Tested with Claude 3.7

## Definition of Done

- [x] Functionality scope stated & covered
- [ ] Tests cover the scope above
- [ ] Error handling created / updated & covered by the tests above
- [ ] ~Aligned changes with the JavaScript SDK~
- [ ] [Documentation](https://github.com/SAP/ai-sdk/tree/main/docs-java) updated
- [ ] Release notes updated
