### PR TITLE
fix: [DevOps] spec update workflow edge case

### DIFF
--- a/.github/workflows/spec-update.yaml
+++ b/.github/workflows/spec-update.yaml
@@ -105,16 +105,11 @@ jobs:
             echo "spec_diff=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: "Install Baseline SDK Version"
-        # this is needed as otherwise "process sources" will fail on e.g. orchestration module, if the core module isn't in the maven cache
-        run: |
-          mvn install -DskipTests
-
       - name: "Generate"
         id: generate
         if: steps.spec_diff.outputs.spec_diff == 'true'
         run: |
-          mvn process-sources -Dgenerate ${{ env.MVN_MULTI_THREADED_ARGS }}
+          mvn install -DskipTests -Dgenerate ${{ env.MVN_MULTI_THREADED_ARGS }}
 
       - name: "Compile and Test"
         id: compile


### PR DESCRIPTION
## Context

- If a breaking change is added to the spec -> the workflow fails
- If the breaking change is removed -> it should succeed. But the `Install baseline SDK Version` step fails because the branch saved the previous broken spec

## Solution

Install and generate everything, meaning it will actually fail the workflow for compilation failures
_(good for us with regards to breaking changes)_
