### PR TITLE
chore: [DevOps] succeed early if spec is unchanged

### DIFF
--- a/.github/workflows/spec-update.yaml
+++ b/.github/workflows/spec-update.yaml
@@ -59,11 +59,6 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           cache: 'maven'
 
-      - name: "Install Baseline SDK Version"
-        # this is needed as otherwise "process sources" will fail on e.g. orchestration module, if the core module isn't in the maven cache
-        run: |
-          mvn install -DskipTests
-
       - name: "Checkout or Create Branch"
         id: branch
         # Checkout branch if it exists, otherwise create it
@@ -109,6 +104,11 @@ jobs:
           else
             echo "spec_diff=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: "Install Baseline SDK Version"
+        # this is needed as otherwise "process sources" will fail on e.g. orchestration module, if the core module isn't in the maven cache
+        run: |
+          mvn install -DskipTests
 
       - name: "Generate"
         id: generate


### PR DESCRIPTION
## Context

The action is being called a lot more by different repositories, while it is only called if the branch changes the spec file, it might not be changed on every commit, thus we can save time and finish early