### PR TITLE
chore: Remove repo name

### DIFF
--- a/.github/workflows/weekly-spec-update.yaml
+++ b/.github/workflows/weekly-spec-update.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: 'Get orchestration version'
         if: matrix.service == 'orchestration'
         run: |
-          ORCH_VERSION=$(curl --silent --request GET --url "https://github.tools.sap/api/v3/repos/MLF-prod/mlf-gitops-prod/contents/services/llm-orchestration/source/Chart.yaml?ref=aws.eu-central-1.prod-eu/current" -H "Authorization: Bearer $TOKEN" -H "Accept: application/vnd.github.v3.raw" | grep 'version:' | awk '{print $2}')
+          ORCH_VERSION=$(curl --silent --request GET --url "$ORCH_GITOPS_LINK" -H "Authorization: Bearer $TOKEN" -H "Accept: application/vnd.github.v3.raw" | grep 'version:' | awk '{print $2}')
 
           if [ -z "$ORCH_VERSION" ]; then
               echo "Failed to fetch orchestration version"
@@ -37,6 +37,7 @@ jobs:
           echo "ORCH_VERSION=$ORCH_VERSION" >> $GITHUB_ENV
         env:
           TOKEN: ${{ secrets.GH_TOOLS_TOKEN }}
+          ORCH_GITOPS_LINK: ${{ secrets.ORCH_GITOPS_LINK }}
 
       - name: 'Trigger spec update'
         run: |

--- a/docs/adrs/005-release-strategy.md
+++ b/docs/adrs/005-release-strategy.md
@@ -94,8 +94,7 @@ In case of delays in the release process of AI Core:
   2. The AI SDK release is delayed equally
   3. The AI SDK is released anyway with exceptional PO approval
 
-## Further Links
+## Further Remarks
 
-- The single source of truth for all landscapes is in [mlf-gitops](https://github.tools.sap/MLF-prod/mlf-gitops-prod)
-  - In particular, we care about the [version of orchestration](https://github.tools.sap/MLF-prod/mlf-gitops-prod/blob/aws.eu-central-1.prod-eu/current/services/llm-orchestration/source/Chart.yaml)
-- [This JIRA ticket](https://jira.tools.sap/browse/AI-44024) tracks releases
+- The single source of truth for all landscapes, including the version of orchestration, is in the internal mlf operations repo.
+  - This is handled by the weekly spec update workflow, so it should not be necessary to check this manually.


### PR DESCRIPTION
## Context

- https://github.com/SAP/ai-sdk-java-backlog/issues/397

This PR removes all mentions of the internal repo from the main branch.

Successful evaluation of orchestration version with the new secret [here](https://github.com/SAP/ai-sdk-java/actions/runs/25807140117/job/75812966080#step:3:15).
