### PR TITLE
fix: [DevOps] Fix failing e2e script

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -99,3 +99,19 @@ jobs:
         # print response body with headers to stdout.  q:body only  O:print  -:stdout  S:headers
         run: wget -qO- -S localhost:8080
 
+      - name: "Slack Notification"
+        if: failure()
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            blocks:
+              - type: "section"
+                text:
+                    type: "mrkdwn"
+                    text: "⚠️ End-to-end tests failed! 😬 Please inspect & fix by clicking <https://github.com/SAP/ai-sdk-java/actions/runs/${{ github.run_id }}|here>"
+              - type: "section"
+                text:
+                  type: "plain_text"
+                  text: "${{ steps.run_tests.outputs.error_message }} "

--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
@@ -318,6 +318,24 @@ class OrchestrationTest {
     assertThat(choices.get(0).getMessage().getContent()).isNotEmpty();
   }
 
+  @Test
+  void testImageInputBase64() {
+    String dataUrl = "";
+    try {
+      URL url = new URL("https://upload.wikimedia.org/wikipedia/commons/c/c9/Sap-logo-700x700.jpg");
+      try (InputStream inputStream = url.openStream()) {
+        byte[] imageBytes = inputStream.readAllBytes();
+        byte[] encodedBytes = Base64.getEncoder().encode(imageBytes);
+        String encodedString = new String(encodedBytes, StandardCharsets.UTF_8);
+        dataUrl = "data:image/jpeg;base64," + encodedString;
+      }
+    } catch (Exception e) {
+      System.out.println("Error fetching or reading the image from URL: " + e.getMessage());
+    }
+    val result = service.imageInput(dataUrl).getOriginalResponse();
+    val choices = (result.getFinalResult()).getChoices();
+    assertThat(choices.get(0).getMessage().getContent()).isNotEmpty();
+  }
 
   @Test
   void testMultiStringInput() {


### PR DESCRIPTION
## Context

Our e2e script was failing before the actual tests were run ([see example run](https://github.com/SAP/ai-sdk-java/actions/runs/17197730884)). 

- The main issue seemed to be that the evaluated secret had special characters inside that were interpreted as parts of a shell command. To fix this, I now use `'` instead of `"` when reading the secrets.
- Also, no Slack notification was sent after the runs failed. This was due to the Slack GH-action failing if one of the *blocks* of a multi-block message is empty (see [reference](https://github.com/slackapi/bolt-js/issues/1877)). To fix this, I added a whitespace to the second block (that otherwise would be empty if the script fails for a reason that is not a test-failure).

[Link to successful run of e2e tests on this branch](https://github.com/SAP/ai-sdk-java/actions/runs/17209023660) (without running the one test that is actually failing right now, will fix that in a separate PR).

### Feature scope:
 
- [x] fix reading secrets
- [x] fix sending Slack notification

## Definition of Done

- [x] Functionality scope stated & covered
- [ ] ~Tests cover the scope above~
- [x] Error handling created / updated & covered by the tests above
- [ ] ~Aligned changes with the JavaScript SDK~
- [ ] ~[Documentation](https://github.com/SAP/ai-sdk/tree/main/docs-java) updated~
- [ ] ~Release notes updated~