### PR TITLE
chore: Add `@Beta` to `OrchestrationModuleConfig#withStreamConfig`

### DIFF
--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationModuleConfig.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationModuleConfig.java
@@ -136,7 +136,9 @@ public class OrchestrationModuleConfig {
    *
    * @param config The stream configuration to use.
    * @return A new configuration with the given stream configuration.
+   * @since 1.12.0
    */
+  @Beta
   @Nonnull
   public OrchestrationModuleConfig withStreamConfig(
       @Nonnull final OrchestrationStreamConfig config) {

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationStreamConfig.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationStreamConfig.java
@@ -1,5 +1,6 @@
 package com.sap.ai.sdk.orchestration;
 
+import com.google.common.annotations.Beta;
 import com.sap.ai.sdk.orchestration.model.FilteringStreamOptions;
 import com.sap.ai.sdk.orchestration.model.GlobalStreamOptions;
 import java.util.List;
@@ -18,6 +19,7 @@ import lombok.val;
  */
 @Value
 @With
+@Beta
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class OrchestrationStreamConfig {
   /**


### PR DESCRIPTION
## Context

Minor follow up to https://github.com/SAP/ai-sdk-java/pull/561
https://github.com/SAP/ai-sdk-java-backlog/issues/317

We may want to keep it `@Beta` until we see some traction, or a single stakeholder.

## Definition of Done

- [x] Functionality scope stated & covered
- [x] ~Tests cover the scope above~
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Aligned changes with the JavaScript SDK~
- [x] ~[Documentation](https://github.com/SAP/ai-sdk/tree/main/docs-java) updated~
- [x] ~Release notes updated~
