### PR TITLE
fix: Add scm information (now required by maven central)

### DIFF
--- a/core-services/document-grounding/pom.xml
+++ b/core-services/document-grounding/pom.xml
@@ -30,6 +30,11 @@
       <organizationUrl>https://www.sap.com</organizationUrl>
     </developer>
   </developers>
+  <scm>
+    <connection>scm:git:git://github.com/SAP/ai-sdk-java.git</connection>
+    <developerConnection>scm:git:ssh://github.com:SAP/ai-sdk-java.git</developerConnection>
+    <url>https://github.com/SAP/ai-sdk-java/tree/main</url>
+  </scm>
   <properties>
     <project.rootdir>${project.basedir}/../../</project.rootdir>
     <coverage.complexity>80%</coverage.complexity>

--- a/core-services/prompt-registry/pom.xml
+++ b/core-services/prompt-registry/pom.xml
@@ -31,6 +31,11 @@
       <organizationUrl>https://www.sap.com</organizationUrl>
     </developer>
   </developers>
+  <scm>
+    <connection>scm:git:git://github.com/SAP/ai-sdk-java.git</connection>
+    <developerConnection>scm:git:ssh://github.com:SAP/ai-sdk-java.git</developerConnection>
+    <url>https://github.com/SAP/ai-sdk-java/tree/main</url>
+  </scm>
   <properties>
     <project.rootdir>${project.basedir}/../../</project.rootdir>
     <coverage.complexity>75%</coverage.complexity>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -28,6 +28,11 @@
       <organizationUrl>https://www.sap.com</organizationUrl>
     </developer>
   </developers>
+  <scm>
+    <connection>scm:git:git://github.com/SAP/ai-sdk-java.git</connection>
+    <developerConnection>scm:git:ssh://github.com:SAP/ai-sdk-java.git</developerConnection>
+    <url>https://github.com/SAP/ai-sdk-java/tree/main</url>
+  </scm>
   <properties>
     <project.rootdir>${project.basedir}/../</project.rootdir>
     <coverage.complexity>64%</coverage.complexity>

--- a/foundation-models/openai/pom.xml
+++ b/foundation-models/openai/pom.xml
@@ -31,6 +31,11 @@
       <organizationUrl>https://www.sap.com</organizationUrl>
     </developer>
   </developers>
+  <scm>
+    <connection>scm:git:git://github.com/SAP/ai-sdk-java.git</connection>
+    <developerConnection>scm:git:ssh://github.com:SAP/ai-sdk-java.git</developerConnection>
+    <url>https://github.com/SAP/ai-sdk-java/tree/main</url>
+  </scm>
   <properties>
     <project.rootdir>${project.basedir}/../../</project.rootdir>
     <coverage.complexity>72%</coverage.complexity>

--- a/orchestration/pom.xml
+++ b/orchestration/pom.xml
@@ -29,6 +29,11 @@
       <organizationUrl>https://www.sap.com</organizationUrl>
     </developer>
   </developers>
+  <scm>
+    <connection>scm:git:git://github.com/SAP/ai-sdk-java.git</connection>
+    <developerConnection>scm:git:ssh://github.com:SAP/ai-sdk-java.git</developerConnection>
+    <url>https://github.com/SAP/ai-sdk-java/tree/main</url>
+  </scm>
   <properties>
     <project.rootdir>${project.basedir}/../</project.rootdir>
     <coverage.complexity>82%</coverage.complexity>

--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,9 @@
     <module>foundation-models/openai</module>
   </modules>
   <scm>
-    <connection/>
-    <url/>
+    <connection>scm:git:git://github.com/SAP/ai-sdk-java.git</connection>
+    <developerConnection>scm:git:ssh://github.com:SAP/ai-sdk-java.git</developerConnection>
+    <url>https://github.com/SAP/ai-sdk-java/tree/main</url>
   </scm>
   <distributionManagement>
     <repository>


### PR DESCRIPTION
## Context

SCM information is now mandatory to include in pom files so that maven central validates the modules during deployment.
