### PR TITLE
chore: Update to Spring AI 1.1.6 to resolve CVE

### DIFF
--- a/foundation-models/openai/src/test/java/com/sap/ai/sdk/foundationmodels/openai/spring/OpenAiChatModelTest.java
+++ b/foundation-models/openai/src/test/java/com/sap/ai/sdk/foundationmodels/openai/spring/OpenAiChatModelTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
+import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.chat.messages.AssistantMessage.ToolCall;
@@ -225,8 +226,14 @@ public class OpenAiChatModelTest {
     val prompt1 = new Prompt("What is the capital of France?");
     val prompt2 = new Prompt("And what is the typical food there?");
 
-    cl.prompt(prompt1).call().content();
-    cl.prompt(prompt2).call().content();
+    cl.prompt(prompt1)
+        .advisors(spec -> spec.param(ChatMemory.CONVERSATION_ID, "test-conversation"))
+        .call()
+        .content();
+    cl.prompt(prompt2)
+        .advisors(spec -> spec.param(ChatMemory.CONVERSATION_ID, "test-conversation"))
+        .call()
+        .content();
     // The response is not important
     // We just want to verify that the second call remembered the first call
     try (var requestInputStream = fileLoader.apply("chatMemory.json")) {

--- a/orchestration/src/test/java/com/sap/ai/sdk/orchestration/spring/OrchestrationChatModelTest.java
+++ b/orchestration/src/test/java/com/sap/ai/sdk/orchestration/spring/OrchestrationChatModelTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
+import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.chat.messages.AssistantMessage.ToolCall;
@@ -246,8 +247,14 @@ class OrchestrationChatModelTest {
     val prompt1 = new Prompt("What is the capital of France?", defaultOptions);
     val prompt2 = new Prompt("And what is the typical food there?", defaultOptions);
 
-    cl.prompt(prompt1).call().content();
-    cl.prompt(prompt2).call().content();
+    cl.prompt(prompt1)
+        .advisors(spec -> spec.param(ChatMemory.CONVERSATION_ID, "test-conversation"))
+        .call()
+        .content();
+    cl.prompt(prompt2)
+        .advisors(spec -> spec.param(ChatMemory.CONVERSATION_ID, "test-conversation"))
+        .call()
+        .content();
     // The response is not important
     // We just want to verify that the second call remembered the first call
     try (var requestInputStream = fileLoader.apply("chatMemory.json")) {

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <checkstyle.version>13.4.1</checkstyle.version>
     <system-stubs.version>2.1.3</system-stubs.version>
     <surefire.version>3.5.5</surefire.version>
-    <spring-ai.version>1.1.5</spring-ai.version>
+    <spring-ai.version>1.1.6</spring-ai.version>
     <reactor-core.version>3.8.5</reactor-core.version>
     <dotenv-java.version>3.2.0</dotenv-java.version>
     <mockito.version>5.23.0</mockito.version>

--- a/sample-code/spring-app/pom.xml
+++ b/sample-code/spring-app/pom.xml
@@ -59,6 +59,12 @@
         <artifactId>tomcat-embed-websocket</artifactId>
         <version>${apache-tomcat-embed.version}</version>
       </dependency>
+      <!-- Pin mcp-core to align with spring-ai-client-chat transitive dependency -->
+      <dependency>
+        <groupId>io.modelcontextprotocol.sdk</groupId>
+        <artifactId>mcp-core</artifactId>
+        <version>${mcp-core.version}</version>
+      </dependency>
       <!-- Enforce consistent Junit version -->
       <dependency>
         <groupId>org.junit</groupId>

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/PromptRegistryController.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/controllers/PromptRegistryController.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import lombok.val;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
+import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.chat.messages.Message;
@@ -147,7 +148,11 @@ class PromptRegistryController {
 
     final List<Message> messages = SpringAiConverter.promptTemplateToMessages(promptResponse);
     val prompt = new Prompt(messages);
-    val response = cl.prompt(prompt).call().chatResponse();
+    val response =
+        cl.prompt(prompt)
+            .advisors(spec -> spec.param(ChatMemory.CONVERSATION_ID, "conversation id"))
+            .call()
+            .chatResponse();
     return response != null ? response.getResult() : null;
   }
 

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/SpringAiAgenticWorkflowService.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/SpringAiAgenticWorkflowService.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
+import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.chat.model.ChatModel;
@@ -68,7 +69,12 @@ public class SpringAiAgenticWorkflowService {
 
       // Make a call to the LLM with the new input
       response =
-          Objects.requireNonNull(cl.prompt(prompt).call().chatResponse(), "Chat response is null.");
+          Objects.requireNonNull(
+              cl.prompt(prompt)
+                  .advisors(spec -> spec.param(ChatMemory.CONVERSATION_ID, "conversation id"))
+                  .call()
+                  .chatResponse(),
+              "Chat response is null.");
       responseText = response.getResult().getOutput().getText();
     }
 

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/SpringAiOpenAiService.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/SpringAiOpenAiService.java
@@ -10,6 +10,7 @@ import javax.annotation.Nonnull;
 import lombok.val;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
+import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.chat.model.ChatModel;
@@ -112,8 +113,15 @@ public class SpringAiOpenAiService {
     val prompt1 = new Prompt("What is the capital of France?");
     val prompt2 = new Prompt("And what is the typical food there?");
 
-    cl.prompt(prompt1).call().content();
+    cl.prompt(prompt1)
+        .advisors(spec -> spec.param(ChatMemory.CONVERSATION_ID, "conversation id"))
+        .call()
+        .content();
     return Objects.requireNonNull(
-        cl.prompt(prompt2).call().chatResponse(), "Chat response is null");
+        cl.prompt(prompt2)
+            .advisors(spec -> spec.param(ChatMemory.CONVERSATION_ID, "conversation id"))
+            .call()
+            .chatResponse(),
+        "Chat response is null");
   }
 }

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/SpringAiOrchestrationService.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/SpringAiOrchestrationService.java
@@ -23,6 +23,7 @@ import javax.annotation.Nullable;
 import lombok.val;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
+import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.chat.messages.SystemMessage;
@@ -234,9 +235,16 @@ public class SpringAiOrchestrationService {
     val prompt1 = new Prompt("What is the capital of France?", defaultOptions);
     val prompt2 = new Prompt("And what is the typical food there?", defaultOptions);
 
-    cl.prompt(prompt1).call().content();
+    cl.prompt(prompt1)
+        .advisors(spec -> spec.param(ChatMemory.CONVERSATION_ID, "conversation id"))
+        .call()
+        .content();
     return Objects.requireNonNull(
-        cl.prompt(prompt2).call().chatResponse(), "Chat response is null");
+        cl.prompt(prompt2)
+            .advisors(spec -> spec.param(ChatMemory.CONVERSATION_ID, "conversation id"))
+            .call()
+            .chatResponse(),
+        "Chat response is null");
   }
 
   /**


### PR DESCRIPTION
## Context

This PR updates Spring AI to `1.1.6` to resolve 3 CVEs found by our [OWASP scan](https://github.com/SAP/ai-sdk-java/actions/runs/25779259246).

Spring AI introduces breaking changes in that version (to resolve one of the CVEs). Thus our tests needed to be adapted. I also changed the relevant [parts in our docs](https://github.com/SAP/ai-sdk/pull/493).
