### PR TITLE
chore: [DevOps] Spec update definition of done now mentions documentation

### DIFF
--- a/.github/workflows/spec-update.yaml
+++ b/.github/workflows/spec-update.yaml
@@ -348,8 +348,9 @@ jobs:
 
           ## Definition of Done
 
-          - [ ] Unit tests cover new classes
+          - [ ] (Optional) Unit tests cover new classes
           - [ ] Release notes updated
+          - [ ] Documentation code samples updated
           ") && echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
 
       - name: 'Generate Job Summary'


### PR DESCRIPTION
## Context

AI/ai-sdk-java-backlog#448.

Documentation code samples were often forgotten when updating generated code