### PR TITLE
fix: [DevOps] Japicmp use orchestration-staging as baseline

### DIFF
--- a/.github/workflows/spec-update.yaml
+++ b/.github/workflows/spec-update.yaml
@@ -233,15 +233,16 @@ jobs:
         if: steps.spec_diff.outputs.spec_diff == 'true'
         env:
           MODULE_PATH: ${{ steps.download.outputs.module_path }}
+          BASE: ${{ steps.pr_base.outputs.BASE }}
         run: |
-          # Extract main branch source into a temporary directory
-          git fetch --no-tags --depth=1 origin main
-          mkdir -p /tmp/main-baseline
-          git archive origin/main | tar -x -C /tmp/main-baseline
+          # Extract $BASE branch source into a temporary directory
+          git fetch --no-tags --depth=1 origin "$BASE"
+          mkdir -p /tmp/api-baseline
+          git archive "origin/$BASE" | tar -x -C /tmp/api-baseline
 
           # Build inside a subshell to avoid polluting the working directory
           (
-            cd /tmp/main-baseline
+            cd /tmp/api-baseline
             mvn package -DskipTests -pl "$MODULE_PATH" -am ${{ env.MVN_MULTI_THREADED_ARGS }}
             FINAL_NAME=$(mvn -q -pl "$MODULE_PATH" help:evaluate -Dexpression=project.build.finalName -DforceStdout)
             cp "$MODULE_PATH/target/${FINAL_NAME}.jar" /tmp/baseline.jar
@@ -270,9 +271,9 @@ jobs:
           FINAL_NAME=$(mvn -q -pl "$MODULE_PATH" help:evaluate -Dexpression=project.build.finalName -DforceStdout)
           CURRENT_JAR="$MODULE_PATH/target/${FINAL_NAME}.jar"
 
-          # Run japicmp: compare baseline (main) JAR vs newly generated JAR
+          # Run japicmp: compare baseline ($BASE) JAR vs newly generated JAR
           if mvn com.github.siom79.japicmp:japicmp-maven-plugin:cmp@api-compatibility \
-            -pl "$MODULE_PATH" \
+            -pl "$MODULE_PATH" \ 
             -Djapicmp.oldVersion.file=/tmp/baseline.jar \
             -Djapicmp.newVersion.file="$CURRENT_JAR" \
             ${{ env.MVN_MULTI_THREADED_ARGS }} ; then


### PR DESCRIPTION
## Context

AI/ai-sdk-java-backlog#ISSUENUMBER.

Changing the narative of the Japicmp check from

>  Is the newly generated orchestration JAR compatible with `main`?


towards

> Is the newly generated orchestration JAR compatible with the currently accepted orchestration api?


- Here "currently accepted orchestration api" assumes `orchestration-staging` branch contains fixes that are human-reviewed and accepted.

Without this change, orchestration PRs that already has a fix ready will keep failing since the defacto baseline is main. This is just noisy since some team member already looked at the problem, fixed it and created `orchestration-staging`. Without this, every upcoming orchestration PRs will always fail too.

### Feature scope:
 
- [x] Use orchestration-staging as baseline if it exists

## Definition of Done

- [x] Functionality scope stated & covered
- [ ] Tests cover the scope above
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Aligned changes with the JavaScript SDK~
- [ ] ~[Documentation](https://github.com/SAP/ai-sdk/tree/main/docs-java) updated~
- [ ] ~Release notes updated~
