### PR TITLE
fix: [DevOps] Dependency check action permissions

### DIFF
--- a/.github/workflows/fosstars-report.yml
+++ b/.github/workflows/fosstars-report.yml
@@ -16,7 +16,8 @@ jobs:
     name: "Security rating"
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
+      actions: write
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v4


### PR DESCRIPTION
## Context

#540 broke the dependency check action, I added `actions: write` to enable cache deletion.

[Successful run](https://github.com/SAP/ai-sdk-java/actions/runs/16986728091)
