### PR TITLE
chore: Increase java version in GH workflows

### DIFF
--- a/.github/workflows/cache-maven-dependencies.yaml
+++ b/.github/workflows/cache-maven-dependencies.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: "sapmachine"
-          java-version: 25
+          java-version: 21
 
       - name: "Download Dependencies"
         run: mvn -B dependency:go-offline

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -9,7 +9,7 @@ on:
 env:
   MVN_MULTI_THREADED_ARGS: --batch-mode --no-transfer-progress --fail-at-end --show-version --threads 1C
   MVN_SKIP_CI_PLUGINS: -DskipFormatting -Denforcer.skip -Djacoco.skip -Dmdep.analyze.skip
-  JAVA_VERSION: 25
+  JAVA_VERSION: 21
   # keep the following two variables in sync with our 'cache-maven-dependencies.yaml' workflow
   MAVEN_CACHE_KEY: maven-dependencies
   MAVEN_CACHE_DIR: ~/.m2

--- a/.github/workflows/dependency-test.yaml
+++ b/.github/workflows/dependency-test.yaml
@@ -5,7 +5,7 @@ on:
 
 env:
   MVN_MULTI_THREADED_ARGS: --batch-mode --no-transfer-progress --fail-at-end --show-version --threads 1C
-  JAVA_VERSION: 25
+  JAVA_VERSION: 21
 
 jobs:
   fetch-dependency-versions:

--- a/.github/workflows/deploy-snapshot.yaml
+++ b/.github/workflows/deploy-snapshot.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: "sapmachine"
-          java-version: "25"
+          java-version: "21"
           server-id: artifactory-snapshots
           server-username: DEPLOYMENT_USER
           server-password: DEPLOYMENT_PASS

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -6,7 +6,7 @@ on:
 
 env:
   MVN_MULTI_THREADED_ARGS: --batch-mode --no-transfer-progress --fail-at-end --show-version --threads 1C
-  JAVA_VERSION: 25
+  JAVA_VERSION: 21
 
 jobs:
   end-to-end-tests:

--- a/.github/workflows/fosstars-report.yml
+++ b/.github/workflows/fosstars-report.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   MVN_MULTI_THREADED_ARGS: --batch-mode --no-transfer-progress --fail-at-end --show-version --threads 1C
-  JAVA_VERSION: 25
+  JAVA_VERSION: 21
   CVE_CACHE_KEY: cve-db
   CVE_CACHE_DIR: ~/.m2/repository/org/owasp/dependency-check-data
   CVE_CACHE_REF: refs/heads/main

--- a/.github/workflows/perform-release.yaml
+++ b/.github/workflows/perform-release.yaml
@@ -14,7 +14,7 @@ on:
 
 env:
   MVN_CLI_ARGS: --batch-mode --no-transfer-progress --fail-at-end --show-version -DskipTests
-  JAVA_VERSION: 25
+  JAVA_VERSION: 21
   DOCS_REPO: SAP/ai-sdk
 
 jobs:

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -14,7 +14,7 @@ on:
 env:
   CI_BUILD_WORKFLOW: "continuous-integration.yaml" # Name of the workflow that should be triggered for CI build
   MVN_MULTI_THREADED_ARGS: --batch-mode --no-transfer-progress --fail-at-end --show-version --threads 1C
-  JAVA_VERSION: 25
+  JAVA_VERSION: 21
   DOCS_REPO: SAP/ai-sdk
 
 jobs:

--- a/.github/workflows/spec-update.yaml
+++ b/.github/workflows/spec-update.yaml
@@ -26,7 +26,7 @@ on:
 
 env:
   MVN_MULTI_THREADED_ARGS: --batch-mode --no-transfer-progress --fail-at-end --show-version --threads 1C
-  JAVA_VERSION: 25
+  JAVA_VERSION: 21
   # keep the following two variables in sync with our 'cache-maven-dependencies.yaml' workflow
   MAVEN_CACHE_KEY: maven-dependencies
   MAVEN_CACHE_DIR: ~/.m2


### PR DESCRIPTION
## Context

Checkstyle needs JDK21 or higher. So this PR increase the JDK version used by the GH runner to this version (it does not change java version in which the SDK is compiled).

Workflows tested with the new JDK version:
- [CI](https://github.com/SAP/ai-sdk-java/actions/runs/21205173531)
- [Cache Maven version](https://github.com/SAP/ai-sdk-java/actions/runs/21205332968)
- [Fosstar](https://github.com/SAP/ai-sdk-java/actions/runs/21205485856)
- [E2E test](https://github.com/SAP/ai-sdk-java/actions/runs/21205451013)
- [spec update](https://github.com/SAP/ai-sdk-java/actions/runs/21205521577)
- [prepare release](https://github.com/SAP/ai-sdk-java/actions/runs/21209217271)

Workflows not tested:
- [Deploy to artifactory](https://github.com/SAP/ai-sdk-java/actions/runs/21205360410): Not run through because of (the usual) authorisation issue
- Perform release
