### PR TITLE
fix: [DevOps] remove distributionManagement sonatype

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,10 +41,6 @@
     <url>https://github.com/SAP/ai-sdk-java/tree/main</url>
   </scm>
   <distributionManagement>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org</url>
-    </repository>
     <snapshotRepository>
       <id>artifactory-snapshots</id>
       <url>https://common.repositories.cloud.sap/artifactory/build-snapshots-cloudsdk</url>


### PR DESCRIPTION
## Context

This is not used
- [see Cloud SDK `distributionManagement`](https://github.com/SAP/cloud-sdk-java/blob/bd6e1f94dc902b6becb25ba313349fb2179fa30a/pom.xml#L44)
- [Also see AI SDK server id defined in `sonatype publish plugin`](https://github.com/SAP/ai-sdk-java/blob/e366acb2bccb8b5db9bed006f7179a04606e6154/pom.xml#L927)

### Feature scope:
 
- [x] Removed useless `distributionManagement`
