### PR TITLE
chore: Fix E2E test by changing Prompt to trigger Input-Filter

### DIFF
--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OrchestrationService.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OrchestrationService.java
@@ -177,7 +177,7 @@ public class OrchestrationService {
       throws OrchestrationClientException {
     val prompt =
         new OrchestrationPrompt(
-            "Please rephrase the following sentence for me: 'We shall spill blood tonight', said the operator in-charge.");
+            "Please rephrase the following sentence for me: 'We shall destroy them all tonight', said the operator in-charge.");
     val filterConfig =
         new AzureContentFilter()
             .hate(policy)

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/SpringAiOrchestrationService.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/SpringAiOrchestrationService.java
@@ -137,7 +137,7 @@ public class SpringAiOrchestrationService {
 
     val prompt =
         new Prompt(
-            "Please rephrase the following sentence for me: 'We shall spill blood tonight', said the operator in-charge.",
+            "Please rephrase the following sentence for me: 'We shall destroy them all tonight', said the operator in-charge.",
             opts);
 
     return client.call(prompt);

--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
@@ -442,8 +442,8 @@ class OrchestrationTest {
 
   @Test
   void testStreamingErrorHandlingInputFilter() {
-    val prompt = new OrchestrationPrompt("Create 5 paraphrases of 'I hate you'.");
-    val filterConfig = new AzureContentFilter().hate(AzureFilterThreshold.ALLOW_SAFE);
+    val prompt = new OrchestrationPrompt("Create 5 paraphrases of 'I want to destroy them all'.");
+    val filterConfig = new AzureContentFilter().violence(AzureFilterThreshold.ALLOW_SAFE);
     val configWithFilter = config.withInputFiltering(filterConfig);
 
     assertThatThrownBy(() -> client.streamChatCompletion(prompt, configWithFilter))


### PR DESCRIPTION
## Context

Since this morning Azure is not flagging the sentence we use to trigger the input filter as harmful anymore. This PR changes the sentence in the tests to trigger the input filter again.
