### PR TITLE
chore: Clean up release notes

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -19,8 +19,7 @@
 
 ### ✨ New Functionality
 
-- [Orchestration] Added `CLAUDE_4_8_OPUS`, `QWEN_3_MAX`, `QWEN_3_6_PLUS` and `QWEN_3_6_FLASH` to the
-  model list in `OrchestrationAiModel`.
+- [Orchestration] Added `CLAUDE_4_8_OPUS` to the model list in `OrchestrationAiModel`.
 - [Orchestration] Added `getReasoningContent()` to assistant messages.
 - [Orchestration] Added `PartialOrchestrationConfig` to override config references in
   `CompletionRequestConfigurationReferenceById` and


### PR DESCRIPTION
## Context

Removed qwen models from the release notes since they are not yet GA (and might not be available in all regions once they are GA).
