### PR TITLE
test: [Orchestration] Set 'mask_grounding_input` to null on embedding requests

### DIFF
--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationEmbeddingRequest.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationEmbeddingRequest.java
@@ -148,7 +148,11 @@ public class OrchestrationEmbeddingRequest {
             .modules(EmbeddingsModuleConfigs.create().embeddings(embeddingsModelConfig));
 
     if (masking != null) {
-      final var dpiConfigs = masking.stream().map(MaskingProvider::createConfig).toList();
+      final var dpiConfigs =
+          masking.stream()
+              .map(MaskingProvider::createConfig)
+              .map(config -> config.maskGroundingInput(null))
+              .toList();
       modules.getModules().setMasking(MaskingModuleConfigProviders.create().providers(dpiConfigs));
     }
     return EmbeddingsPostRequest.create().config(modules).input(input);

--- a/orchestration/src/test/resources/embeddingRequest.json
+++ b/orchestration/src/test/resources/embeddingRequest.json
@@ -24,10 +24,7 @@
             "allowlist": [
               "SAP",
               "Joule"
-            ],
-            "mask_grounding_input": {
-              "enabled": false
-            }
+            ]
           }
         ]
       }


### PR DESCRIPTION
## Context

AI/ai-sdk-java-backlog#ISSUENUMBER.

-[ Failing E2E](https://github.com/SAP/ai-sdk-java/actions/runs/18363857618)

### Feature scope:
 
- On embedding requests, the masking embedding input flag is always set to `null`. 

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Aligned changes with the JavaScript SDK~
- [x] [Documentation](https://github.com/SAP/ai-sdk/tree/main/docs-java) updated
- [x] Release notes updated
