### PR TITLE
Feat/spring ai ga release

### DIFF
--- a/foundation-models/openai/pom.xml
+++ b/foundation-models/openai/pom.xml
@@ -99,7 +99,7 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.ai</groupId>
-      <artifactId>spring-ai-core</artifactId>
+      <artifactId>spring-ai-model</artifactId>
       <optional>true</optional>
     </dependency>
     <!-- scope "provided" -->

--- a/orchestration/pom.xml
+++ b/orchestration/pom.xml
@@ -56,7 +56,7 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.ai</groupId>
-      <artifactId>spring-ai-core</artifactId>
+      <artifactId>spring-ai-model</artifactId>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/orchestration/pom.xml
+++ b/orchestration/pom.xml
@@ -60,6 +60,11 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>org.springframework.ai</groupId>
+      <artifactId>spring-ai-client-chat</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>io.projectreactor</groupId>
       <artifactId>reactor-core</artifactId>
       <optional>true</optional>

--- a/orchestration/src/test/java/com/sap/ai/sdk/orchestration/spring/OrchestrationChatModelTest.java
+++ b/orchestration/src/test/java/com/sap/ai/sdk/orchestration/spring/OrchestrationChatModelTest.java
@@ -41,11 +41,12 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
-import org.springframework.ai.chat.memory.InMemoryChatMemory;
+import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository;
+import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.chat.messages.AssistantMessage.ToolCall;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
-import org.springframework.ai.tool.ToolCallbacks;
+import org.springframework.ai.support.ToolCallbacks;
 import reactor.core.publisher.Flux;
 
 @WireMockTest
@@ -238,8 +239,9 @@ public class OrchestrationChatModelTest {
                     .withBodyFile("templatingResponse.json") // The response is not important
                     .withHeader("Content-Type", "application/json")));
 
-    val memory = new InMemoryChatMemory();
-    val advisor = new MessageChatMemoryAdvisor(memory);
+    val repository = new InMemoryChatMemoryRepository();
+    val memory = MessageWindowChatMemory.builder().chatMemoryRepository(repository).build();
+    val advisor = MessageChatMemoryAdvisor.builder(memory).build();
     val cl = ChatClient.builder(client).defaultAdvisors(advisor).build();
     val prompt1 = new Prompt("What is the capital of France?", defaultOptions);
     val prompt2 = new Prompt("And what is the typical food there?", defaultOptions);

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <system-stubs.version>2.1.3</system-stubs.version>
     <surefire.version>3.5.3</surefire.version>
     <springframework.version>6.2.8</springframework.version>
-    <spring-ai.version>1.0.0-M6</spring-ai.version>
+    <spring-ai.version>1.0.0</spring-ai.version>
     <reactor-core.version>3.6.12</reactor-core.version>
     <dotenv-java.version>3.2.0</dotenv-java.version>
     <mockito.version>5.18.0</mockito.version>
@@ -119,7 +119,7 @@
       </dependency>
       <dependency>
         <groupId>org.springframework.ai</groupId>
-        <artifactId>spring-ai-core</artifactId>
+        <artifactId>spring-ai-model</artifactId>
         <version>${spring-ai.version}</version>
       </dependency>
       <dependency>
@@ -265,24 +265,6 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <repositories>
-    <repository>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <id>spring-milestones</id>
-      <name>Spring Milestones</name>
-      <url>https://repo.spring.io/milestone</url>
-    </repository>
-    <repository>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <id>spring-snapshots</id>
-      <name>Spring Snapshots</name>
-      <url>https://repo.spring.io/snapshot</url>
-    </repository>
-  </repositories>
   <build>
     <resources>
       <resource>

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,11 @@
         <version>${spring-ai.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.springframework.ai</groupId>
+        <artifactId>spring-ai-client-chat</artifactId>
+        <version>${spring-ai.version}</version>
+      </dependency>
+      <dependency>
         <groupId>io.projectreactor</groupId>
         <artifactId>reactor-core</artifactId>
         <version>${reactor-core.version}</version>

--- a/sample-code/spring-app/pom.xml
+++ b/sample-code/spring-app/pom.xml
@@ -100,6 +100,10 @@
       <artifactId>spring-ai-model</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.ai</groupId>
+      <artifactId>spring-ai-client-chat</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
       <version>${spring-boot.version}</version>

--- a/sample-code/spring-app/pom.xml
+++ b/sample-code/spring-app/pom.xml
@@ -97,7 +97,7 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.ai</groupId>
-      <artifactId>spring-ai-core</artifactId>
+      <artifactId>spring-ai-model</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/SpringAiOrchestrationService.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/SpringAiOrchestrationService.java
@@ -22,12 +22,13 @@ import javax.annotation.Nullable;
 import lombok.val;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
-import org.springframework.ai.chat.memory.InMemoryChatMemory;
+import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository;
+import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.chat.prompt.PromptTemplate;
-import org.springframework.ai.tool.ToolCallbacks;
+import org.springframework.ai.support.ToolCallbacks;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 
@@ -178,8 +179,9 @@ public class SpringAiOrchestrationService {
    */
   @Nonnull
   public ChatResponse chatMemory() {
-    val memory = new InMemoryChatMemory();
-    val advisor = new MessageChatMemoryAdvisor(memory);
+    val repository = new InMemoryChatMemoryRepository();
+    val memory = MessageWindowChatMemory.builder().chatMemoryRepository(repository).build();
+    val advisor = MessageChatMemoryAdvisor.builder(memory).build();
     val cl = ChatClient.builder(client).defaultAdvisors(advisor).build();
     val prompt1 = new Prompt("What is the capital of France?", defaultOptions);
     val prompt2 = new Prompt("And what is the typical food there?", defaultOptions);


### PR DESCRIPTION
## Context

AI/ai-sdk-java-backlog#294.

This PR increases the version of Spring AI to the GA release 1.0.0. This comes with breaking changes for current Spring-AI users.

### Feature scope:
 
- [ ] Increase to `1.0.0`
- [ ] Migrate to new tool API (e.g. `FunctionCallback` to `ToolCallback`)
- [ ] Migrate to new chat history API (e.g. `new MessageWindowChatMemory()` to `MessageWindowChatMemory.builder(..)`

## Definition of Done

- [ ] Functionality scope stated & covered
- [ ] Tests cover the scope above
- [ ] Error handling created / updated & covered by the tests above
- [ ] ~Aligned changes with the JavaScript SDK~
- [ ] [Documentation](https://github.com/SAP/ai-sdk/tree/main/docs-java) updated
- [ ] Release notes updated
