### PR TITLE
fix: [DevOps] Temporary for NVD, use datafeed instead of API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <javaparser.version>3.28.2</javaparser.version>
     <jsonschema-generator.version>4.38.0</jsonschema-generator.version>
     <jackson.version>2.22.0</jackson.version>
-    <logback.version>1.5.36</logback.version>
+    <logback.version>1.5.37</logback.version>
     <commons-codec.version>1.22.0</commons-codec.version>
     <japicmp.version>0.26.1</japicmp.version>
     <!-- conflicts resolution -->

--- a/pom.xml
+++ b/pom.xml
@@ -828,6 +828,7 @@ https://gitbox.apache.org/repos/asf?p=maven-pmd-plugin.git;a=blob_plain;f=src/ma
         <version>12.1.0</version>
         <configuration>
           <connectionTimeout>60000</connectionTimeout>
+          <nvdDatafeedUrl>https://dependency-check.github.io/DependencyCheck_Builder/nvd_cache/nvdcve-{0}.json.gz</nvdDatafeedUrl>
           <nvdMaxRetryCount>20</nvdMaxRetryCount>
           <failBuildOnCVSS>7</failBuildOnCVSS>
           <nvdApiKeyEnvironmentVariable>NVD_API_KEY</nvdApiKeyEnvironmentVariable>

--- a/sample-code/spring-app/pom.xml
+++ b/sample-code/spring-app/pom.xml
@@ -34,7 +34,6 @@
   <properties>
     <project.rootdir>${project.basedir}/../../</project.rootdir>
     <spring-boot.version>3.5.16</spring-boot.version>
-    <logback.version>1.5.36</logback.version>
     <cf-logging.version>4.2.0</cf-logging.version>
     <apache-tomcat-embed.version>11.0.22</apache-tomcat-embed.version>
     <mcp-core.version>2.0.0</mcp-core.version>
@@ -48,6 +47,12 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- Pin logback-core to match logback-classic version (Spring Boot BOM pins an older version) -->
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-core</artifactId>
+        <version>${logback.version}</version>
+      </dependency>
       <!-- Temporary fix for CVE-2025-48988 -->
       <dependency>
         <groupId>org.apache.tomcat.embed</groupId>

--- a/sample-code/spring-app/pom.xml
+++ b/sample-code/spring-app/pom.xml
@@ -47,12 +47,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- Pin logback-core to match logback-classic version (Spring Boot BOM pins an older version) -->
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-core</artifactId>
-        <version>${logback.version}</version>
-      </dependency>
       <!-- Temporary fix for CVE-2025-48988 -->
       <dependency>
         <groupId>org.apache.tomcat.embed</groupId>
@@ -85,6 +79,12 @@
         <version>${spring-boot.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <!-- Override Spring Boot BOM's logback-core version to align with logback-classic -->
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-core</artifactId>
+        <version>${logback.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
## Context

AI/ai-sdk-java-backlog#448.

If the current dependency vulnerability scan fails, then we move temporarily to a data feed, higher bandwidth but higher reliability.