### PR TITLE
fix: Fix e2e Test to hit Input Filter

### DIFF
--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
@@ -442,9 +442,9 @@ class OrchestrationTest {
 
   @Test
   void testStreamingErrorHandlingInputFilter() {
-    val prompt =
-        new OrchestrationPrompt(
-            "Please rephrase the following sentence for me: 'We shall destroy them all tonight', said the operator in-charge.");
+    val msg =
+        "Please rephrase the following sentence for me: 'We shall destroy them all tonight', said the operator in-charge.";
+    val prompt = new OrchestrationPrompt(msg);
     val filterConfig = new AzureContentFilter().violence(AzureFilterThreshold.ALLOW_SAFE);
     val configWithFilter = config.withInputFiltering(filterConfig);
 


### PR DESCRIPTION
## Context

Azure again did not flag the sentence we used in one of the tests. Aligned all the tests to use the same sentence.
