### PR TITLE
feat: add support for qwen models

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -12,7 +12,8 @@
 
 ### ✨ New Functionality
 
--
+- [Orchestration] Added QWEN_3_7_MAX, QWEN_3_7_PLUS and ALIBABA_TEXT_EMBEDDING_4 to model list in OrchestrationAiModel.
+- [Orchestration] Marked as deprecated QWEN_3_MAX model (retired, use newer models instead, e.g. QWEN_3_7_MAX).
 
 ### 📈 Improvements
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -12,8 +12,8 @@
 
 ### ✨ New Functionality
 
-- [Orchestration] Added QWEN_3_7_MAX, QWEN_3_7_PLUS and ALIBABA_TEXT_EMBEDDING_4 to model list in OrchestrationAiModel.
-- [Orchestration] Marked as deprecated QWEN_3_MAX model (retired, use newer models instead, e.g. QWEN_3_7_MAX).
+- [Orchestration] Added `QWEN_3_7_MAX`, `QWEN_3_7_PLUS` and `ALIBABA_TEXT_EMBEDDING_4` to model list in `OrchestrationAiModel`.
+- [Orchestration] Marked as deprecated `QWEN_3_MAX` model (retired, use newer models instead, e.g. `QWEN_3_7_MAX`).
 - [OpenAI] You can now add multiple custom headers to an `OpenAiClient` at once via `.withHeaders()`.
 
 ### 📈 Improvements

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationAiModel.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationAiModel.java
@@ -461,10 +461,11 @@ public class OrchestrationAiModel {
   /** SAP ABAP 1 model */
   public static final OrchestrationAiModel SAP_ABAP_1 = new OrchestrationAiModel("sap-abap-1");
 
-  /** Alibaba Qwen 3 max model
+  /**
+   * Alibaba Qwen 3 max model
    *
    * @deprecated This model is deprecated on AI Core with a planned retirement on 2026-02-01.
-   * */
+   */
   @Deprecated
   public static final OrchestrationAiModel QWEN_3_MAX = new OrchestrationAiModel("qwen3-max");
 
@@ -472,7 +473,8 @@ public class OrchestrationAiModel {
   public static final OrchestrationAiModel QWEN_3_6_PLUS = new OrchestrationAiModel("qwen3.6-plus");
 
   /** Alibaba Qwen 3.6 flash model */
-  public static final OrchestrationAiModel QWEN_3_6_FLASH = new OrchestrationAiModel("qwen3.6-flash");
+  public static final OrchestrationAiModel QWEN_3_6_FLASH =
+      new OrchestrationAiModel("qwen3.6-flash");
 
   /** Alibaba Qwen 3.7 max model */
   public static final OrchestrationAiModel QWEN_3_7_MAX = new OrchestrationAiModel("qwen3.7-max");
@@ -481,7 +483,8 @@ public class OrchestrationAiModel {
   public static final OrchestrationAiModel QWEN_3_7_PLUS = new OrchestrationAiModel("qwen3.7-plus");
 
   /** Alibaba text-embedding-4 model */
-  public static final OrchestrationAiModel ALIBABA_TEXT_EMBEDDING_4 = new OrchestrationAiModel("text-embedding-4");
+  public static final OrchestrationAiModel ALIBABA_TEXT_EMBEDDING_4 =
+      new OrchestrationAiModel("text-embedding-4");
 
   OrchestrationAiModel(@Nonnull final String name) {
     this(name, Map.of(), "latest");

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationAiModel.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationAiModel.java
@@ -465,15 +465,27 @@ public class OrchestrationAiModel {
   /** SAP ABAP 1 model */
   public static final OrchestrationAiModel SAP_ABAP_1 = new OrchestrationAiModel("sap-abap-1");
 
-  /** Alibaba Qwen 3 max model */
+  /** Alibaba Qwen 3 max model
+   *
+   * @deprecated This model is deprecated on AI Core with a planned retirement on 2026-02-01.
+   * */
+  @Deprecated
   public static final OrchestrationAiModel QWEN_3_MAX = new OrchestrationAiModel("qwen3-max");
 
   /** Alibaba Qwen 3.6 plus model */
   public static final OrchestrationAiModel QWEN_3_6_PLUS = new OrchestrationAiModel("qwen3.6-plus");
 
   /** Alibaba Qwen 3.6 flash model */
-  public static final OrchestrationAiModel QWEN_3_6_FLASH =
-      new OrchestrationAiModel("qwen3.6-flash");
+  public static final OrchestrationAiModel QWEN_3_6_FLASH = new OrchestrationAiModel("qwen3.6-flash");
+
+  /** Alibaba Qwen 3.7 max model */
+  public static final OrchestrationAiModel QWEN_3_7_MAX = new OrchestrationAiModel("qwen3.7-max");
+
+  /** Alibaba Qwen 3.7 plus model */
+  public static final OrchestrationAiModel QWEN_3_7_PLUS = new OrchestrationAiModel("qwen3.7-plus");
+
+  /** Alibaba text-embedding-4 model */
+  public static final OrchestrationAiModel ALIBABA_TEXT_EMBEDDING_4 = new OrchestrationAiModel("text-embedding-4");
 
   OrchestrationAiModel(@Nonnull final String name) {
     this(name, Map.of(), "latest");

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationAiModel.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationAiModel.java
@@ -490,10 +490,6 @@ public class OrchestrationAiModel {
   /** Alibaba Qwen 3.7 plus model */
   public static final OrchestrationAiModel QWEN_3_7_PLUS = new OrchestrationAiModel("qwen3.7-plus");
 
-  /** Alibaba text-embedding-4 model */
-  public static final OrchestrationAiModel ALIBABA_TEXT_EMBEDDING_4 =
-      new OrchestrationAiModel("text-embedding-4");
-
   OrchestrationAiModel(@Nonnull final String name) {
     this(name, Map.of(), "latest");
   }

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationEmbeddingModel.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/OrchestrationEmbeddingModel.java
@@ -55,6 +55,10 @@ public class OrchestrationEmbeddingModel implements AiModel {
   public static final OrchestrationEmbeddingModel GEMINI_EMBEDDING =
       new OrchestrationEmbeddingModel("gemini-embedding");
 
+  /** Alibaba text-embedding-4 model */
+  public static final OrchestrationEmbeddingModel ALIBABA_TEXT_EMBEDDING_4 =
+      new OrchestrationEmbeddingModel("text-embedding-4");
+
   /**
    * Creates a new embedding model configuration with the specified name.
    *


### PR DESCRIPTION
## Context

AI/ai-sdk-java-backlog#414.

Added support for the following Alibaba models
- qwen3.6-flash
- qwen3.7-max
- qwen3.7-plus
- text-embedding-4

Marked the following model as deprecated:
- qwen3-max (retired 2026-02-01)

## Definition of Done

- [X] Functionality scope stated & covered
- [ ] Tests cover the scope above
- [ ] Error handling created / updated & covered by the tests above
- [ ] ~Aligned changes with the JavaScript SDK~
- [ ] [Documentation](https://github.com/SAP/ai-sdk/tree/main/docs-java) updated
- [x] Release notes updated
