### PR TITLE
fix: [OpenAI] bug `.withHeader` deletes context from `OpenAiClient`

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -12,7 +12,7 @@
 
 ### ✨ New Functionality
 
--
+- [OpenAI] You can now add multiple custom headers to an `OpenAiClient` at once via `.withHeaders()`.
 
 ### 📈 Improvements
 

--- a/foundation-models/openai/pom.xml
+++ b/foundation-models/openai/pom.xml
@@ -40,7 +40,7 @@
     <project.rootdir>${project.basedir}/../../</project.rootdir>
     <coverage.complexity>82%</coverage.complexity>
     <coverage.line>92%</coverage.line>
-    <coverage.instruction>89%</coverage.instruction>
+    <coverage.instruction>90%</coverage.instruction>
     <coverage.branch>79%</coverage.branch>
     <coverage.method>91%</coverage.method>
     <coverage.class>92%</coverage.class>

--- a/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/OpenAiClient.java
+++ b/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/OpenAiClient.java
@@ -34,6 +34,7 @@ import com.sap.cloud.sdk.cloudplatform.connectivity.HttpDestination;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -146,8 +147,28 @@ public final class OpenAiClient {
   @Nonnull
   public OpenAiClient withHeader(@Nonnull final String key, @Nonnull final String value) {
     final var newClient = new OpenAiClient(this.destination);
+    newClient.systemPrompt = this.systemPrompt;
     newClient.customHeaders.addAll(this.customHeaders);
     newClient.customHeaders.add(new Header(key, value));
+    return newClient;
+  }
+
+  /**
+   * Create a new openAI client with multiple custom headers added to every call made with this
+   * client
+   *
+   * @param headers a map of key value pairs for the custom headers to add
+   * @return a new client.
+   * @since 1.22.0
+   */
+  @Nonnull
+  public OpenAiClient withHeaders(@Nonnull final Map<String, String> headers) {
+    final var newClient = new OpenAiClient(this.destination);
+    newClient.systemPrompt = this.systemPrompt;
+    newClient.customHeaders.addAll(this.customHeaders);
+    headers.entrySet().stream()
+        .map(e -> new Header(e.getKey(), e.getValue()))
+        .forEach(newClient.customHeaders::add);
     return newClient;
   }
 

--- a/foundation-models/openai/src/test/java/com/sap/ai/sdk/foundationmodels/openai/OpenAiClientTest.java
+++ b/foundation-models/openai/src/test/java/com/sap/ai/sdk/foundationmodels/openai/OpenAiClientTest.java
@@ -507,4 +507,45 @@ class OpenAiClientTest extends BaseOpenAiClientTest {
             .withHeader("Header-For-Both", equalTo("value"))
             .withHeader("foot", equalTo("baz")));
   }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  void testWithHeaderPreservesSystemPrompt() {
+    stubForChatCompletion();
+
+    client
+        .withSystemPrompt("You are a helpful AI")
+        .withHeader("foo", "bar")
+        .chatCompletion("Hello World! Why is this phrase so famous?");
+
+    verify(
+        postRequestedFor(anyUrl())
+            .withHeader("foo", equalTo("bar"))
+            .withRequestBody(
+                matchingJsonPath("$.messages[0].role", equalTo("system"))
+                    .and(
+                        matchingJsonPath(
+                            "$.messages[0].content", equalTo("You are a helpful AI")))));
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  void testMultipleCustomHeaders() {
+    stubForChatCompletion();
+
+    client
+        .withSystemPrompt("You are a helpful AI")
+        .withHeaders(Map.of("foo", "bar", "baz", "qux"))
+        .chatCompletion("Hello World! Why is this phrase so famous?");
+
+    verify(
+        postRequestedFor(anyUrl())
+            .withHeader("foo", equalTo("bar"))
+            .withHeader("baz", equalTo("qux"))
+            .withRequestBody(
+                matchingJsonPath("$.messages[0].role", equalTo("system"))
+                    .and(
+                        matchingJsonPath(
+                            "$.messages[0].content", equalTo("You are a helpful AI")))));
+  }
 }


### PR DESCRIPTION
## Context

AI/ai-sdk-java-backlog#415.

Singular method `.withHeader` deletes context from `OpenAiClient` so was fixed and also created `.withHeaders` which accepts multiple custom headers.

### Feature scope:
 
- [x] bug in `.withHeader` fixed to include systemPrompt.
- [x] implemented a `OpenAiClient.withHeaders(Map<String, String> headers)` method
- [x] Added unit tests to both changes 

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] Error handling created / updated & covered by the tests above
- [ ] ~Aligned changes with the JavaScript SDK~
- [ ] [Documentation](https://github.com/SAP/ai-sdk/tree/main/docs-java) updated
- [x] Release notes updated
