### PR TITLE
docs: Clarify optionality of frameworks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,11 @@ If you don't have a deployment yet, please refer to [this guide](https://help.sa
 Add the following dependency to your `pom.xml` file:
 
 ```xml
-
 <dependency>
-  <groupId>com.sap.ai.sdk</groupId>
-  <artifactId>orchestration</artifactId>
-  <!-- Use the latest version here -->
-  <version>${ai-sdk.version}</version>
+    <groupId>com.sap.ai.sdk</groupId>
+    <artifactId>orchestration</artifactId>
+    <!-- Use the latest version here -->
+    <version>${ai-sdk.version}</version>
 </dependency>
 ```
 
@@ -94,7 +93,7 @@ Next, we'll specify the model we want to use:
 
 ```java
 var config = new OrchestrationModuleConfig()
-    .withLlmConfig(OrchestrationAiModel.GPT_4O);
+        .withLlmConfig(OrchestrationAiModel.GPT_4O);
 ```
 
 Now we can create our first prompt:
@@ -172,10 +171,7 @@ var destination =
         .build();
 
 // AI Core client
-service =service.
-
-withBaseDestination(destination);
-
+service = service.withBaseDestination(destination);
 DeploymentApi client = new DeploymentApi(service);
 ```
 
@@ -197,6 +193,7 @@ This is a known false-positive finding.
 Depending on the tooling any product called "SAP Cloud SDK" or similar with a low version number may be marked as vulnerable, incorrectly.
 Please consider suppressing the warning, [as we do](https://github.com/SAP/ai-sdk-java/blob/main/.pipeline/dependency-check-suppression.xml).
 
+
 ### _"Are there any example projects?"_
 
 Explore example applications and code snippets:
@@ -206,20 +203,20 @@ Explore example applications and code snippets:
 ## Contribute, Support and Feedback
 
 This project is open to feature requests/suggestions, bug reports etc. via [GitHub issues](https://github.com/SAP/ai-sdk-java/issues).
-Contribution and feedback are encouraged and always welcome.
+Contribution and feedback are encouraged and always welcome. 
 For more information about how to contribute, the project structure, as well as additional contribution information, see our [Contribution Guidelines](CONTRIBUTING.md).
 
 ## Security / Disclosure
 
-If you find any bug that may be a security problem, please follow our instructions at [in our security policy](https://github.com/SAP/ai-sdk-java/security/policy) on how to report it.
+If you find any bug that may be a security problem, please follow our instructions at [in our security policy](https://github.com/SAP/ai-sdk-java/security/policy) on how to report it. 
 Please do not create GitHub issues for security-related doubts or problems.
 
 ## Code of Conduct
 
-We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone.
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone. 
 By participating in this project, you agree to abide by its [Code of Conduct](https://github.com/SAP/.github/blob/main/CODE_OF_CONDUCT.md) at all times.
 
 ## Licensing
 
-Copyright 2024 SAP SE or an SAP affiliate company and ai-sdk-java contributors. Please see our [LICENSE](LICENSE) for copyright and license information.
+Copyright 2024 SAP SE or an SAP affiliate company and ai-sdk-java contributors. Please see our [LICENSE](LICENSE) for copyright and license information. 
 Detailed information including third-party components and their licensing/copyright information is available [via the REUSE tool](https://api.reuse.software/info/github.com/SAP/ai-sdk-java).

--- a/README.md
+++ b/README.md
@@ -30,24 +30,26 @@ The SDK simplifies the setup and interaction with SAP AI Core, allowing you to f
 
 ## General Requirements
 
-To use the SDK in a Java application, it is necessary to understand the technical prerequisites and required versions for common dependencies.
+#### Development Environment
 
-- Java 17 or higher.
-- Access to an **SAP AI Core Service** instance.
+These are required on the developer side to build and run applications with the SDK:
 
-Please refer to [this documentation on **how to connect the SDK to AI Core**](https://sap.github.io/ai-sdk/docs/java/guides/connecting-to-ai-core).
+* **Java JDK**: 17 or higher (21 LTS recommended).
+* **SAP Cloud SDK**: 5.6.0 or later (latest recommended, added as a Maven dependency).
 
-The following table lists the required versions, based on the latest release:
+#### SAP AI Core Service instance
 
-| Dependency             | Minimum Version | Recommended Version |
-|------------------------|-----------------|---------------------|
-| JDK                    | 17 (LTS)        | 21 (LTS)            |
-| SAP Cloud SDK          | 5.6.0           | latest              |
-| (optional) CAP Java    | 3.0.0           | latest              |
-| (optional) Spring Boot | 3.0             | latest              |
-| (optional) Spring AI   | 1.0.0           | latest              |
+To make of use the services supported by the SDK, you need to have access to an SAP AI Core Service instance. Checkout [how to connect](link).
 
-See [an example `pom.xml` in our Spring Boot application](sample-code/spring-app/pom.xml).
+#### Optional Integrations
+
+The SDK can be combined with popular Java frameworks. These are not required for core functionality, but version compatibility is listed for reference:
+
+* **Spring AI** ≥ 1.0.0
+* **Spring Boot** ≥ 3.0
+* **CAP Java** ≥ 3.0.0
+
+👉 See an [example `pom.xml`](link) in our sample Spring Boot application.
 
 > [!WARNING]  
 > All classes under any of the `...model` packages are generated from an OpenAPI specification and marked as `@Beta`.
@@ -71,11 +73,12 @@ If you don't have a deployment yet, please refer to [this guide](https://help.sa
 Add the following dependency to your `pom.xml` file:
 
 ```xml
+
 <dependency>
-    <groupId>com.sap.ai.sdk</groupId>
-    <artifactId>orchestration</artifactId>
-    <!-- Use the latest version here -->
-    <version>${ai-sdk.version}</version>
+  <groupId>com.sap.ai.sdk</groupId>
+  <artifactId>orchestration</artifactId>
+  <!-- Use the latest version here -->
+  <version>${ai-sdk.version}</version>
 </dependency>
 ```
 
@@ -91,7 +94,7 @@ Next, we'll specify the model we want to use:
 
 ```java
 var config = new OrchestrationModuleConfig()
-        .withLlmConfig(OrchestrationAiModel.GPT_4O);
+    .withLlmConfig(OrchestrationAiModel.GPT_4O);
 ```
 
 Now we can create our first prompt:
@@ -169,7 +172,10 @@ var destination =
         .build();
 
 // AI Core client
-service = service.withBaseDestination(destination);
+service =service.
+
+withBaseDestination(destination);
+
 DeploymentApi client = new DeploymentApi(service);
 ```
 
@@ -191,7 +197,6 @@ This is a known false-positive finding.
 Depending on the tooling any product called "SAP Cloud SDK" or similar with a low version number may be marked as vulnerable, incorrectly.
 Please consider suppressing the warning, [as we do](https://github.com/SAP/ai-sdk-java/blob/main/.pipeline/dependency-check-suppression.xml).
 
-
 ### _"Are there any example projects?"_
 
 Explore example applications and code snippets:
@@ -201,20 +206,20 @@ Explore example applications and code snippets:
 ## Contribute, Support and Feedback
 
 This project is open to feature requests/suggestions, bug reports etc. via [GitHub issues](https://github.com/SAP/ai-sdk-java/issues).
-Contribution and feedback are encouraged and always welcome. 
+Contribution and feedback are encouraged and always welcome.
 For more information about how to contribute, the project structure, as well as additional contribution information, see our [Contribution Guidelines](CONTRIBUTING.md).
 
 ## Security / Disclosure
 
-If you find any bug that may be a security problem, please follow our instructions at [in our security policy](https://github.com/SAP/ai-sdk-java/security/policy) on how to report it. 
+If you find any bug that may be a security problem, please follow our instructions at [in our security policy](https://github.com/SAP/ai-sdk-java/security/policy) on how to report it.
 Please do not create GitHub issues for security-related doubts or problems.
 
 ## Code of Conduct
 
-We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone. 
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone.
 By participating in this project, you agree to abide by its [Code of Conduct](https://github.com/SAP/.github/blob/main/CODE_OF_CONDUCT.md) at all times.
 
 ## Licensing
 
-Copyright 2024 SAP SE or an SAP affiliate company and ai-sdk-java contributors. Please see our [LICENSE](LICENSE) for copyright and license information. 
+Copyright 2024 SAP SE or an SAP affiliate company and ai-sdk-java contributors. Please see our [LICENSE](LICENSE) for copyright and license information.
 Detailed information including third-party components and their licensing/copyright information is available [via the REUSE tool](https://api.reuse.software/info/github.com/SAP/ai-sdk-java).


### PR DESCRIPTION
## Context

https://github.com/SAP/ai-sdk-java/issues/569

Simply additing clarification on the purpose of these frameworks listen in our README.md so users don't expect documentation along with.

## Definition of Done

- [ ] ~Functionality scope stated & covered~
- [ ] ~Tests cover the scope above~
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Aligned changes with the JavaScript SDK~
- [ ] ~[Documentation](https://github.com/SAP/ai-sdk/tree/main/docs-java) updated~
- [ ] ~Release notes updated~
