### PR TITLE
feat: [DevOps] Spec updates uses `orchestration-staging` base branch whenever possible

### DIFF
--- a/.github/workflows/spec-update.yaml
+++ b/.github/workflows/spec-update.yaml
@@ -82,11 +82,29 @@ jobs:
 
       - name: "Checkout or Create Branch"
         id: branch
-        # Checkout branch if it exists, otherwise create it
+        env:
+          BASE: ${{ steps.pr_base.outputs.BASE }}
+          CHOICE: ${{ env.CHOICE }}
+          REF: ${{ env.REF }}
         run: |
           BRANCH="spec-update/$CHOICE/$REF"
-          git fetch origin $BRANCH || true
-          git checkout -B $BRANCH origin/$BRANCH || git checkout -b $BRANCH
+          
+          # try to fetch the base and the target branch (ignore failures if missing)
+          git fetch --no-tags --depth=1 origin "$BASE" || true
+          git fetch origin "$BRANCH" || true
+          
+          # if remote target branch exists, base the local branch on it
+          if git ls-remote --heads origin "$BRANCH" | grep -q "refs/heads/$BRANCH"; then
+            git checkout -B "$BRANCH" "origin/$BRANCH"
+          else
+            # otherwise, create the branch from origin/BASE if it exists, else from current HEAD
+            if git ls-remote --heads origin "$BASE" | grep -q "refs/heads/$BASE"; then
+              git checkout -B "$BRANCH" "origin/$BASE"
+            else
+              git checkout -B "$BRANCH"
+            fi
+          fi
+          
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 
       - name: "Download specification file"


### PR DESCRIPTION
## Context

AI/ai-sdk-java-backlog#494.

#### Background
Whenever orchestration merges spec changes onto their main branch that are breaking for us we are forced right now to merge these breaking changes into our main branch. Otherwise, the test that runs on each orchestration repo PR to check for (new) breaking changes will be meaningless, as it would always be failing. That leads to situations were we have code on our main branch that we cannot release (since it is about feature from orchestration that are on there main branch but not released to prod yet).

#### Solution Attempt
In order to improve this for us, we need a new `orchestration-staging` branch. This branch acts as the basis for the tests that run on the orchestration repo PRs. All new breaking changes from orchestration can then be merged onto this branch. Whenever our weekly spec update workflow shows that we need to update the orchestration version on main, we can merge the relevant breaking changes from `orchestration-staging` into main. (We have to make sure that we do not merge more than is needed, i.e., if there are multiple breaking changes from orchestration, not all of which are released yet.)

### Feature scope:
 
- [x] Use `orchestration-staging` base branch whenever possible

## Definition of Done

- [x] Functionality scope stated & covered
- [ ] ~Tests cover the scope above~
- [x] Error handling created / updated & covered by the tests above
- [ ] ~Aligned changes with the JavaScript SDK~
- [ ] ~[Documentation](https://github.com/SAP/ai-sdk/tree/main/docs-java) updated~
- [ ] ~Release notes updated~
