### PR TITLE
fix: Grounding `getAllPipelines` now does not throw anymore

### DIFF
--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/GroundingTest.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/GroundingTest.java
@@ -26,10 +26,11 @@ class GroundingTest {
   void testPipelinesGetAll() {
     final var controller = new GroundingController();
 
+    // we don't have testable data yet, but the endpoint works without errors
     var result = controller.getAllPipelines(JSON_FORMAT, RESOURCE_GROUP);
     assertThat(result).isInstanceOf(GetPipelines.class);
     var pipelinesList = ((GetPipelines) result).getResources();
-    assertThat(pipelinesList).hasSize(0);
+    assertThat(pipelinesList).isEmpty();
     var pipelinesCount = ((GetPipelines) result).getCount();
     assertThat(pipelinesCount).isEqualTo(0);
   }


### PR DESCRIPTION
## Context

Fix e2e test

