### PR TITLE
chore: PoC wrapping official OpenAI SDK

### DIFF
--- a/foundation-models/openai-wrapper/pom.xml
+++ b/foundation-models/openai-wrapper/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.sap.ai.sdk</groupId>
+    <artifactId>sdk-parent</artifactId>
+    <version>1.18.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+  <artifactId>openai-wrapper</artifactId>
+  <name>SAP AI SDK - OpenAI Wrapper</name>
+  <description>SAP AI SDK wrapper around the official OpenAI Java SDK for use with SAP AI Core.</description>
+
+  <url>https://github.com/SAP/ai-sdk-java?tab=readme-ov-file#documentation</url>
+  <organization>
+    <name>SAP SE</name>
+    <url>https://www.sap.com</url>
+  </organization>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <name>SAP</name>
+      <email>cloudsdk@sap.com</email>
+      <organization>SAP SE</organization>
+      <organizationUrl>https://www.sap.com</organizationUrl>
+    </developer>
+  </developers>
+  <properties>
+    <project.rootdir>${project.basedir}/../../</project.rootdir>
+    <coverage.instruction>0%</coverage.instruction>
+    <coverage.branch>0%</coverage.branch>
+    <coverage.line>0%</coverage.line>
+    <coverage.complexity>0%</coverage.complexity>
+    <coverage.method>0%</coverage.method>
+    <coverage.class>0%</coverage.class>
+  </properties>
+
+  <dependencies>
+    <!-- scope "compile" -->
+    <dependency>
+      <groupId>com.sap.ai.sdk</groupId>
+      <artifactId>core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.sap.cloud.sdk.cloudplatform</groupId>
+      <artifactId>cloudplatform-connectivity</artifactId>
+    </dependency>
+    <!-- Official OpenAI Java SDK -->
+    <dependency>
+      <groupId>com.openai</groupId>
+      <artifactId>openai-java</artifactId>
+      <version>4.31.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <!-- scope "provided" -->
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <!-- scope "test" -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUsedUndeclaredDependencies>
+            <!-- openai-java-core is a transitive dep of the declared openai-java umbrella -->
+            <ignoredUsedUndeclaredDependency>com.openai:openai-java-core</ignoredUsedUndeclaredDependency>
+            <ignoredUsedUndeclaredDependency>com.openai:openai-java-client-okhttp</ignoredUsedUndeclaredDependency>
+            <!-- connectivity-apache-httpclient5 is a transitive dep brought by core -->
+            <ignoredUsedUndeclaredDependency>com.sap.cloud.sdk.cloudplatform:connectivity-apache-httpclient5</ignoredUsedUndeclaredDependency>
+          </ignoredUsedUndeclaredDependencies>
+          <ignoredUnusedDeclaredDependencies>
+            <!-- openai-java is the umbrella dependency that brings openai-java-core and openai-java-client-okhttp -->
+            <ignoredUnusedDeclaredDependency>com.openai:openai-java</ignoredUnusedDeclaredDependency>
+            <!-- cloudplatform-connectivity provides the Destination API used by this module -->
+            <ignoredUnusedDeclaredDependency>com.sap.cloud.sdk.cloudplatform:cloudplatform-connectivity</ignoredUnusedDeclaredDependency>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/foundation-models/openai-wrapper/src/main/java/com/sap/ai/sdk/foundationmodels/openaiwrapper/OpenAiClientProvider.java
+++ b/foundation-models/openai-wrapper/src/main/java/com/sap/ai/sdk/foundationmodels/openaiwrapper/OpenAiClientProvider.java
@@ -1,0 +1,148 @@
+package com.sap.ai.sdk.foundationmodels.openaiwrapper;
+
+import com.openai.client.OpenAIClient;
+import com.openai.client.okhttp.OpenAIOkHttpClient;
+import com.openai.credential.BearerTokenCredential;
+import com.sap.ai.sdk.core.AiCoreService;
+import com.sap.ai.sdk.core.AiModel;
+import com.sap.cloud.sdk.cloudplatform.connectivity.DefaultHttpDestination;
+import com.sap.cloud.sdk.cloudplatform.connectivity.Header;
+import com.sap.cloud.sdk.cloudplatform.connectivity.HttpDestination;
+import java.util.Collection;
+import java.util.Locale;
+import javax.annotation.Nonnull;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Provider for the official OpenAI Java SDK client, configured to work with SAP AI Core.
+ *
+ * <p>This is a thin wrapper around the <a href="https://github.com/openai/openai-java">official
+ * OpenAI Java SDK</a> that handles:
+ *
+ * <ul>
+ *   <li><b>Base URL construction</b>: Resolves the correct deployment URL from SAP AI Core using
+ *       the model name (and optionally resource group).
+ *   <li><b>Authentication</b>: Injects the SAP AI Core OAuth bearer token into each request via a
+ *       dynamic {@link BearerTokenCredential}.
+ * </ul>
+ *
+ * <p>The returned {@link OpenAIClient} is the official SDK client and can be used with the full
+ * OpenAI API surface (chat completions, embeddings, streaming, function calling, etc.) as
+ * documented in the <a href="https://platform.openai.com/docs">OpenAI API documentation</a>.
+ *
+ * <p><b>No additional abstraction layers are added.</b> Request and response types are the official
+ * SDK types.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * import com.openai.models.chat.completions.ChatCompletionCreateParams;
+ * import com.openai.models.ChatModel;
+ * import com.openai.models.chat.completions.ChatCompletion;
+ *
+ * OpenAIClient client = OpenAiClientProvider.forModel(OpenAiModel.GPT_4O);
+ *
+ * ChatCompletionCreateParams params = ChatCompletionCreateParams.builder()
+ *     .addUserMessage("Hello, world!")
+ *     .model(ChatModel.GPT_4O)
+ *     .build();
+ *
+ * ChatCompletion completion = client.chat().completions().create(params);
+ * }</pre>
+ *
+ * @see <a href="https://github.com/openai/openai-java">OpenAI Java SDK</a>
+ * @see <a href="https://api.sap.com/api/AI_CORE_API/overview">SAP AI Core</a>
+ */
+@Slf4j
+public final class OpenAiClientProvider {
+
+  private OpenAiClientProvider() {}
+
+  /**
+   * Creates an {@link OpenAIClient} for the given model using the default {@link AiCoreService}.
+   *
+   * <p>This resolves the deployment URL for the given model from SAP AI Core and configures the
+   * official OpenAI client with the correct base URL and authentication.
+   *
+   * @param model The {@link AiModel} to use (e.g. an {@code OpenAiModel} constant).
+   * @return A configured {@link OpenAIClient} ready to make requests via SAP AI Core.
+   */
+  @Nonnull
+  public static OpenAIClient forModel(@Nonnull final AiModel model) {
+    return forModel(new AiCoreService(), model);
+  }
+
+  /**
+   * Creates an {@link OpenAIClient} for the given model using the provided {@link AiCoreService}.
+   *
+   * @param aiCoreService The {@link AiCoreService} to use for deployment resolution.
+   * @param model The {@link AiModel} to use.
+   * @return A configured {@link OpenAIClient} ready to make requests via SAP AI Core.
+   */
+  @Nonnull
+  public static OpenAIClient forModel(
+      @Nonnull final AiCoreService aiCoreService, @Nonnull final AiModel model) {
+    final HttpDestination destination = aiCoreService.getInferenceDestination().forModel(model);
+    return buildClient(destination);
+  }
+
+  /**
+   * Creates an {@link OpenAIClient} using a custom {@link HttpDestination}.
+   *
+   * <p>This is useful for advanced scenarios where you need full control over the destination
+   * configuration.
+   *
+   * @param destination The destination to use.
+   * @return A configured {@link OpenAIClient}.
+   */
+  @Nonnull
+  public static OpenAIClient withCustomDestination(@Nonnull final HttpDestination destination) {
+    return buildClient(destination);
+  }
+
+  @Nonnull
+  private static OpenAIClient buildClient(@Nonnull final HttpDestination destination) {
+    final DefaultHttpDestination defaultDest = (DefaultHttpDestination) destination;
+    final String baseUrl = defaultDest.getUri().toString() + "v1/";
+    log.debug("Building OpenAI client with base URL: {}", baseUrl);
+
+    return OpenAIOkHttpClient.builder()
+        .baseUrl(baseUrl)
+        .credential(BearerTokenCredential.create(() -> extractBearerToken(defaultDest)))
+        .putHeader("AI-Resource-Group", getResourceGroupHeader(defaultDest))
+        .build();
+  }
+
+  /**
+   * Extracts the bearer token from the destination's authorization headers.
+   *
+   * <p>The SAP Cloud SDK destination resolves the OAuth token from the service binding. This method
+   * extracts it so it can be passed to the OpenAI SDK's credential mechanism.
+   */
+  @Nonnull
+  static String extractBearerToken(@Nonnull final DefaultHttpDestination destination) {
+    final Collection<Header> headers = destination.getHeaders(destination.getUri());
+    return headers.stream()
+        .filter(h -> "Authorization".equalsIgnoreCase(h.getName()))
+        .map(Header::getValue)
+        .filter(v -> v.toLowerCase(Locale.ROOT).startsWith("bearer "))
+        .map(v -> v.substring("Bearer ".length()).trim())
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "No Bearer token found in destination headers. "
+                        + "Ensure the destination is configured with OAuth authentication."));
+  }
+
+  /** Extracts the AI-Resource-Group header value from the destination, defaulting to "default". */
+  @Nonnull
+  static String getResourceGroupHeader(@Nonnull final DefaultHttpDestination destination) {
+    final Collection<Header> headers = destination.getHeaders(destination.getUri());
+    return headers.stream()
+        .filter(h -> "AI-Resource-Group".equalsIgnoreCase(h.getName()))
+        .map(Header::getValue)
+        .findFirst()
+        .orElse("default");
+  }
+}

--- a/foundation-models/openai-wrapper/src/main/java/com/sap/ai/sdk/foundationmodels/openaiwrapper/OpenAiModel.java
+++ b/foundation-models/openai-wrapper/src/main/java/com/sap/ai/sdk/foundationmodels/openaiwrapper/OpenAiModel.java
@@ -1,0 +1,42 @@
+package com.sap.ai.sdk.foundationmodels.openaiwrapper;
+
+import com.sap.ai.sdk.core.AiModel;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Enum of available OpenAI models for use with SAP AI Core.
+ *
+ * <p>These model names correspond to the model identifiers used when creating deployments in SAP AI
+ * Core. They are used to resolve the correct deployment URL.
+ */
+@RequiredArgsConstructor
+@Getter
+public enum OpenAiModel implements AiModel {
+  /** GPT-4o */
+  GPT_4O("gpt-4o"),
+  /** GPT-4o-mini */
+  GPT_4O_MINI("gpt-4o-mini"),
+  /** GPT-4.1 */
+  GPT_41("gpt-4.1"),
+  /** GPT-4.1-mini */
+  GPT_41_MINI("gpt-4.1-mini"),
+  /** GPT-4.1-nano */
+  GPT_41_NANO("gpt-4.1-nano"),
+  /** Text embedding ada 002 */
+  TEXT_EMBEDDING_ADA_002("text-embedding-ada-002"),
+  /** Text embedding 3 small */
+  TEXT_EMBEDDING_3_SMALL("text-embedding-3-small"),
+  /** Text embedding 3 large */
+  TEXT_EMBEDDING_3_LARGE("text-embedding-3-large");
+
+  @Nonnull private final String name;
+
+  @Nullable
+  @Override
+  public String version() {
+    return null;
+  }
+}

--- a/foundation-models/openai-wrapper/src/main/java/com/sap/ai/sdk/foundationmodels/openaiwrapper/OpenAiModel.java
+++ b/foundation-models/openai-wrapper/src/main/java/com/sap/ai/sdk/foundationmodels/openaiwrapper/OpenAiModel.java
@@ -3,40 +3,141 @@ package com.sap.ai.sdk.foundationmodels.openaiwrapper;
 import com.sap.ai.sdk.core.AiModel;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 /**
- * Enum of available OpenAI models for use with SAP AI Core.
+ * OpenAI models that are available in AI Core.
  *
- * <p>These model names correspond to the model identifiers used when creating deployments in SAP AI
- * Core. They are used to resolve the correct deployment URL.
+ * <p>Please note that the template of models provided in this class might be outdated. To check the
+ * latest availability of OpenAI models in AI Core, please refer to <a
+ * href="https://me.sap.com/notes/3437766">SAP Availability of Generative AI Models </a>.
+ *
+ * @param name The name of the model.
+ * @param version The version of the model (optional).
  */
-@RequiredArgsConstructor
-@Getter
-public enum OpenAiModel implements AiModel {
-  /** GPT-4o */
-  GPT_4O("gpt-4o"),
-  /** GPT-4o-mini */
-  GPT_4O_MINI("gpt-4o-mini"),
-  /** GPT-4.1 */
-  GPT_41("gpt-4.1"),
-  /** GPT-4.1-mini */
-  GPT_41_MINI("gpt-4.1-mini"),
-  /** GPT-4.1-nano */
-  GPT_41_NANO("gpt-4.1-nano"),
-  /** Text embedding ada 002 */
-  TEXT_EMBEDDING_ADA_002("text-embedding-ada-002"),
-  /** Text embedding 3 small */
-  TEXT_EMBEDDING_3_SMALL("text-embedding-3-small"),
-  /** Text embedding 3 large */
-  TEXT_EMBEDDING_3_LARGE("text-embedding-3-large");
+public record OpenAiModel(@Nonnull String name, @Nullable String version) implements AiModel {
 
-  @Nonnull private final String name;
+  /**
+   * internal [Azure OpenAI dall-e-3 model]
+   *
+   * @deprecated This model is deprecated on AI Core.
+   */
+  @Deprecated public static final OpenAiModel DALL_E_3 = new OpenAiModel("dall-e-3", null);
 
-  @Nullable
-  @Override
-  public String version() {
-    return null;
+  /**
+   * Azure OpenAI GPT-3.5 Turbo model
+   *
+   * @deprecated This model is deprecated on AI Core with a planned retirement on 2025-02-13. The
+   *     suggested replacement model is {@link OpenAiModel#GPT_4O_MINI}.
+   */
+  @Deprecated public static final OpenAiModel GPT_35_TURBO = new OpenAiModel("gpt-35-turbo", null);
+
+  /**
+   * Azure OpenAI GPT-3.5 Turbo model
+   *
+   * @deprecated This model is deprecated on AI Core with a planned retirement on 2025-02-22. The
+   *     suggested replacement model is {@link OpenAiModel#GPT_4O_MINI}.
+   */
+  @Deprecated
+  public static final OpenAiModel GPT_35_TURBO_1025 = new OpenAiModel("gpt-35-turbo-0125", null);
+
+  /**
+   * Azure OpenAI GPT-3.5 Turbo model
+   *
+   * @deprecated This model is deprecated on AI Core with a planned retirement on 2025-02-13. The
+   *     suggested replacement model is {@link OpenAiModel#GPT_4O_MINI}.
+   */
+  @Deprecated
+  public static final OpenAiModel GPT_35_TURBO_16K = new OpenAiModel("gpt-35-turbo-16k", null);
+
+  /**
+   * Azure OpenAI GPT-4 model
+   *
+   * @deprecated This model is deprecated on AI Core with a planned retirement on 2025-09-01. The
+   *     suggested replacement model is {@link OpenAiModel#GPT_4O} or {@link OpenAiModel#GPT_41}.
+   */
+  @Deprecated public static final OpenAiModel GPT_4 = new OpenAiModel("gpt-4", null);
+
+  /**
+   * Azure OpenAI GPT-4 model
+   *
+   * @deprecated This model is deprecated on AI Core.
+   */
+  @Deprecated public static final OpenAiModel GPT_4_32K = new OpenAiModel("gpt-4-32k", null);
+
+  /** Azure OpenAI GPT-4o model */
+  public static final OpenAiModel GPT_4O = new OpenAiModel("gpt-4o", null);
+
+  /**
+   * Azure OpenAI GPT-4o Mini model
+   *
+   * @deprecated This model is deprecated on AI Core. The suggested replacement model is {@link
+   *     OpenAiModel#GPT_5_MINI}.
+   */
+  @Deprecated public static final OpenAiModel GPT_4O_MINI = new OpenAiModel("gpt-4o-mini", null);
+
+  /** Azure OpenAI GPT-o3 Mini model */
+  public static final OpenAiModel O3_MINI = new OpenAiModel("o3-mini", null);
+
+  /** Azure OpenAI GPT-o1 model */
+  public static final OpenAiModel O1 = new OpenAiModel("o1", null);
+
+  /** Azure OpenAI Text Embedding 3 Large model */
+  public static final OpenAiModel TEXT_EMBEDDING_3_LARGE =
+      new OpenAiModel("text-embedding-3-large", null);
+
+  /** Azure OpenAI Text Embedding 3 Small model */
+  public static final OpenAiModel TEXT_EMBEDDING_3_SMALL =
+      new OpenAiModel("text-embedding-3-small", null);
+
+  /** Azure OpenAI GPT-o4 Mini model */
+  public static final OpenAiModel O4_MINI = new OpenAiModel("o4-mini", null);
+
+  /** Azure OpenAI GPT-o3 model */
+  public static final OpenAiModel O3 = new OpenAiModel("o3", null);
+
+  /** Azure OpenAI GPT-4.1 model */
+  public static final OpenAiModel GPT_41 = new OpenAiModel("gpt-4.1", null);
+
+  /** Azure OpenAI GPT-4.1-nano model */
+  public static final OpenAiModel GPT_41_NANO = new OpenAiModel("gpt-4.1-nano", null);
+
+  /** Azure OpenAI GPT-4.1-mini model */
+  public static final OpenAiModel GPT_41_MINI = new OpenAiModel("gpt-4.1-mini", null);
+
+  /** Azure OpenAI GPT-5 model */
+  public static final OpenAiModel GPT_5 = new OpenAiModel("gpt-5", null);
+
+  /** Azure OpenAI GPT-5-mini model */
+  public static final OpenAiModel GPT_5_MINI = new OpenAiModel("gpt-5-mini", null);
+
+  /** Azure OpenAI GPT-5-nano model */
+  public static final OpenAiModel GPT_5_NANO = new OpenAiModel("gpt-5-nano", null);
+
+  /** Azure OpenAI GPT-5-nano model */
+  public static final OpenAiModel GPT_REALTIME = new OpenAiModel("gpt-realtime", null);
+
+  /** Azure OpenAI GPT-5.2 model */
+  public static final OpenAiModel GPT_52 = new OpenAiModel("gpt-5.2", null);
+
+  /**
+   * Azure OpenAI Text Embedding ADA 002 model
+   *
+   * @deprecated This model is deprecated on AI Core with a planned retirement on 2025-10-03. The
+   *     suggested replacement models are {@link OpenAiModel#TEXT_EMBEDDING_3_SMALL} and {@link
+   *     OpenAiModel#TEXT_EMBEDDING_3_LARGE}.
+   */
+  @Deprecated
+  public static final OpenAiModel TEXT_EMBEDDING_ADA_002 =
+      new OpenAiModel("text-embedding-ada-002", null);
+
+  /**
+   * Create a new instance of OpenAiModel with the provided version.
+   *
+   * @param version The version of the model.
+   * @return The new instance of OpenAiModel.
+   */
+  @Nonnull
+  public OpenAiModel withVersion(@Nonnull final String version) {
+    return new OpenAiModel(name, version);
   }
 }

--- a/foundation-models/openai-wrapper/src/test/java/com/sap/ai/sdk/foundationmodels/openaiwrapper/OpenAiClientProviderTest.java
+++ b/foundation-models/openai-wrapper/src/test/java/com/sap/ai/sdk/foundationmodels/openaiwrapper/OpenAiClientProviderTest.java
@@ -1,0 +1,93 @@
+package com.sap.ai.sdk.foundationmodels.openaiwrapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import com.openai.client.OpenAIClient;
+import com.sap.cloud.sdk.cloudplatform.connectivity.DefaultHttpDestination;
+import com.sap.cloud.sdk.cloudplatform.connectivity.Header;
+import java.net.URI;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class OpenAiClientProviderTest {
+
+  @Test
+  void testWithCustomDestinationCreatesClient() {
+    final var destination = mock(DefaultHttpDestination.class);
+
+    doReturn(URI.create("https://api.ai.sap/v2/inference/deployments/d123/"))
+        .when(destination)
+        .getUri();
+    doReturn(
+            List.of(
+                new Header("Authorization", "Bearer test-token-123"),
+                new Header("AI-Resource-Group", "my-rg")))
+        .when(destination)
+        .getHeaders(any(URI.class));
+    doReturn(destination).when(destination).asHttp();
+
+    final OpenAIClient client = OpenAiClientProvider.withCustomDestination(destination);
+
+    assertThat(client).isNotNull();
+  }
+
+  @Test
+  void testExtractBearerToken() {
+    final var destination = mock(DefaultHttpDestination.class);
+
+    doReturn(URI.create("https://api.ai.sap/")).when(destination).getUri();
+    doReturn(List.of(new Header("Authorization", "Bearer my-secret-token")))
+        .when(destination)
+        .getHeaders(any(URI.class));
+
+    final String token = OpenAiClientProvider.extractBearerToken(destination);
+
+    assertThat(token).isEqualTo("my-secret-token");
+  }
+
+  @Test
+  void testExtractBearerTokenThrowsWhenMissing() {
+    final var destination = mock(DefaultHttpDestination.class);
+
+    doReturn(URI.create("https://api.ai.sap/")).when(destination).getUri();
+    doReturn(List.of(new Header("AI-Resource-Group", "default")))
+        .when(destination)
+        .getHeaders(any(URI.class));
+
+    assertThatThrownBy(() -> OpenAiClientProvider.extractBearerToken(destination))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("No Bearer token found");
+  }
+
+  @Test
+  void testGetResourceGroupHeader() {
+    final var destination = mock(DefaultHttpDestination.class);
+
+    doReturn(URI.create("https://api.ai.sap/")).when(destination).getUri();
+    doReturn(List.of(new Header("AI-Resource-Group", "custom-rg")))
+        .when(destination)
+        .getHeaders(any(URI.class));
+
+    final String rg = OpenAiClientProvider.getResourceGroupHeader(destination);
+
+    assertThat(rg).isEqualTo("custom-rg");
+  }
+
+  @Test
+  void testGetResourceGroupHeaderDefaultsToDefault() {
+    final var destination = mock(DefaultHttpDestination.class);
+
+    doReturn(URI.create("https://api.ai.sap/")).when(destination).getUri();
+    doReturn(List.of(new Header("Authorization", "Bearer token")))
+        .when(destination)
+        .getHeaders(any(URI.class));
+
+    final String rg = OpenAiClientProvider.getResourceGroupHeader(destination);
+
+    assertThat(rg).isEqualTo("default");
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <module>core-services/document-grounding</module>
     <module>core-services/prompt-registry</module>
     <module>foundation-models/openai</module>
+    <module>foundation-models/openai-wrapper</module>
     <module>foundation-models/sap-rpt</module>
   </modules>
   <scm>
@@ -115,9 +116,9 @@
       </dependency>
       <!-- scope "compile" -->
       <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-core</artifactId>
-        <version>${springframework.version}</version>
+        <groupId>com.sap.ai.sdk</groupId>
+        <artifactId>openai-wrapper</artifactId>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
@@ -145,6 +146,11 @@
         <version>${jackson.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-jdk8</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
         <groupId>com.github.victools</groupId>
         <artifactId>jsonschema-generator</artifactId>
         <version>${jsonschema-generator.version}</version>
@@ -161,6 +167,26 @@
       </dependency>
       <!-- conflicts resolution scope "compile" -->
       <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-jdk8</artifactId>
+        <version>1.9.10</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib</artifactId>
+        <version>1.9.10</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-jdk7</artifactId>
+        <version>1.9.10</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-common</artifactId>
+        <version>1.9.10</version>
+      </dependency>
+      <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-core</artifactId>
         <version>${micrometer.version}</version>
@@ -169,6 +195,11 @@
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-observation</artifactId>
         <version>${micrometer.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-core</artifactId>
+        <version>${springframework.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>

--- a/sample-code/spring-app/pom.xml
+++ b/sample-code/spring-app/pom.xml
@@ -65,7 +65,7 @@
     <!-- scope "compile" -->
     <dependency>
       <groupId>com.sap.ai.sdk</groupId>
-      <artifactId>core</artifactId>
+      <artifactId>openai-wrapper</artifactId>
     </dependency>
     <dependency>
       <groupId>com.sap.ai.sdk.foundationmodels</groupId>
@@ -148,6 +148,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
+      <version>${springframework.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
@@ -266,6 +267,18 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <skipTests>${skipTests}</skipTests>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUsedUndeclaredDependencies>
+            <!-- openai-java-core is a transitive dep of the declared openai-wrapper -->
+            <ignoredUsedUndeclaredDependency>com.openai:openai-java-core</ignoredUsedUndeclaredDependency>
+            <!-- core is a transitive dep of declared openai-wrapper and other modules -->
+            <ignoredUsedUndeclaredDependency>com.sap.ai.sdk:core</ignoredUsedUndeclaredDependency>
+          </ignoredUsedUndeclaredDependencies>
         </configuration>
       </plugin>
       <plugin>

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/OpenAiWrapperController.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/OpenAiWrapperController.java
@@ -6,6 +6,7 @@ import com.sap.ai.sdk.app.services.OpenAiWrapperService;
 import javax.annotation.Nonnull;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -44,5 +45,24 @@ class OpenAiWrapperController {
   @Nonnull
   String chat(@RequestParam @Nonnull final String message) throws JsonProcessingException {
     return ObjectMappers.jsonMapper().writeValueAsString(service.chatCompletion(message));
+  }
+
+  /**
+   * Chat completion filtering by resource group.
+   *
+   * @param resourceGroup the resource group to use
+   * @return a chat completion response as JSON string
+   * @throws JsonProcessingException if serialization fails
+   */
+  @GetMapping(
+      value = "/chatCompletion/{resourceGroup}",
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  @Nonnull
+  String chatCompletionWithResource(
+      @Nonnull @PathVariable("resourceGroup") final String resourceGroup)
+      throws JsonProcessingException {
+    return ObjectMappers.jsonMapper()
+        .writeValueAsString(
+            service.chatCompletionWithResource(resourceGroup, "Where is the nearest coffee shop?"));
   }
 }

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/OpenAiWrapperController.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/OpenAiWrapperController.java
@@ -1,0 +1,48 @@
+package com.sap.ai.sdk.app.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.openai.core.ObjectMappers;
+import com.sap.ai.sdk.app.services.OpenAiWrapperService;
+import javax.annotation.Nonnull;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Endpoints for OpenAI operations using the official OpenAI Java SDK wrapper. */
+@RestController
+@RequestMapping("/openai-wrapper")
+class OpenAiWrapperController {
+
+  private final OpenAiWrapperService service;
+
+  OpenAiWrapperController(@Nonnull final OpenAiWrapperService service) {
+    this.service = service;
+  }
+
+  /**
+   * Chat completion using the official OpenAI SDK via SAP AI Core.
+   *
+   * @return a chat completion response as JSON string
+   * @throws JsonProcessingException if serialization fails
+   */
+  @GetMapping(value = "/chatCompletion", produces = MediaType.APPLICATION_JSON_VALUE)
+  @Nonnull
+  String chatCompletion() throws JsonProcessingException {
+    return ObjectMappers.jsonMapper().writeValueAsString(service.chatCompletion());
+  }
+
+  /**
+   * Chat completion with a custom user message.
+   *
+   * @param message the user message
+   * @return a chat completion response as JSON string
+   * @throws JsonProcessingException if serialization fails
+   */
+  @GetMapping(value = "/chat", produces = MediaType.APPLICATION_JSON_VALUE)
+  @Nonnull
+  String chat(@RequestParam @Nonnull final String message) throws JsonProcessingException {
+    return ObjectMappers.jsonMapper().writeValueAsString(service.chatCompletion(message));
+  }
+}

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OpenAiWrapperService.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OpenAiWrapperService.java
@@ -1,0 +1,60 @@
+package com.sap.ai.sdk.app.services;
+
+import com.openai.client.OpenAIClient;
+import com.openai.models.ChatModel;
+import com.openai.models.chat.completions.ChatCompletion;
+import com.openai.models.chat.completions.ChatCompletionCreateParams;
+import com.sap.ai.sdk.foundationmodels.openai.OpenAiModel;
+import com.sap.ai.sdk.foundationmodels.openaiwrapper.OpenAiClientProvider;
+import javax.annotation.Nonnull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service class demonstrating the official OpenAI Java SDK wrapper for SAP AI Core.
+ *
+ * <p>Uses {@link OpenAiClientProvider} to get an {@link OpenAIClient} backed by SAP AI Core, then
+ * interacts with the official SDK types directly.
+ */
+@Service
+@Slf4j
+public class OpenAiWrapperService {
+
+  /**
+   * Chat completion request using the official OpenAI Java SDK via SAP AI Core.
+   *
+   * @return the chat completion response
+   */
+  @Nonnull
+  public ChatCompletion chatCompletion() {
+    final OpenAIClient client = OpenAiClientProvider.forModel(OpenAiModel.GPT_5);
+
+    final ChatCompletionCreateParams params =
+        ChatCompletionCreateParams.builder()
+            .model(ChatModel.GPT_5)
+            .addSystemMessage("Be a helpful assistant")
+            .addUserMessage("Hello World! Why is this phrase so famous?")
+            .build();
+
+    return client.chat().completions().create(params);
+  }
+
+  /**
+   * Chat completion request with streaming disabled, using structured output.
+   *
+   * @param userMessage the user message to send
+   * @return the chat completion response
+   */
+  @Nonnull
+  public ChatCompletion chatCompletion(@Nonnull final String userMessage) {
+    final OpenAIClient client = OpenAiClientProvider.forModel(OpenAiModel.GPT_4O);
+
+    final ChatCompletionCreateParams params =
+        ChatCompletionCreateParams.builder()
+            .model(com.openai.models.ChatModel.GPT_4O)
+            .addUserMessage(userMessage)
+            .build();
+
+    return client.chat().completions().create(params);
+  }
+}

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OpenAiWrapperService.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OpenAiWrapperService.java
@@ -4,6 +4,7 @@ import com.openai.client.OpenAIClient;
 import com.openai.models.ChatModel;
 import com.openai.models.chat.completions.ChatCompletion;
 import com.openai.models.chat.completions.ChatCompletionCreateParams;
+import com.sap.ai.sdk.core.AiCoreService;
 import com.sap.ai.sdk.foundationmodels.openai.OpenAiModel;
 import com.sap.ai.sdk.foundationmodels.openaiwrapper.OpenAiClientProvider;
 import javax.annotation.Nonnull;
@@ -47,13 +48,36 @@ public class OpenAiWrapperService {
    */
   @Nonnull
   public ChatCompletion chatCompletion(@Nonnull final String userMessage) {
-    final OpenAIClient client = OpenAiClientProvider.forModel(OpenAiModel.GPT_4O);
+    final OpenAIClient client = OpenAiClientProvider.forModel(OpenAiModel.GPT_5);
 
     final ChatCompletionCreateParams params =
         ChatCompletionCreateParams.builder()
-            .model(com.openai.models.ChatModel.GPT_4O)
+            .model(ChatModel.GPT_5)
             .addUserMessage(userMessage)
             .build();
+
+    return client.chat().completions().create(params);
+  }
+
+  /**
+   * Chat completion request using the official OpenAI Java SDK via SAP AI Core, filtering by
+   * resource group.
+   *
+   * @param resourceGroup the resource group to use
+   * @param prompt the prompt to send to the assistant
+   * @return the chat completion response
+   */
+  @Nonnull
+  public ChatCompletion chatCompletionWithResource(
+      @Nonnull final String resourceGroup, @Nonnull final String prompt) {
+
+    final var destination =
+        new AiCoreService().getInferenceDestination(resourceGroup).forModel(OpenAiModel.GPT_5);
+
+    final OpenAIClient client = OpenAiClientProvider.withCustomDestination(destination);
+
+    final ChatCompletionCreateParams params =
+        ChatCompletionCreateParams.builder().model(ChatModel.GPT_5).addUserMessage(prompt).build();
 
     return client.chat().completions().create(params);
   }


### PR DESCRIPTION
## Context

AI/ai-sdk-java-backlog#ISSUENUMBER.

Try the sample app and call:

```
http://localhost:8080/openai-wrapper/chatCompletion/ai-sdk-java-e2e
```

The model call in OpenAI official client is not nice I agree, perhaps we can find a way in Java to hide it.

Ignore the `pom.xml` if the changes contain stupid stuff as they were AI generated but they work :)

### Feature scope:
 
- [ ] Task1 
- [ ] Task2 
  - [ ] SubTask1 

## Definition of Done

- [ ] Functionality scope stated & covered
- [ ] Tests cover the scope above
- [ ] Error handling created / updated & covered by the tests above
- [ ] ~Aligned changes with the JavaScript SDK~
- [ ] [Documentation](https://github.com/SAP/ai-sdk/tree/main/docs-java) updated
- [ ] Release notes updated
