### PR TITLE
fix: [DevOps] spec update notification condition

### DIFF
--- a/.github/workflows/spec-update.yaml
+++ b/.github/workflows/spec-update.yaml
@@ -214,7 +214,7 @@ jobs:
           exit 1
 
       - name: "Slack Notification"
-        if: failure() && ${{ github.event.inputs.create-pr }}
+        if: failure() && github.event.inputs.create-pr == true
         uses: slackapi/slack-github-action@v2.1.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
I didn't want to do `== true` but it seems I have to do it.