### PR TITLE
chore: Bump version of mpc-core to avoid CVE-2026-35568

### DIFF
--- a/sample-code/spring-app/pom.xml
+++ b/sample-code/spring-app/pom.xml
@@ -37,6 +37,7 @@
     <logback.version>1.5.32</logback.version>
     <cf-logging.version>4.2.0</cf-logging.version>
     <apache-tomcat-embed.version>11.0.21</apache-tomcat-embed.version>
+    <mcp-core.version>1.1.1</mcp-core.version>
     <!-- Skip end-to-end tests by default, can be overridden with -DskipTests=false -->
     <skipTests>true</skipTests>
     <!-- Allow logging frameworks because this module is not released -->
@@ -114,6 +115,18 @@
     <dependency>
       <groupId>org.springframework.ai</groupId>
       <artifactId>spring-ai-mcp</artifactId>
+      <scope>runtime</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.modelcontextprotocol.sdk</groupId>
+          <artifactId>mcp-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.modelcontextprotocol.sdk</groupId>
+      <artifactId>mcp-core</artifactId>
+      <version>${mcp-core.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Context

This PR bumps the version of `io.modelcontextprotocol.sdk:mcp-core` to avoid [CVE-2026-35568](https://nvd.nist.gov/vuln/detail/CVE-2026-35568).

