### PR TITLE
fix: [DevOps] Update perform-release.yaml permission

### DIFF
--- a/.github/workflows/perform-release.yaml
+++ b/.github/workflows/perform-release.yaml
@@ -21,7 +21,7 @@ jobs:
   prerequisites:
     name: 'Prerequisites'
     permissions:
-      contents: read
+      contents: write # needed to view draft releases
       pull-requests: read
       statuses: read
       checks: read


### PR DESCRIPTION
Requires write permission to view draft release. Otherwise fails with "release not found".

Failing Perform Release: https://github.com/SAP/ai-sdk-java/actions/runs/25552804105/job/75004510691#step:2:24
List of available release tags: https://github.com/SAP/ai-sdk-java/tags

