### PR TITLE
chore: [DevOps] Fix e2e test

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -44,9 +44,9 @@ jobs:
         id: run_tests
         run: |
           if [ "${{ matrix.environment }}" = "canary" ]; then
-              export AICORE_SERVICE_KEY="${{ secrets.AI_CORE_CANARY }}"
+              export AICORE_SERVICE_KEY='${{ secrets.AI_CORE_CANARY }}'
           else
-              export AICORE_SERVICE_KEY="${{ secrets.AI_CORE_PRODUCTION }}"
+              export AICORE_SERVICE_KEY='${{ secrets.AI_CORE_PRODUCTION }}'
           fi
           
           MVN_ARGS="${{ env.MVN_MULTI_THREADED_ARGS }} surefire:test -pl :spring-app -DskipTests=false"
@@ -74,9 +74,9 @@ jobs:
       - name: "Start Application Locally"
         run: |
           if [ "${{ matrix.environment }}" = "canary" ]; then
-              export AICORE_SERVICE_KEY="${{ secrets.AI_CORE_CANARY }}"
+              export AICORE_SERVICE_KEY='${{ secrets.AI_CORE_CANARY }}'
           else
-              export AICORE_SERVICE_KEY="${{ secrets.AI_CORE_PRODUCTION }}"
+              export AICORE_SERVICE_KEY='${{ secrets.AI_CORE_PRODUCTION }}'
           fi
           
           cd sample-code/spring-app
@@ -114,4 +114,4 @@ jobs:
               - type: "section"
                 text:
                   type: "plain_text"
-                  text: "${{ steps.run_tests.outputs.error_message }}"
+                  text: "${{ steps.run_tests.outputs.error_message }} "

--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
@@ -24,6 +24,7 @@ import com.sap.ai.sdk.orchestration.model.DPIEntities;
 import com.sap.ai.sdk.orchestration.model.GenericModuleResult;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -323,7 +324,10 @@ class OrchestrationTest {
     String dataUrl = "";
     try {
       URL url = new URL("https://upload.wikimedia.org/wikipedia/commons/c/c9/Sap-logo-700x700.jpg");
-      try (InputStream inputStream = url.openStream()) {
+      // the "User-Agent" header is required to avoid a 403
+      HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+      connection.setRequestProperty("User-Agent", "Test implementation");
+      try (InputStream inputStream = connection.getInputStream()) {
         byte[] imageBytes = inputStream.readAllBytes();
         byte[] encodedBytes = Base64.getEncoder().encode(imageBytes);
         String encodedString = new String(encodedBytes, StandardCharsets.UTF_8);


### PR DESCRIPTION
## Context

The `testImageInputBase64()` test failed because it could no longer access an example image we use from wikimedia. This seems to be because wikimedia responds with 403 to requests without a "User-Agent" header. Why this worked before, I do not know. I now added such a header to the call and it works again.

### Feature scope:
 
- [x] add User-Agent heade

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] Error handling created / updated & covered by the tests above
- [ ] ~Aligned changes with the JavaScript SDK~
- [ ] ~[Documentation](https://github.com/SAP/ai-sdk/tree/main/docs-java) updated~
- [ ] ~Release notes updated~
