### PR TITLE
chore: [OpenAI] Improve E2E test stability

### DIFF
--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/AiCoreOpenAiTest.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/AiCoreOpenAiTest.java
@@ -13,6 +13,7 @@ import com.openai.models.responses.ResponseOutputItem;
 import com.openai.models.responses.ResponseStatus;
 import com.sap.ai.sdk.app.services.AiCoreOpenAiService;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
@@ -134,7 +135,15 @@ class AiCoreOpenAiTest {
     final var message =
         followUp.output().stream().filter(ResponseOutputItem::isMessage).findFirst();
     assertThat(message).isPresent();
-    assertThat(message.get().asMessage().content().get(0).asOutputText().text())
+    assertThat(
+            message
+                .get()
+                .asMessage()
+                .content()
+                .get(0)
+                .asOutputText()
+                .text()
+                .toLowerCase(Locale.ROOT))
         .containsAnyOf("three", "3");
   }
 


### PR DESCRIPTION
## Context

Test failed twice in a row with actual `"Three."`
