### PR TITLE
fix: [DevOps] Switch to app token instead of GITHUB_TOKEN in release

### DIFF
--- a/.github/workflows/perform-release.yaml
+++ b/.github/workflows/perform-release.yaml
@@ -122,7 +122,7 @@ jobs:
           # x=extract v=verbose z=decompress f=file C=destination directory
           tar -xvzf release-artifacts.tar.gz -C .
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: 'Import GPG Key'
         run: |


### PR DESCRIPTION
## Context

AI/ai-sdk-java-backlog#ISSUENUMBER.

Currently, downloading asset fails as the **draft** release is not visible with just `read` permission on the repo. So, I am switching to the available app token


## Definition of Done

- [x] Functionality scope stated & covered
- [ ] ~Tests cover the scope above~
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Aligned changes with the JavaScript SDK~
- [ ] ~[Documentation](https://github.com/SAP/ai-sdk/tree/main/docs-java) updated~
- [ ] ~Release notes updated~
