### PR TITLE
feat: [Orchestration] Stream from low-level request objects

### DIFF
--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationClient.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationClient.java
@@ -249,6 +249,8 @@ public class OrchestrationClient {
   @Nonnull
   public Stream<OrchestrationChatCompletionDelta> streamChatCompletionDeltas(
       @Nonnull final CompletionPostRequest request) throws OrchestrationClientException {
+    // since CompletionPostRequest is an empty and generated interface, we have to access the stream
+    // options explicitly for each type
     if (request instanceof CompletionRequestConfiguration r) {
       enableStreaming(r.getConfig()::getStream, r.getConfig()::setStream);
     } else if (request instanceof CompletionRequestConfigurationReferenceById r) {
@@ -262,7 +264,10 @@ public class OrchestrationClient {
       }
       enableStreaming(r.getConfig()::getStream, r.getConfig()::setStream);
     } else {
-      throw new IllegalStateException("Unsupported request type: " + request.getClass().getName());
+      throw new IllegalStateException(
+          "Unsupported request type: "
+              + request.getClass().getName()
+              + ". This method only supports classes from com.sap.ai.sdk.orchestration.model.");
     }
     return executor.stream(COMPLETION_ENDPOINT, request, customHeaders);
   }

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationClient.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationClient.java
@@ -11,12 +11,15 @@ import com.sap.ai.sdk.core.AiCoreService;
 import com.sap.ai.sdk.orchestration.model.CompletionPostRequest;
 import com.sap.ai.sdk.orchestration.model.CompletionPostResponse;
 import com.sap.ai.sdk.orchestration.model.CompletionRequestConfiguration;
+import com.sap.ai.sdk.orchestration.model.CompletionRequestConfigurationReferenceById;
+import com.sap.ai.sdk.orchestration.model.CompletionRequestConfigurationReferenceByNameScenarioVersion;
 import com.sap.ai.sdk.orchestration.model.EmbeddingsPostRequest;
 import com.sap.ai.sdk.orchestration.model.EmbeddingsPostResponse;
 import com.sap.ai.sdk.orchestration.model.GlobalStreamOptions;
 import com.sap.ai.sdk.orchestration.model.OrchestrationConfig;
 import com.sap.cloud.sdk.cloudplatform.connectivity.Header;
 import com.sap.cloud.sdk.cloudplatform.connectivity.HttpDestination;
+import io.vavr.NotImplementedError;
 import io.vavr.control.Try;
 import java.util.ArrayList;
 import java.util.List;
@@ -241,7 +244,7 @@ public class OrchestrationClient {
    */
   @SuppressWarnings("PMD.PublicApiExposesModelType")
   @Nonnull
-  public Stream<OrchestrationChatCompletionDelta> streamChatCompletionDeltas(
+  public Stream<OrchestrationChatCompletionDelta> streamChatCompletionDeltasOld(
       @Nonnull final CompletionRequestConfiguration request) throws OrchestrationClientException {
     val config = request.getConfig();
     val stream = config.getStream();
@@ -253,6 +256,41 @@ public class OrchestrationClient {
 
     return executor.stream(COMPLETION_ENDPOINT, request, customHeaders);
   }
+
+  @Nonnull
+  public Stream<OrchestrationChatCompletionDelta> streamChatCompletionDeltas(
+      @Nonnull final CompletionPostRequest request) throws OrchestrationClientException {
+    if (request instanceof CompletionRequestConfiguration requestConfig) {
+      val config = requestConfig.getConfig();
+      val stream = config.getStream();
+      if (stream == null) {
+        config.setStream(GlobalStreamOptions.create().enabled(true).delimiters(null));
+      } else {
+        stream.enabled(true);
+      }
+    } else if (request instanceof CompletionRequestConfigurationReferenceById requestConfigById) {
+      val config = requestConfigById.getConfig();
+      val stream = config.getStream();
+      if (stream == null) {
+        config.setStream(GlobalStreamOptions.create().enabled(true).delimiters(null));
+      } else {
+        stream.enabled(true);
+      }
+    } else if (request instanceof CompletionRequestConfigurationReferenceByNameScenarioVersion requestConfigByNSV) {
+      val config = requestConfigByNSV.getConfig();
+      val stream = config.getStream();
+      if (stream == null) {
+        config.setStream(GlobalStreamOptions.create().enabled(true).delimiters(null));
+      } else {
+        stream.enabled(true);
+      }
+    } else {
+      throw new RuntimeException("This should not happen.");
+    }
+    return executor.stream(COMPLETION_ENDPOINT, request, customHeaders);
+  }
+
+//  private obtainConfig
 
   /**
    * Generate embeddings for a {@code OrchestrationEmbeddingRequest} request.

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationClient.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationClient.java
@@ -19,11 +19,11 @@ import com.sap.ai.sdk.orchestration.model.GlobalStreamOptions;
 import com.sap.ai.sdk.orchestration.model.OrchestrationConfig;
 import com.sap.cloud.sdk.cloudplatform.connectivity.Header;
 import com.sap.cloud.sdk.cloudplatform.connectivity.HttpDestination;
-import io.vavr.NotImplementedError;
 import io.vavr.control.Try;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -260,37 +260,28 @@ public class OrchestrationClient {
   @Nonnull
   public Stream<OrchestrationChatCompletionDelta> streamChatCompletionDeltas(
       @Nonnull final CompletionPostRequest request) throws OrchestrationClientException {
-    if (request instanceof CompletionRequestConfiguration requestConfig) {
-      val config = requestConfig.getConfig();
-      val stream = config.getStream();
-      if (stream == null) {
-        config.setStream(GlobalStreamOptions.create().enabled(true).delimiters(null));
-      } else {
-        stream.enabled(true);
-      }
-    } else if (request instanceof CompletionRequestConfigurationReferenceById requestConfigById) {
-      val config = requestConfigById.getConfig();
-      val stream = config.getStream();
-      if (stream == null) {
-        config.setStream(GlobalStreamOptions.create().enabled(true).delimiters(null));
-      } else {
-        stream.enabled(true);
-      }
-    } else if (request instanceof CompletionRequestConfigurationReferenceByNameScenarioVersion requestConfigByNSV) {
-      val config = requestConfigByNSV.getConfig();
-      val stream = config.getStream();
-      if (stream == null) {
-        config.setStream(GlobalStreamOptions.create().enabled(true).delimiters(null));
-      } else {
-        stream.enabled(true);
-      }
+    if (request instanceof CompletionRequestConfiguration r) {
+      enableStreaming(r.getConfig()::getStream, r.getConfig()::setStream);
+    } else if (request instanceof CompletionRequestConfigurationReferenceById r) {
+      enableStreaming(r.getConfig()::getStream, r.getConfig()::setStream);
+    } else if (request instanceof CompletionRequestConfigurationReferenceByNameScenarioVersion r) {
+      enableStreaming(r.getConfig()::getStream, r.getConfig()::setStream);
     } else {
-      throw new RuntimeException("This should not happen.");
+      throw new OrchestrationClientException(
+          "Unsupported request type: " + request.getClass().getName());
     }
     return executor.stream(COMPLETION_ENDPOINT, request, customHeaders);
   }
 
-//  private obtainConfig
+  private static void enableStreaming(
+      @Nonnull final Supplier<GlobalStreamOptions> getStream,
+      @Nonnull final Consumer<GlobalStreamOptions> setStream) {
+    if (getStream.get() == null) {
+      setStream.accept(GlobalStreamOptions.create().enabled(true).delimiters(null));
+    } else {
+      getStream.get().enabled(true);
+    }
+  }
 
   /**
    * Generate embeddings for a {@code OrchestrationEmbeddingRequest} request.

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationClient.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationClient.java
@@ -267,7 +267,12 @@ public class OrchestrationClient {
       throw new IllegalStateException(
           "Unsupported request type: "
               + request.getClass().getName()
-              + ". This method only supports classes from com.sap.ai.sdk.orchestration.model.");
+              + ". This method only supports "
+              + CompletionRequestConfiguration.class.getName()
+              + ", "
+              + CompletionRequestConfigurationReferenceById.class.getName()
+              + ", and "
+              + CompletionRequestConfigurationReferenceByNameScenarioVersion.class.getName());
     }
     return executor.stream(COMPLETION_ENDPOINT, request, customHeaders);
   }

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationClient.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationClient.java
@@ -245,20 +245,6 @@ public class OrchestrationClient {
    */
   @SuppressWarnings("PMD.PublicApiExposesModelType")
   @Nonnull
-  public Stream<OrchestrationChatCompletionDelta> streamChatCompletionDeltasOld(
-      @Nonnull final CompletionRequestConfiguration request) throws OrchestrationClientException {
-    val config = request.getConfig();
-    val stream = config.getStream();
-    if (stream == null) {
-      config.setStream(GlobalStreamOptions.create().enabled(true).delimiters(null));
-    } else {
-      stream.enabled(true);
-    }
-
-    return executor.stream(COMPLETION_ENDPOINT, request, customHeaders);
-  }
-
-  @Nonnull
   public Stream<OrchestrationChatCompletionDelta> streamChatCompletionDeltas(
       @Nonnull final CompletionPostRequest request) throws OrchestrationClientException {
     if (request instanceof CompletionRequestConfiguration r) {

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationClient.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationClient.java
@@ -236,7 +236,9 @@ public class OrchestrationClient {
   }
 
   /**
-   * Generate a completion for the given prompt.
+   * Generate a completion for the given request object.
+   *
+   * <p>Note, that streaming will get enabled on the request object as a side effect.
    *
    * @param request the prompt, including messages and other parameters.
    * @return A stream of chat completion delta elements.
@@ -260,8 +262,7 @@ public class OrchestrationClient {
       }
       enableStreaming(r.getConfig()::getStream, r.getConfig()::setStream);
     } else {
-      throw new OrchestrationClientException(
-          "Unsupported request type: " + request.getClass().getName());
+      throw new IllegalStateException("Unsupported request type: " + request.getClass().getName());
     }
     return executor.stream(COMPLETION_ENDPOINT, request, customHeaders);
   }

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationClient.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationClient.java
@@ -277,6 +277,11 @@ public class OrchestrationClient {
     return executor.stream(COMPLETION_ENDPOINT, request, customHeaders);
   }
 
+  // getStream reads the current GlobalStreamOptions from the request config (which may be null).
+  // setStream writes a GlobalStreamOptions back into the request config.
+  // Both are passed as lambdas because the config types (OrchestrationConfig vs
+  // PartialOrchestrationConfig) share no common usable supertype, so a single generic method is not
+  // possible without reflection.
   private static void enableStreaming(
       @Nonnull final Supplier<GlobalStreamOptions> getStream,
       @Nonnull final Consumer<GlobalStreamOptions> setStream) {

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationClient.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationClient.java
@@ -17,6 +17,7 @@ import com.sap.ai.sdk.orchestration.model.EmbeddingsPostRequest;
 import com.sap.ai.sdk.orchestration.model.EmbeddingsPostResponse;
 import com.sap.ai.sdk.orchestration.model.GlobalStreamOptions;
 import com.sap.ai.sdk.orchestration.model.OrchestrationConfig;
+import com.sap.ai.sdk.orchestration.model.PartialOrchestrationConfig;
 import com.sap.cloud.sdk.cloudplatform.connectivity.Header;
 import com.sap.cloud.sdk.cloudplatform.connectivity.HttpDestination;
 import io.vavr.control.Try;
@@ -263,8 +264,14 @@ public class OrchestrationClient {
     if (request instanceof CompletionRequestConfiguration r) {
       enableStreaming(r.getConfig()::getStream, r.getConfig()::setStream);
     } else if (request instanceof CompletionRequestConfigurationReferenceById r) {
+      if (r.getConfig() == null) {
+        r.setConfig(PartialOrchestrationConfig.create());
+      }
       enableStreaming(r.getConfig()::getStream, r.getConfig()::setStream);
     } else if (request instanceof CompletionRequestConfigurationReferenceByNameScenarioVersion r) {
+      if (r.getConfig() == null) {
+        r.setConfig(PartialOrchestrationConfig.create());
+      }
       enableStreaming(r.getConfig()::getStream, r.getConfig()::setStream);
     } else {
       throw new OrchestrationClientException(

--- a/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
+++ b/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
@@ -45,6 +45,12 @@ import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.github.tomakehurst.wiremock.stubbing.Scenario;
 import com.sap.ai.sdk.orchestration.model.ChatDelta;
+import com.sap.ai.sdk.orchestration.model.CompletionPostRequest;
+import com.sap.ai.sdk.orchestration.model.CompletionRequestConfiguration;
+import com.sap.ai.sdk.orchestration.model.CompletionRequestConfigurationReferenceById;
+import com.sap.ai.sdk.orchestration.model.CompletionRequestConfigurationReferenceByIdConfigRef;
+import com.sap.ai.sdk.orchestration.model.CompletionRequestConfigurationReferenceByNameScenarioVersion;
+import com.sap.ai.sdk.orchestration.model.CompletionRequestConfigurationReferenceByNameScenarioVersionConfigRef;
 import com.sap.ai.sdk.orchestration.model.DPIEntities;
 import com.sap.ai.sdk.orchestration.model.DataRepositoryType;
 import com.sap.ai.sdk.orchestration.model.DocumentGroundingFilter;
@@ -52,6 +58,7 @@ import com.sap.ai.sdk.orchestration.model.ErrorResponse;
 import com.sap.ai.sdk.orchestration.model.ErrorResponseError;
 import com.sap.ai.sdk.orchestration.model.FilteringStreamOptions;
 import com.sap.ai.sdk.orchestration.model.GenericModuleResult;
+import com.sap.ai.sdk.orchestration.model.GlobalStreamOptions;
 import com.sap.ai.sdk.orchestration.model.GroundingFilterSearchConfiguration;
 import com.sap.ai.sdk.orchestration.model.GroundingModuleConfig;
 import com.sap.ai.sdk.orchestration.model.GroundingModuleConfigConfig;
@@ -59,6 +66,7 @@ import com.sap.ai.sdk.orchestration.model.GroundingModuleConfigConfigPlaceholder
 import com.sap.ai.sdk.orchestration.model.KeyValueListPair;
 import com.sap.ai.sdk.orchestration.model.LlamaGuard38b;
 import com.sap.ai.sdk.orchestration.model.ModuleResultsStreaming;
+import com.sap.ai.sdk.orchestration.model.PartialOrchestrationConfig;
 import com.sap.ai.sdk.orchestration.model.ResponseFormatText;
 import com.sap.ai.sdk.orchestration.model.SearchDocumentKeyValueListPair;
 import com.sap.ai.sdk.orchestration.model.SearchSelectOptionEnum;
@@ -1031,6 +1039,77 @@ class OrchestrationUnitTest {
       }
       Mockito.verify(inputStream, times(1)).close();
     }
+  }
+
+  private static Stream<CompletionPostRequest> streamChatCompletionDeltasRequests() {
+    var localConfig = new OrchestrationModuleConfig().withLlmConfig(CUSTOM_GPT_4O);
+    var localPrompt = new OrchestrationPrompt("Hello World! Why is this phrase so famous?");
+    var requestConfig = OrchestrationClient.toCompletionPostRequest(localPrompt, localConfig);
+    var requestById =
+        CompletionRequestConfigurationReferenceById.create()
+            .configRef(CompletionRequestConfigurationReferenceByIdConfigRef.create().id("test-id"))
+            .config(PartialOrchestrationConfig.create());
+    var requestByNSV =
+        CompletionRequestConfigurationReferenceByNameScenarioVersion.create()
+            .configRef(
+                CompletionRequestConfigurationReferenceByNameScenarioVersionConfigRef.create()
+                    .scenario("scenario")
+                    .name("name")
+                    .version("0.0.1"))
+            .config(PartialOrchestrationConfig.create());
+    return Stream.of(requestConfig, requestById, requestByNSV);
+  }
+
+  @ParameterizedTest
+  @MethodSource("streamChatCompletionDeltasRequests")
+  void testEnableStreamingOnAllRequestTypes(@Nonnull final CompletionPostRequest request)
+      throws IOException {
+    try (var inputStream = fileLoader.apply("streamChatCompletion.txt")) {
+      final var httpClient = mock(HttpClient.class);
+      ApacheHttpClient5Accessor.setHttpClientFactory(destination -> httpClient);
+      final var mockResponse = new BasicClassicHttpResponse(200, "OK");
+      mockResponse.setEntity(new InputStreamEntity(inputStream, ContentType.TEXT_PLAIN));
+      mockResponse.setHeader("Content-Type", "text/event-stream");
+      doReturn(mockResponse).when(httpClient).executeOpen(any(), any(), any());
+
+      client.streamChatCompletionDeltas(request).toList();
+    }
+
+    if (request instanceof CompletionRequestConfiguration r) {
+      assertThat(r.getConfig().getStream().isEnabled()).isTrue();
+    } else if (request instanceof CompletionRequestConfigurationReferenceById r) {
+      assertThat(r.getConfig().getStream().isEnabled()).isTrue();
+    } else if (request instanceof CompletionRequestConfigurationReferenceByNameScenarioVersion r) {
+      assertThat(r.getConfig().getStream().isEnabled()).isTrue();
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("streamChatCompletionDeltasRequests")
+  void testEnableStreamingPreservesExistingStreamOptions(
+      @Nonnull final CompletionPostRequest request) throws IOException {
+    var existingStream = GlobalStreamOptions.create().enabled(false).chunkSize(42);
+    if (request instanceof CompletionRequestConfiguration r) {
+      r.getConfig().setStream(existingStream);
+    } else if (request instanceof CompletionRequestConfigurationReferenceById r) {
+      r.getConfig().setStream(existingStream);
+    } else if (request instanceof CompletionRequestConfigurationReferenceByNameScenarioVersion r) {
+      r.getConfig().setStream(existingStream);
+    }
+
+    try (var inputStream = fileLoader.apply("streamChatCompletion.txt")) {
+      final var httpClient = mock(HttpClient.class);
+      ApacheHttpClient5Accessor.setHttpClientFactory(destination -> httpClient);
+      final var mockResponse = new BasicClassicHttpResponse(200, "OK");
+      mockResponse.setEntity(new InputStreamEntity(inputStream, ContentType.TEXT_PLAIN));
+      mockResponse.setHeader("Content-Type", "text/event-stream");
+      doReturn(mockResponse).when(httpClient).executeOpen(any(), any(), any());
+
+      client.streamChatCompletionDeltas(request).toList();
+    }
+
+    assertThat(existingStream.isEnabled()).isTrue();
+    assertThat(existingStream.getChunkSize()).isEqualTo(42);
   }
 
   @Test

--- a/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
+++ b/orchestration/src/test/java/com/sap/ai/sdk/orchestration/OrchestrationUnitTest.java
@@ -1113,6 +1113,14 @@ class OrchestrationUnitTest {
   }
 
   @Test
+  void testStreamChatCompletionDeltasThrowsOnUnsupportedRequestType() {
+    final CompletionPostRequest unknownRequest = new CompletionPostRequest() {};
+    assertThatThrownBy(() -> client.streamChatCompletionDeltas(unknownRequest))
+        .isExactlyInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Unsupported request type");
+  }
+
+  @Test
   void testMultiMessage() throws IOException {
     stubFor(
         post("/v2/completion")

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OrchestrationService.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/services/OrchestrationService.java
@@ -18,6 +18,7 @@ import com.sap.ai.sdk.orchestration.ImageItem;
 import com.sap.ai.sdk.orchestration.LlamaGuardFilter;
 import com.sap.ai.sdk.orchestration.Message;
 import com.sap.ai.sdk.orchestration.OrchestrationAiModel;
+import com.sap.ai.sdk.orchestration.OrchestrationChatCompletionDelta;
 import com.sap.ai.sdk.orchestration.OrchestrationChatResponse;
 import com.sap.ai.sdk.orchestration.OrchestrationClient;
 import com.sap.ai.sdk.orchestration.OrchestrationClientException;
@@ -30,6 +31,10 @@ import com.sap.ai.sdk.orchestration.ResponseJsonSchema;
 import com.sap.ai.sdk.orchestration.SystemMessage;
 import com.sap.ai.sdk.orchestration.TemplateConfig;
 import com.sap.ai.sdk.orchestration.TranslationConfig;
+import com.sap.ai.sdk.orchestration.model.CompletionRequestConfigurationReferenceById;
+import com.sap.ai.sdk.orchestration.model.CompletionRequestConfigurationReferenceByIdConfigRef;
+import com.sap.ai.sdk.orchestration.model.CompletionRequestConfigurationReferenceByNameScenarioVersion;
+import com.sap.ai.sdk.orchestration.model.CompletionRequestConfigurationReferenceByNameScenarioVersionConfigRef;
 import com.sap.ai.sdk.orchestration.model.DPIEntities;
 import com.sap.ai.sdk.orchestration.model.DataRepositoryType;
 import com.sap.ai.sdk.orchestration.model.DocumentGroundingFilter;
@@ -871,6 +876,70 @@ public class OrchestrationService {
         new OrchestrationModuleConfig()
             .withLlmConfig(new OrchestrationAiModel("broken_name_2", Map.of(), "latest"));
     return client.chatCompletion(prompt, brokenConfig, secondBrokenConfig, workingConfig);
+  }
+
+  /**
+   * Streaming chat completion using a {@link
+   * com.sap.ai.sdk.orchestration.model.CompletionRequestConfiguration} (inline config).
+   *
+   * @param famousPhrase the phrase to send to the assistant
+   * @return a stream of chat completion deltas
+   */
+  @Nonnull
+  public Stream<OrchestrationChatCompletionDelta> streamDeltasWithInlineConfig(
+      @Nonnull final String famousPhrase) {
+    val prompt = new OrchestrationPrompt(famousPhrase + " Why is this phrase so famous?");
+    val config = new OrchestrationModuleConfig().withLlmConfig(GPT_5_MINI);
+    val request = OrchestrationClient.toCompletionPostRequest(prompt, config);
+    return client.streamChatCompletionDeltas(request);
+  }
+
+  /**
+   * Streaming chat completion using a {@link
+   * com.sap.ai.sdk.orchestration.model.CompletionRequestConfigurationReferenceById} (config
+   * referenced by ID from the orchestration config registry).
+   *
+   * @return a stream of chat completion deltas
+   */
+  @Nonnull
+  public Stream<OrchestrationChatCompletionDelta> streamDeltasWithReferenceById() {
+    // get a valid id
+    ensureOrchestrationConfigExists("sdk-test-paraphrase", "create-3-paraphrases-of-sentence");
+    val orchConfigClient = new OrchestrationConfigClient();
+    val id =
+        orchConfigClient.listOrchestrationConfigs().getResources().stream()
+            .filter(r -> r.getName().equals("test-config-for-OrchestrationTest"))
+            .findFirst()
+            .orElseThrow()
+            .getId()
+            .toString();
+    // build the request object using the id
+    val request =
+        CompletionRequestConfigurationReferenceById.create()
+            .configRef(CompletionRequestConfigurationReferenceByIdConfigRef.create().id(id))
+            .placeholderValues(Map.of("phrase", "Hello World"));
+    return client.streamChatCompletionDeltas(request);
+  }
+
+  /**
+   * Streaming chat completion using a {@link
+   * com.sap.ai.sdk.orchestration.model.CompletionRequestConfigurationReferenceByNameScenarioVersion}
+   * (config referenced by scenario, name, and version).
+   *
+   * @return a stream of chat completion deltas
+   */
+  @Nonnull
+  public Stream<OrchestrationChatCompletionDelta> streamDeltasWithReferenceByScenario() {
+    ensureOrchestrationConfigExists("sdk-test-paraphrase", "create-3-paraphrases-of-sentence");
+    val request =
+        CompletionRequestConfigurationReferenceByNameScenarioVersion.create()
+            .configRef(
+                CompletionRequestConfigurationReferenceByNameScenarioVersionConfigRef.create()
+                    .scenario("sdk-test-scenario")
+                    .name("test-config-for-OrchestrationTest")
+                    .version("0.0.1"))
+            .placeholderValues(Map.of("phrase", "Hello World"));
+    return client.streamChatCompletionDeltas(request);
   }
 
   /**

--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/OrchestrationTest.java
@@ -635,6 +635,48 @@ class OrchestrationTest {
   }
 
   @Test
+  void testStreamDeltasWithInlineConfig() {
+    final var stream = service.streamDeltasWithInlineConfig("HelloWorld!");
+    val filledDeltaCount = new AtomicInteger(0);
+    stream.forEach(
+        delta -> {
+          log.info("delta: {}", delta);
+          if (!delta.getDeltaContent().isEmpty()) {
+            filledDeltaCount.incrementAndGet();
+          }
+        });
+    assertThat(filledDeltaCount.get()).isGreaterThan(0);
+  }
+
+  @Test
+  void testStreamDeltasWithReferenceById() {
+    final var stream = service.streamDeltasWithReferenceById();
+    val filledDeltaCount = new AtomicInteger(0);
+    stream.forEach(
+        delta -> {
+          log.info("delta: {}", delta);
+          if (!delta.getDeltaContent().isEmpty()) {
+            filledDeltaCount.incrementAndGet();
+          }
+        });
+    assertThat(filledDeltaCount.get()).isGreaterThan(0);
+  }
+
+  @Test
+  void testStreamDeltasWithReferenceByScenario() {
+    final var stream = service.streamDeltasWithReferenceByScenario();
+    val filledDeltaCount = new AtomicInteger(0);
+    stream.forEach(
+        delta -> {
+          log.info("delta: {}", delta);
+          if (!delta.getDeltaContent().isEmpty()) {
+            filledDeltaCount.incrementAndGet();
+          }
+        });
+    assertThat(filledDeltaCount.get()).isGreaterThan(0);
+  }
+
+  @Test
   void testCompletionWithFallbackAllFail() {
     assertThatThrownBy(() -> service.completionWithFallbackAllFail("HelloWorld!"))
         .isInstanceOf(OrchestrationClientException.class)


### PR DESCRIPTION
## Context

Joule colleagues asked us [via Teams](https://teams.microsoft.com/l/message/19:99897d25f028415cb21d7fdf65c216bb@thread.v2/1783337251971?context=%7B%22contextType%22%3A%22chat%22%7D) to enable streaming in the `OrchestrationClient` from low-level request objects (similar to the already existing `.executeRequest()`).

This PR implements that feature.

### Feature scope:
 
- [x] implement feature
- [x] add unit tests
- [x] add e2e tests

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] Error handling created / updated & covered by the tests above
- [ ] ~Aligned changes with the JavaScript SDK~
- [ ] ~[Documentation](https://github.com/SAP/ai-sdk/tree/main/docs-java) updated~
- [ ] ~Release notes updated~
