### PR TITLE
chore: [DevOps] Move dependabot to Tuesday

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,7 +6,7 @@ updates:
     directory: '/'
     schedule:
       interval: weekly
-      time: '02:00'
+      time: '23:00'
       timezone: 'Europe/Berlin'
     open-pull-requests-limit: 5
     commit-message:

--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -3,7 +3,7 @@ name: "Dependabot Auto-Merge"
 on:
   workflow_dispatch:
   schedule:
-    - cron: '00 04 * * Mon' # trigger every Monday at 04:00 a.m., as our dependabot is configured to raise PRs every Monday at 2:00 a.m.
+    - cron: '00 01 * * Tue' # trigger every Tuesday at 01:00 a.m., as our dependabot is configured to raise PRs every Monday at 23:00 p.m.
 
 env:
   DEPENDABOT_GROUPS: |


### PR DESCRIPTION
## Context

The support handover is on Monday. Dependabot should not trigger just before the handover because it closes all previous PRs, [same as in Cloud SDK](https://github.com/SAP/cloud-sdk-java/blob/9d44dd4b58a45812c70ef381000a2c13eb7ee867/.github/dependabot.yaml#L9)