### PR TITLE
chore: [DevOps] Fix dependency-test workflow and change service key

### DIFF
--- a/.github/workflows/dependency-test.yaml
+++ b/.github/workflows/dependency-test.yaml
@@ -106,7 +106,7 @@ jobs:
           mvn $MVN_ARGS
         env:
           # See "End-to-end test application instructions" on the README.md to update the secret
-          AICORE_SERVICE_KEY: ${{ secrets.AICORE_SERVICE_KEY }}
+          AICORE_SERVICE_KEY: ${{ secrets.AI_CORE_CANARY }}
 
       - name: "Start Application Locally"
         run: |
@@ -123,7 +123,7 @@ jobs:
           done
         env:
           # See "End-to-end test application instructions" on the README.md to update the secret
-          AICORE_SERVICE_KEY: ${{ secrets.AICORE_SERVICE_KEY }}
+          AICORE_SERVICE_KEY: ${{ secrets.AI_CORE_CANARY }}
 
       - name: "Health Check"
         # print response body with headers to stdout.  q:body only  O:print  -:stdout  S:headers

--- a/.github/workflows/dependency-test.yaml
+++ b/.github/workflows/dependency-test.yaml
@@ -27,7 +27,7 @@ jobs:
           response=$(curl -s "https://search.maven.org/solrsearch/select?q=g:%22${GROUP_ID}%22+AND+a:%22${ARTIFACT_ID}%22&rows=15&core=gav&wt=json")
           
           # Extract and filter versions (e.g., to exclude snapshots or specific versions)
-          versions=$(echo "$response" | jq -r '.response.docs[].v' | grep -v -E 'SNAPSHOT|alpha|beta' | sort -V)
+          versions=$(echo "$response" | jq -r '.response.docs[].v' | grep -v -E 'SNAPSHOT|alpha|beta' | sort -rV | head -15 | sort -V)
           
           # Convert the versions to a JSON array
           json_versions=$(echo "$versions" | jq -R . | jq -s . | tr -d '\n')

--- a/.github/workflows/dependency-test.yaml
+++ b/.github/workflows/dependency-test.yaml
@@ -23,11 +23,11 @@ jobs:
           GROUP_ID="com.sap.cloud.sdk"
           ARTIFACT_ID="sdk-bom"
 
-          # Fetch available versions from Maven Central API
-          response=$(curl -s "https://search.maven.org/solrsearch/select?q=g:%22${GROUP_ID}%22+AND+a:%22${ARTIFACT_ID}%22&rows=15&core=gav&wt=json")
-          
+          # Fetch available versions from Maven Central metadata (covers both legacy and Sonatype Central releases)
+          response=$(curl -s "https://repo1.maven.org/maven2/${GROUP_ID//.//}/${ARTIFACT_ID}/maven-metadata.xml")
+
           # Extract and filter versions (e.g., to exclude snapshots or specific versions)
-          versions=$(echo "$response" | jq -r '.response.docs[].v' | grep -v -E 'SNAPSHOT|alpha|beta' | sort -rV | head -15 | sort -V)
+          versions=$(echo "$response" | grep -oP '(?<=<version>)[^<]+' | grep -v -E 'SNAPSHOT|alpha|beta' | sort -rV | head -15 | sort -V)
           
           # Convert the versions to a JSON array
           json_versions=$(echo "$versions" | jq -R . | jq -s . | tr -d '\n')


### PR DESCRIPTION
## Context

This PR fixes the dependency-test workflow and changes the secret used in the workflow.

This is part of the effort of [the security BLI](https://github.com/SAP/ai-sdk-java-backlog/issues/399).

[Link to successfull run](https://github.com/SAP/ai-sdk-java/actions/runs/26756758004).

