### PR TITLE
chore: [DevOps] Change auto-merger schedule to daily

### DIFF
--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -3,7 +3,7 @@ name: 'Dependabot Auto-Merge'
 on:
   workflow_dispatch:
   schedule:
-    - cron: '00 01 * * Tue' # trigger every Tuesday at 01:00 a.m., as our dependabot is configured to raise PRs every Monday at 23:00 p.m.
+    - cron: '00 01 * * *' # trigger daily at 01:00 a.m.
 
 env:
   DEPENDABOT_GROUPS: |


### PR DESCRIPTION
See [same PR on Cloud SDK](https://github.com/SAP/cloud-sdk-java/pull/1217).

We want to run the merger daily to pick up also off-schedule PRs.