### PR TITLE
chore: [DevOps] Fix path to prompt-registry spec

### DIFF
--- a/.github/workflows/spec-update.yaml
+++ b/.github/workflows/spec-update.yaml
@@ -402,15 +402,15 @@ jobs:
           echo "Previous run failed and there were no spec changes since, thus failing this run as well."
           exit 1
 
-#      - name: 'Slack Notification'
-#        if: failure() && github.event.inputs.create-pr == 'true'
-#        uses: slackapi/slack-github-action@v3.0.3
-#        with:
-#          webhook: ${{ secrets.SLACK_WEBHOOK }}
-#          webhook-type: incoming-webhook
-#          payload: |
-#            blocks:
-#              - type: "section"
-#                text:
-#                    type: "mrkdwn"
-#                    text: "⚠️ Weekly spec update failed! 😬 Please inspect & fix by clicking <https://github.com/SAP/ai-sdk-java/actions/runs/${{ github.run_id }}|here>"
+      - name: 'Slack Notification'
+        if: failure() && github.event.inputs.create-pr == 'true'
+        uses: slackapi/slack-github-action@v3.0.3
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            blocks:
+              - type: "section"
+                text:
+                    type: "mrkdwn"
+                    text: "⚠️ Weekly spec update failed! 😬 Please inspect & fix by clicking <https://github.com/SAP/ai-sdk-java/actions/runs/${{ github.run_id }}|here>"

--- a/.github/workflows/spec-update.yaml
+++ b/.github/workflows/spec-update.yaml
@@ -157,7 +157,7 @@ jobs:
               MODULE_PATH='orchestration'
               ;;
             prompt-registry)
-              API_URL="$API_BASE_URL/AI/prompt-registry/contents/src/spec/generated/prompt-registry-combined.yaml?ref=$REF"
+              API_URL="$API_BASE_URL/AI/prompt-registry/components/prompt-registry-api/src/spec/generated/prompt-registry-combined.yaml?ref=$REF"
               FILE_PATH='core-services/prompt-registry/src/main/resources/spec/prompt-registry.yaml'
               MODULE_PATH='core-services/prompt-registry'
               ;;

--- a/.github/workflows/spec-update.yaml
+++ b/.github/workflows/spec-update.yaml
@@ -157,7 +157,7 @@ jobs:
               MODULE_PATH='orchestration'
               ;;
             prompt-registry)
-              API_URL="$API_BASE_URL/AI/prompt-registry/components/prompt-registry-api/src/spec/generated/prompt-registry-combined.yaml?ref=$REF"
+              API_URL="$API_BASE_URL/AI/prompt-registry/contents/components/prompt-registry-api/src/spec/generated/prompt-registry-combined.yaml?ref=$REF"
               FILE_PATH='core-services/prompt-registry/src/main/resources/spec/prompt-registry.yaml'
               MODULE_PATH='core-services/prompt-registry'
               ;;
@@ -402,15 +402,15 @@ jobs:
           echo "Previous run failed and there were no spec changes since, thus failing this run as well."
           exit 1
 
-      - name: 'Slack Notification'
-        if: failure() && github.event.inputs.create-pr == 'true'
-        uses: slackapi/slack-github-action@v3.0.3
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK }}
-          webhook-type: incoming-webhook
-          payload: |
-            blocks:
-              - type: "section"
-                text:
-                    type: "mrkdwn"
-                    text: "⚠️ Weekly spec update failed! 😬 Please inspect & fix by clicking <https://github.com/SAP/ai-sdk-java/actions/runs/${{ github.run_id }}|here>"
+#      - name: 'Slack Notification'
+#        if: failure() && github.event.inputs.create-pr == 'true'
+#        uses: slackapi/slack-github-action@v3.0.3
+#        with:
+#          webhook: ${{ secrets.SLACK_WEBHOOK }}
+#          webhook-type: incoming-webhook
+#          payload: |
+#            blocks:
+#              - type: "section"
+#                text:
+#                    type: "mrkdwn"
+#                    text: "⚠️ Weekly spec update failed! 😬 Please inspect & fix by clicking <https://github.com/SAP/ai-sdk-java/actions/runs/${{ github.run_id }}|here>"


### PR DESCRIPTION
## Context

Prompt-registry refactored their repo recently, so we need to update the path to get the prompt-registry spec file from in the spec-update workflow. 

I [checked with prompt registry colleagues](https://sap-ml.slack.com/archives/C090TSZ2M1N/p1782118485689529) that this is the correct path to use.

Successful download in trial run [here](https://github.com/SAP/ai-sdk-java/actions/runs/27958514521/job/82733293857#step:8:53).
