### PR TITLE
fix: [DevOps] Run compile and test even if api compatibility test fails

### DIFF
--- a/.github/workflows/spec-update.yaml
+++ b/.github/workflows/spec-update.yaml
@@ -273,9 +273,6 @@ jobs:
             echo "api_compat_result=compatible" >> "$GITHUB_OUTPUT"
           else
             echo "api_compat_result=incompatible" >> "$GITHUB_OUTPUT"
-            echo "## ❌ API Compatibility: Breaking changes detected" >> $GITHUB_STEP_SUMMARY
-            echo "Download the **japicmp-report** artifact for details." >> $GITHUB_STEP_SUMMARY
-            exit 1
           fi
 
       - name: 'Upload japicmp report'
@@ -384,6 +381,12 @@ jobs:
         if: steps.generate.outputs.generation_result == 'failure'
         run: |
           echo "Client generation failed. Please check the Generate step logs for details."
+          exit 1
+
+      - name: 'Fail if API incompatible'
+        if: steps.api_compat.outputs.api_compat_result == 'incompatible'
+        run: |
+          echo "API compatibility check detected breaking changes. Download the japicmp-report artifact for details."
           exit 1
 
       - name: 'Fail if no spec changes and previous run failed'

--- a/.github/workflows/spec-update.yaml
+++ b/.github/workflows/spec-update.yaml
@@ -386,7 +386,7 @@ jobs:
       - name: 'Fail if API incompatible'
         if: steps.api_compat.outputs.api_compat_result == 'incompatible'
         run: |
-          echo "API compatibility check detected breaking changes. Download the japicmp-report artifact for details."
+          echo "API compatibility check detected breaking changes. Check the japicmp-report artifact in the workflow run summary for details."
           exit 1
 
       - name: 'Fail if no spec changes and previous run failed'


### PR DESCRIPTION
## Context

Previously, a failing compatibility skipped and marked all other tests as failing too.

<img width="1031" height="704" alt="image" src="https://github.com/user-attachments/assets/3ef940eb-30dc-4fc3-9496-64db4c1a3648" />

---

**The new behaviour is** 

`Fail workflow later if API incompatible`, the `Compile and Test`, `Push changes` and `Create PR` steps should run before the fail step triggers.
