### PR TITLE
chore: Ignore incompatible spring boot updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -11,6 +11,11 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: 'chore: [DevOps] '
+    ignore:
+      - dependency-name: "org.springframework.boot:*"
+        versions: [ ">=4.0.0" ]
+      - dependency-name: "org.springframework:*"
+        versions: [ ">=7.0.0" ]
     groups:
       production-minor-patch:
         dependency-type: "production"


### PR DESCRIPTION
## Context

Spring Boot 4 and Spring Framework 7 are incompatible with our OpenAPI generated classes (i.e. core classes).

Related
https://github.com/SAP/cloud-sdk-java-backlog/issues/464

