### PR TITLE
chore: [DevOps] CVE 2026-54399 and CVE 2026-54428

### DIFF
--- a/.github/workflows/fosstars-report.yml
+++ b/.github/workflows/fosstars-report.yml
@@ -81,14 +81,14 @@ jobs:
         with:
           report-branch: fosstars-report
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: 'Slack Notification'
-        if: failure()
-        uses: slackapi/slack-github-action@v3.0.3
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "text": "⚠️ OWASP Dependency check failed! 😬 Please inspect & fix by clicking <https://github.com/SAP/ai-sdk-java/actions/runs/${{ github.run_id }}|here>"
-            }
+#
+#      - name: 'Slack Notification'
+#        if: failure()
+#        uses: slackapi/slack-github-action@v3.0.3
+#        with:
+#          webhook: ${{ secrets.SLACK_WEBHOOK }}
+#          webhook-type: incoming-webhook
+#          payload: |
+#            {
+#              "text": "⚠️ OWASP Dependency check failed! 😬 Please inspect & fix by clicking <https://github.com/SAP/ai-sdk-java/actions/runs/${{ github.run_id }}|here>"
+#            }

--- a/.github/workflows/fosstars-report.yml
+++ b/.github/workflows/fosstars-report.yml
@@ -81,14 +81,14 @@ jobs:
         with:
           report-branch: fosstars-report
           token: ${{ secrets.GITHUB_TOKEN }}
-#
-#      - name: 'Slack Notification'
-#        if: failure()
-#        uses: slackapi/slack-github-action@v3.0.3
-#        with:
-#          webhook: ${{ secrets.SLACK_WEBHOOK }}
-#          webhook-type: incoming-webhook
-#          payload: |
-#            {
-#              "text": "⚠️ OWASP Dependency check failed! 😬 Please inspect & fix by clicking <https://github.com/SAP/ai-sdk-java/actions/runs/${{ github.run_id }}|here>"
-#            }
+
+      - name: 'Slack Notification'
+        if: failure()
+        uses: slackapi/slack-github-action@v3.0.3
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "⚠️ OWASP Dependency check failed! 😬 Please inspect & fix by clicking <https://github.com/SAP/ai-sdk-java/actions/runs/${{ github.run_id }}|here>"
+            }

--- a/.pipeline/dependency-check-suppression.xml
+++ b/.pipeline/dependency-check-suppression.xml
@@ -4,4 +4,8 @@
     <notes><![CDATA[This is a JS dependency.]]></notes>
     <cve>CVE-2021-41251</cve>
   </suppress>
+  <suppress>
+    <notes><![CDATA[This is an issue related to Apache HttpComponents v5. OWASP mistakenly flags dependencies from v4.]]></notes>
+    <cve>CVE-2026-54399</cve>
+  </suppress>
 </suppressions>

--- a/.pipeline/dependency-check-suppression.xml
+++ b/.pipeline/dependency-check-suppression.xml
@@ -8,4 +8,8 @@
     <notes><![CDATA[This is an issue related to Apache HttpComponents v5. OWASP mistakenly flags dependencies from v4.]]></notes>
     <cve>CVE-2026-54399</cve>
   </suppress>
+  <suppress>
+    <notes><![CDATA[This is an issue related to Apache HttpComponents v5. OWASP mistakenly flags dependencies from v4.]]></notes>
+    <cve>CVE-2026-54428</cve>
+  </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
     <japicmp.version>0.26.1</japicmp.version>
     <openai-java.version>4.41.0</openai-java.version>
     <!-- conflicts resolution -->
+    <httpcomponents-core5.version>5.4.3</httpcomponents-core5.version>
     <micrometer.version>1.17.0</micrometer.version>
     <json.version>20260522</json.version>
     <snakeyaml.version>2.6</snakeyaml.version>
@@ -155,6 +156,12 @@
         <version>${jackson.version}</version>
       </dependency>
       <!-- conflicts resolution scope "compile" -->
+      <!-- CVE-2026-54428: pin httpcore5-h2 >= 5.4.3 until httpclient5 (pulled via cloud-sdk openapi-core-apache) ships with a fixed version -->
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5-h2</artifactId>
+        <version>${httpcomponents-core5.version}</version>
+      </dependency>
       <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -156,10 +156,15 @@
         <version>${jackson.version}</version>
       </dependency>
       <!-- conflicts resolution scope "compile" -->
-      <!-- CVE-2026-54428: pin httpcore5-h2 >= 5.4.3 until httpclient5 (pulled via cloud-sdk openapi-core-apache) ships with a fixed version -->
+      <!-- CVE-2026-54428, 54399: pin httpcore5-h2, httpcore5 >= 5.4.3 until httpclient5 (pulled via cloud-sdk openapi-core-apache) ships with fixed versions -->
       <dependency>
         <groupId>org.apache.httpcomponents.core5</groupId>
         <artifactId>httpcore5-h2</artifactId>
+        <version>${httpcomponents-core5.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5</artifactId>
         <version>${httpcomponents-core5.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
## Context

There are 2 CVEs ([54428](https://www.cve.org/CVERecord?id=CVE-2026-54428) and [54399](https://www.cve.org/CVERecord?id=CVE-2026-54399)) which are concerned with Apache HttpComponent v5 (see links to CVE database above). I fixed the versions mentioned in the CVE database in this PR. 

For some reason, OWASP also flags HttpComponent v4 as violating both of these CVEs (see [here](https://github.com/SAP/ai-sdk-java/actions/runs/28869664638/job/85628781578#step:8:176) and [here](https://github.com/SAP/ai-sdk-java/actions/runs/28865829919/job/85615556719#step:8:176)). I do not know why since every entry I found online only stated v5 components. I thus ignored the two CVEs in our pipeline.

**Note:** OWASP is still failing as there is yet another new CVE (unrelated to the ones above), but this time without a released fix.
