### PR TITLE
chore: [DevOps] Bump apache tomcat version to avoid CVE-2026-53404

### DIFF
--- a/sample-code/spring-app/pom.xml
+++ b/sample-code/spring-app/pom.xml
@@ -35,7 +35,7 @@
     <project.rootdir>${project.basedir}/../../</project.rootdir>
     <spring-boot.version>3.5.16</spring-boot.version>
     <cf-logging.version>4.2.0</cf-logging.version>
-    <apache-tomcat-embed.version>11.0.22</apache-tomcat-embed.version>
+    <apache-tomcat-embed.version>11.0.23</apache-tomcat-embed.version>
     <mcp-core.version>2.0.0</mcp-core.version>
     <!-- Skip end-to-end tests by default, can be overridden with -DskipTests=false -->
     <skipTests>true</skipTests>


### PR DESCRIPTION
## Context

Fixes [CVE-2026-53404](https://www.cve.org/CVERecord?id=CVE-2026-53404).
