### PR TITLE
chore: Disable tests that fail due to new orchestration spec

### DIFF
--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
@@ -379,6 +380,7 @@ class OrchestrationTest {
   }
 
   @Test
+  @Disabled("This behaviour is not released to canary yet.")
   void testTemplateFromPromptRegistryById() {
     val result = service.templateFromPromptRegistryById("Cloud ERP systems").getOriginalResponse();
     val choices = (result.getFinalResult()).getChoices();
@@ -386,6 +388,7 @@ class OrchestrationTest {
   }
 
   @Test
+  @Disabled("This behaviour is not released to canary yet.")
   void testTemplateFromPromptRegistryByScenario() {
     val result =
         service.templateFromPromptRegistryByScenario("Cloud ERP systems").getOriginalResponse();
@@ -444,6 +447,7 @@ class OrchestrationTest {
   }
 
   @Test
+  @Disabled("This behaviour is not released to canary yet.")
   void testTranslation() {
     val result = service.translation();
     val content = result.getContent();


### PR DESCRIPTION
## Context

Due to [this PR](https://github.com/SAP/ai-sdk-java/pull/588) we currently have behaviour on main that is not testable until the orchestration spec made it through the release pipeline. This PR disables the tests.

I added a note to the [support BLI](https://github.com/SAP/cloud-sdk-java-backlog/issues/448) to enable the tests again before the next release.

### Feature scope:
 
- [x] disable 3 tests

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above~
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Aligned changes with the JavaScript SDK~
- [ ] ~[Documentation](https://github.com/SAP/ai-sdk/tree/main/docs-java) updated~
- [ ] ~Release notes updated~
