### PR TITLE
fix: [Core] Deployment resolution selects running targets

### DIFF
--- a/core/src/main/java/com/sap/ai/sdk/core/DeploymentResolver.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/DeploymentResolver.java
@@ -1,5 +1,7 @@
 package com.sap.ai.sdk.core;
 
+import static com.sap.ai.sdk.core.model.AiDeployment.TargetStatusEnum.RUNNING;
+
 import com.sap.ai.sdk.core.client.DeploymentApi;
 import com.sap.ai.sdk.core.model.AiDeployment;
 import java.util.HashSet;
@@ -118,6 +120,7 @@ class DeploymentResolver {
       @Nonnull final String resourceGroup, @Nonnull final Predicate<AiDeployment> predicate) {
     return cache.getOrDefault(resourceGroup, new HashSet<>()).stream()
         .filter(predicate)
+        .filter(deployment -> deployment.getTargetStatus().equals(RUNNING))
         .findFirst()
         .map(AiDeployment::getId);
   }

--- a/core/src/main/java/com/sap/ai/sdk/core/DeploymentResolver.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/DeploymentResolver.java
@@ -1,9 +1,8 @@
 package com.sap.ai.sdk.core;
 
-import static com.sap.ai.sdk.core.model.AiDeployment.TargetStatusEnum.RUNNING;
-
 import com.sap.ai.sdk.core.client.DeploymentApi;
 import com.sap.ai.sdk.core.model.AiDeployment;
+import com.sap.ai.sdk.core.model.AiDeploymentStatus;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
@@ -11,6 +10,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,7 +29,7 @@ class DeploymentResolver {
 
   @Nonnull private final AiCoreService service;
 
-  /** Cache for deployment ids. The key is the model name and the value is the deployment id. */
+  /** Cache for deployments. The key is the resource group and the value a set of deployments. */
   @Nonnull private final Map<String, Set<AiDeployment>> cache;
 
   DeploymentResolver(@Nonnull final AiCoreService service) {
@@ -37,7 +37,7 @@ class DeploymentResolver {
   }
 
   /**
-   * Remove all entries from the cache then load all deployments into the cache.
+   * Remove cached deployments for the resource group and reload running deployments into the cache.
    *
    * <p><b>Call this whenever a deployment is deleted.</b>
    *
@@ -48,8 +48,16 @@ class DeploymentResolver {
     try {
       val apiClient = new DeploymentApi(service);
       val deployments = new HashSet<>(apiClient.query(resourceGroup).getResources());
-      log.info("Found {} deployments in resource group '{}'.", deployments.size(), resourceGroup);
-      cache.put(resourceGroup, deployments);
+      val runningDeployments =
+          deployments.stream()
+              .filter(deployment -> AiDeploymentStatus.RUNNING.equals(deployment.getStatus()))
+              .collect(Collectors.toSet());
+      log.info(
+          "Found {} of {} deployments running in resource group '{}'.",
+          runningDeployments.size(),
+          deployments.size(),
+          resourceGroup);
+      cache.put(resourceGroup, runningDeployments);
     } catch (final RuntimeException e) {
       throw new DeploymentResolutionException(
           "Failed to load deployments for resource group " + resourceGroup, e);
@@ -120,7 +128,6 @@ class DeploymentResolver {
       @Nonnull final String resourceGroup, @Nonnull final Predicate<AiDeployment> predicate) {
     return cache.getOrDefault(resourceGroup, new HashSet<>()).stream()
         .filter(predicate)
-        .filter(deployment -> RUNNING.equals(deployment.getTargetStatus()))
         .findFirst()
         .map(AiDeployment::getId);
   }

--- a/core/src/main/java/com/sap/ai/sdk/core/DeploymentResolver.java
+++ b/core/src/main/java/com/sap/ai/sdk/core/DeploymentResolver.java
@@ -120,7 +120,7 @@ class DeploymentResolver {
       @Nonnull final String resourceGroup, @Nonnull final Predicate<AiDeployment> predicate) {
     return cache.getOrDefault(resourceGroup, new HashSet<>()).stream()
         .filter(predicate)
-        .filter(deployment -> deployment.getTargetStatus().equals(RUNNING))
+        .filter(deployment -> RUNNING.equals(deployment.getTargetStatus()))
         .findFirst()
         .map(AiDeployment::getId);
   }

--- a/core/src/test/java/com/sap/ai/sdk/core/AiCoreServiceTest.java
+++ b/core/src/test/java/com/sap/ai/sdk/core/AiCoreServiceTest.java
@@ -81,7 +81,8 @@ class AiCoreServiceTest {
     assertThat(destination.getHeaders()).containsExactly(new Header("AI-Resource-Group", "foo"));
 
     // scenario-based destination
-    val d = "{\"count\":1,\"resources\":[{\"id\":\"0123456789abcdef\",\"scenarioId\":\"foobar\"}]}";
+    val d =
+        "{\"count\":1,\"resources\":[{\"id\":\"0123456789abcdef\",\"scenarioId\":\"foobar\", \"status\":\"RUNNING\"}]}";
     val server = new WireMockServer(wireMockConfig().dynamicPort());
     server.start();
     server.stubFor(get(urlEqualTo("/v2/lm/deployments")).willReturn(okJson(d)));

--- a/core/src/test/java/com/sap/ai/sdk/core/DeploymentResolverTest.java
+++ b/core/src/test/java/com/sap/ai/sdk/core/DeploymentResolverTest.java
@@ -179,7 +179,8 @@ class DeploymentResolverTest extends WireMockTestServer {
                     .withBodyFile("hasStoppedDeployment.json")
                     .withHeader("content-type", "application/json")));
 
-    final var deployment = resolver.getDeploymentIdByScenario(DEFAULT_RESOURCE_GROUP, "orchestration");
+    final var deployment =
+        resolver.getDeploymentIdByScenario(DEFAULT_RESOURCE_GROUP, "orchestration");
 
     assertThat(deployment).isEqualTo("d4b1396b84c1944d");
     assertThat(cache.get(DEFAULT_RESOURCE_GROUP))

--- a/core/src/test/java/com/sap/ai/sdk/core/DeploymentResolverTest.java
+++ b/core/src/test/java/com/sap/ai/sdk/core/DeploymentResolverTest.java
@@ -10,6 +10,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.sap.ai.sdk.core.AiCoreService.DEFAULT_RESOURCE_GROUP;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 
 import com.sap.ai.sdk.core.client.WireMockTestServer;
 import com.sap.ai.sdk.core.model.AiDeployment;
@@ -167,6 +168,25 @@ class DeploymentResolverTest extends WireMockTestServer {
     assertThat(DeploymentResolver.isDeploymentOfModel(gpt4AnyVersion, deployment)).isTrue();
     assertThat(DeploymentResolver.isDeploymentOfModel(gpt4Version1, deployment)).isFalse();
     assertThat(DeploymentResolver.isDeploymentOfModel(gpt4VersionLatest, deployment)).isTrue();
+  }
+
+  @Test
+  void testDeploymentResolvesToRunningTarget() {
+    wireMockServer.stubFor(
+        get(anyUrl())
+            .willReturn(
+                aResponse()
+                    .withBodyFile("hasStoppedDeployment.json")
+                    .withHeader("content-type", "application/json")));
+
+    var deployment = resolver.getDeploymentIdByScenario(DEFAULT_RESOURCE_GROUP, "orchestration");
+
+    assertThat(deployment).isEqualTo("d4b1396b84c1944d");
+    assertThat(cache.get("default"))
+        .extracting(AiDeployment::getId, AiDeployment::getTargetStatus)
+        .contains(
+            tuple("d2a491b5010620b0", AiDeployment.TargetStatusEnum.STOPPED),
+            tuple("d4b1396b84c1944d", AiDeployment.TargetStatusEnum.RUNNING));
   }
 
   private record TestModel(String name, String version) implements AiModel {}

--- a/core/src/test/java/com/sap/ai/sdk/core/DeploymentResolverTest.java
+++ b/core/src/test/java/com/sap/ai/sdk/core/DeploymentResolverTest.java
@@ -179,10 +179,10 @@ class DeploymentResolverTest extends WireMockTestServer {
                     .withBodyFile("hasStoppedDeployment.json")
                     .withHeader("content-type", "application/json")));
 
-    var deployment = resolver.getDeploymentIdByScenario(DEFAULT_RESOURCE_GROUP, "orchestration");
+    final var deployment = resolver.getDeploymentIdByScenario(DEFAULT_RESOURCE_GROUP, "orchestration");
 
     assertThat(deployment).isEqualTo("d4b1396b84c1944d");
-    assertThat(cache.get("default"))
+    assertThat(cache.get(DEFAULT_RESOURCE_GROUP))
         .extracting(AiDeployment::getId, AiDeployment::getTargetStatus)
         .contains(
             tuple("d2a491b5010620b0", AiDeployment.TargetStatusEnum.STOPPED),

--- a/core/src/test/java/com/sap/ai/sdk/core/DeploymentResolverTest.java
+++ b/core/src/test/java/com/sap/ai/sdk/core/DeploymentResolverTest.java
@@ -171,7 +171,7 @@ class DeploymentResolverTest extends WireMockTestServer {
   }
 
   @Test
-  void testDeploymentResolvesToRunningTarget() {
+  void testCacheContainsRunningDeployments() {
     wireMockServer.stubFor(
         get(anyUrl())
             .willReturn(
@@ -184,10 +184,8 @@ class DeploymentResolverTest extends WireMockTestServer {
 
     assertThat(deployment).isEqualTo("d4b1396b84c1944d");
     assertThat(cache.get(DEFAULT_RESOURCE_GROUP))
-        .extracting(AiDeployment::getId, AiDeployment::getTargetStatus)
-        .contains(
-            tuple("d2a491b5010620b0", AiDeployment.TargetStatusEnum.STOPPED),
-            tuple("d4b1396b84c1944d", AiDeployment.TargetStatusEnum.RUNNING));
+        .extracting(AiDeployment::getId, AiDeployment::getStatus)
+        .containsExactly(tuple("d4b1396b84c1944d", AiDeploymentStatus.RUNNING));
   }
 
   private record TestModel(String name, String version) implements AiModel {}

--- a/core/src/test/resources/__files/hasStoppedDeployment.json
+++ b/core/src/test/resources/__files/hasStoppedDeployment.json
@@ -1,0 +1,54 @@
+{
+  "count": 8,
+  "resources": [
+    {
+      "id": "d2a491b5010620b0",
+      "createdAt": "2026-06-08T14:56:25Z",
+      "modifiedAt": "2026-06-08T15:10:18Z",
+      "status": "STOPPED",
+      "details": {
+        "scaling": {
+          "backendDetails": {},
+          "backend_details": {}
+        },
+        "resources": {
+          "backendDetails": {},
+          "backend_details": {}
+        }
+      },
+      "scenarioId": "orchestration",
+      "configurationId": "0f0fb4c1-cf2c-441f-98d1-1f983d1b1756",
+      "targetStatus": "STOPPED",
+      "submissionTime": "2026-06-08T15:03:35Z",
+      "startTime": "2026-06-08T15:05:27Z",
+      "completionTime": "2026-06-08T15:27:23Z",
+      "configurationName": "orchestration-config",
+      "deploymentUrl": "https://api.ai.intprod-eu12.eu-central-1.aws.ml.hana.ondemand.com/v2/inference/deployments/d2a491b5010620b0"
+    },
+    {
+      "id": "d4b1396b84c1944d",
+      "createdAt": "2026-04-16T10:03:39Z",
+      "modifiedAt": "2026-04-16T10:03:39Z",
+      "status": "RUNNING",
+      "details": {
+        "scaling": {
+          "backendDetails": {},
+          "backend_details": {}
+        },
+        "resources": {
+          "backendDetails": {},
+          "backend_details": {}
+        }
+      },
+      "scenarioId": "orchestration",
+      "configurationId": "e88f7dba-fd9c-4068-ab18-3306f2aa46bd",
+      "latestRunningConfigurationId": "e88f7dba-fd9c-4068-ab18-3306f2aa46bd",
+      "lastOperation": "CREATE",
+      "targetStatus": "RUNNING",
+      "submissionTime": "2026-04-17T08:32:01Z",
+      "startTime": "2026-04-17T08:32:59Z",
+      "configurationName": "orchestration-config",
+      "deploymentUrl": "https://api.ai.intprod-eu12.eu-central-1.aws.ml.hana.ondemand.com/v2/inference/deployments/d4b1396b84c1944d"
+    }
+  ]
+}

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -18,7 +18,7 @@
 
 ### 📈 Improvements
 
--
+- [Core] Optimized the deployments cache to store only `RUNNING` deployments, ensuring that requests do not resolve to `STOPPED` instances
 
 ### 🐛 Fixed Issues
 


### PR DESCRIPTION
## Context

- https://github.com/SAP/ai-sdk-java/issues/888

Deployment resolution at the moment picks the first deployment under given predicate. A predicate being a scenario, or model. This do not check for the status of the deployment. Therefore, if there are stopped deployments, it might be selected to construct the deployment url.

### Feature scope:
 
- [x] Insert a filter to only pick out deployments with target status running.


**Note:** Regular "status" points to the current status, but not the target state. "targetStatus" points to the expected state of the deployment avoiding the situation where a deployment get picked that will soon be obselete.

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Aligned changes with the JavaScript SDK~
- [ ] [Documentation](https://github.com/SAP/ai-sdk/tree/main/docs-java) updated
- [x] ~Release notes updated~
