### PR TITLE
chore: Offer log configuration for integration test module

### DIFF
--- a/sample-code/spring-app/src/test/resources/logback.xml
+++ b/sample-code/spring-app/src/test/resources/logback.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <import class="ch.qos.logback.classic.encoder.PatternLayoutEncoder" />
+    <import class="ch.qos.logback.core.ConsoleAppender" />
+
+    <appender name="STDOUT" class="ConsoleAppender">
+        <encoder class="PatternLayoutEncoder">
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} -- %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <logger name="org.apache.hc.client5.http.wire" level="DEBUG"/>
+    <logger name="org.apache.http.wire" level="DEBUG"/>
+</configuration>


### PR DESCRIPTION
I want to see wire log during tests.
Previously that was possible via `slf4j-simple` logger and `-D` args. With logback, I'll need a file.
We can disable wirelog by default if you want.