### PR TITLE
fix: [Core] Update deployment test to use `orchestration` scenario

### DIFF
--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/DeploymentController.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/DeploymentController.java
@@ -34,7 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
 class DeploymentController {
 
   private static final DeploymentApi CLIENT = new DeploymentApi();
-  private static final String RESOURCE_GROUP = "default";
+  private static final String RESOURCE_GROUP = "ai-sdk-java-e2e";
 
   /** Create and delete a deployment with the Java specific configuration ID. */
   @Nullable

--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/DeploymentTest.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/DeploymentTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 
 class DeploymentTest {
   /** Java end-to-end test specific configuration ID. "name":"config-java-e2e-test-gpt-5" */
-  public static final String CONFIG_ID = "9db691a2-a136-41c9-8fe1-1ffad5a63594";
+  public static final String CONFIG_ID = "e88f7dba-fd9c-4068-ab18-3306f2aa46bd";
 
   /**
    * Manual execution to create a new config for a new model when the current model gets deprecated.


### PR DESCRIPTION
## Context

AI/ai-sdk-java-backlog#ISSUENUMBER.

Change deployment test from `foundationmodels` to `orchestration` scenario. Also, change resource group to `ai-sdk-java-e2e` for sake of deployment maintainability, for example, deletion without concern of shared use by JS.

Turns out the current limit of 81 deployment doesn't apply to orchestration deployment.

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Aligned changes with the JavaScript SDK~
- [ ] ~[Documentation](https://github.com/SAP/ai-sdk/tree/main/docs-java) updated~
- [ ] ~Release notes updated~
