### PR TITLE
feat: try out Cloud SDK OpenAPI generator 3.1 

### DIFF
--- a/core-services/document-grounding/src/main/java/com/sap/ai/sdk/grounding/model/PostProcessingOperation.java
+++ b/core-services/document-grounding/src/main/java/com/sap/ai/sdk/grounding/model/PostProcessingOperation.java
@@ -85,7 +85,7 @@ public class PostProcessingOperation implements RetrievalSearchInputPostProcessi
    * instance.
    *
    * @param maxChunkCount Maximum number of chunks to be retained in final PerSearchFilterResult.
-   *     Minimum: 0 Maximum: 10000000
+   *     Minimum: 0 (exclusive) Maximum: 10000000
    * @return The same instance of this {@link PostProcessingOperation} class
    */
   @Nonnull
@@ -95,8 +95,8 @@ public class PostProcessingOperation implements RetrievalSearchInputPostProcessi
   }
 
   /**
-   * Maximum number of chunks to be retained in final PerSearchFilterResult. minimum: 0 maximum:
-   * 10000000
+   * Maximum number of chunks to be retained in final PerSearchFilterResult. minimum: 0 (exclusive)
+   * maximum: 10000000
    *
    * @return maxChunkCount The maxChunkCount of this {@link PostProcessingOperation} instance.
    */
@@ -109,7 +109,7 @@ public class PostProcessingOperation implements RetrievalSearchInputPostProcessi
    * Set the maxChunkCount of this {@link PostProcessingOperation} instance.
    *
    * @param maxChunkCount Maximum number of chunks to be retained in final PerSearchFilterResult.
-   *     Minimum: 0 Maximum: 10000000
+   *     Minimum: 0 (exclusive) Maximum: 10000000
    */
   public void setMaxChunkCount(@Nullable final Integer maxChunkCount) {
     this.maxChunkCount = maxChunkCount;

--- a/core-services/document-grounding/src/main/java/com/sap/ai/sdk/grounding/model/RetrievalSearchConfiguration.java
+++ b/core-services/document-grounding/src/main/java/com/sap/ai/sdk/grounding/model/RetrievalSearchConfiguration.java
@@ -45,7 +45,7 @@ public class RetrievalSearchConfiguration
    * instance.
    *
    * @param maxChunkCount Maximum number of chunks to be returned. Cannot be used with
-   *     &#39;maxDocumentCount&#39;. Minimum: 0 Maximum: 10000000
+   *     &#39;maxDocumentCount&#39;. Minimum: 0 (exclusive) Maximum: 10000000
    * @return The same instance of this {@link RetrievalSearchConfiguration} class
    */
   @Nonnull
@@ -56,7 +56,7 @@ public class RetrievalSearchConfiguration
 
   /**
    * Maximum number of chunks to be returned. Cannot be used with &#39;maxDocumentCount&#39;.
-   * minimum: 0 maximum: 10000000
+   * minimum: 0 (exclusive) maximum: 10000000
    *
    * @return maxChunkCount The maxChunkCount of this {@link RetrievalSearchConfiguration} instance.
    */
@@ -69,7 +69,7 @@ public class RetrievalSearchConfiguration
    * Set the maxChunkCount of this {@link RetrievalSearchConfiguration} instance.
    *
    * @param maxChunkCount Maximum number of chunks to be returned. Cannot be used with
-   *     &#39;maxDocumentCount&#39;. Minimum: 0 Maximum: 10000000
+   *     &#39;maxDocumentCount&#39;. Minimum: 0 (exclusive) Maximum: 10000000
    */
   public void setMaxChunkCount(@Nullable final Integer maxChunkCount) {
     this.maxChunkCount = maxChunkCount;
@@ -81,7 +81,8 @@ public class RetrievalSearchConfiguration
    *
    * @param maxDocumentCount [Only supports &#39;vector&#39; dataRepositoryType] - Maximum number of
    *     documents to be returned. Cannot be used with &#39;maxChunkCount&#39;. If maxDocumentCount
-   *     is given, then only one chunk per document is returned. Minimum: 0 Maximum: 10000000
+   *     is given, then only one chunk per document is returned. Minimum: 0 (exclusive) Maximum:
+   *     10000000
    * @return The same instance of this {@link RetrievalSearchConfiguration} class
    */
   @Nonnull
@@ -93,7 +94,7 @@ public class RetrievalSearchConfiguration
   /**
    * [Only supports &#39;vector&#39; dataRepositoryType] - Maximum number of documents to be
    * returned. Cannot be used with &#39;maxChunkCount&#39;. If maxDocumentCount is given, then only
-   * one chunk per document is returned. minimum: 0 maximum: 10000000
+   * one chunk per document is returned. minimum: 0 (exclusive) maximum: 10000000
    *
    * @return maxDocumentCount The maxDocumentCount of this {@link RetrievalSearchConfiguration}
    *     instance.
@@ -108,7 +109,8 @@ public class RetrievalSearchConfiguration
    *
    * @param maxDocumentCount [Only supports &#39;vector&#39; dataRepositoryType] - Maximum number of
    *     documents to be returned. Cannot be used with &#39;maxChunkCount&#39;. If maxDocumentCount
-   *     is given, then only one chunk per document is returned. Minimum: 0 Maximum: 10000000
+   *     is given, then only one chunk per document is returned. Minimum: 0 (exclusive) Maximum:
+   *     10000000
    */
   public void setMaxDocumentCount(@Nullable final Integer maxDocumentCount) {
     this.maxDocumentCount = maxDocumentCount;

--- a/core-services/document-grounding/src/main/java/com/sap/ai/sdk/grounding/model/RetrievalSearchInputPostProcessingInner.java
+++ b/core-services/document-grounding/src/main/java/com/sap/ai/sdk/grounding/model/RetrievalSearchInputPostProcessingInner.java
@@ -86,7 +86,7 @@ public class RetrievalSearchInputPostProcessingInner
    * return the same instance.
    *
    * @param maxChunkCount Maximum number of chunks to be retained in final PerSearchFilterResult.
-   *     Minimum: 0 Maximum: 10000000
+   *     Minimum: 0 (exclusive) Maximum: 10000000
    * @return The same instance of this {@link RetrievalSearchInputPostProcessingInner} class
    */
   @Nonnull
@@ -97,8 +97,8 @@ public class RetrievalSearchInputPostProcessingInner
   }
 
   /**
-   * Maximum number of chunks to be retained in final PerSearchFilterResult. minimum: 0 maximum:
-   * 10000000
+   * Maximum number of chunks to be retained in final PerSearchFilterResult. minimum: 0 (exclusive)
+   * maximum: 10000000
    *
    * @return maxChunkCount The maxChunkCount of this {@link RetrievalSearchInputPostProcessingInner}
    *     instance.
@@ -112,7 +112,7 @@ public class RetrievalSearchInputPostProcessingInner
    * Set the maxChunkCount of this {@link RetrievalSearchInputPostProcessingInner} instance.
    *
    * @param maxChunkCount Maximum number of chunks to be retained in final PerSearchFilterResult.
-   *     Minimum: 0 Maximum: 10000000
+   *     Minimum: 0 (exclusive) Maximum: 10000000
    */
   public void setMaxChunkCount(@Nullable final Integer maxChunkCount) {
     this.maxChunkCount = maxChunkCount;

--- a/core-services/document-grounding/src/main/java/com/sap/ai/sdk/grounding/model/SearchConfiguration.java
+++ b/core-services/document-grounding/src/main/java/com/sap/ai/sdk/grounding/model/SearchConfiguration.java
@@ -45,7 +45,7 @@ public class SearchConfiguration
    * instance.
    *
    * @param maxChunkCount Maximum number of chunks to be returned. Cannot be used with
-   *     &#39;maxDocumentCount&#39;. Minimum: 0 Maximum: 0
+   *     &#39;maxDocumentCount&#39;. Minimum: 0 (exclusive) Maximum: 0
    * @return The same instance of this {@link SearchConfiguration} class
    */
   @Nonnull
@@ -56,7 +56,7 @@ public class SearchConfiguration
 
   /**
    * Maximum number of chunks to be returned. Cannot be used with &#39;maxDocumentCount&#39;.
-   * minimum: 0 maximum: 0
+   * minimum: 0 (exclusive) maximum: 0
    *
    * @return maxChunkCount The maxChunkCount of this {@link SearchConfiguration} instance.
    */
@@ -69,7 +69,7 @@ public class SearchConfiguration
    * Set the maxChunkCount of this {@link SearchConfiguration} instance.
    *
    * @param maxChunkCount Maximum number of chunks to be returned. Cannot be used with
-   *     &#39;maxDocumentCount&#39;. Minimum: 0 Maximum: 0
+   *     &#39;maxDocumentCount&#39;. Minimum: 0 (exclusive) Maximum: 0
    */
   public void setMaxChunkCount(@Nullable final Integer maxChunkCount) {
     this.maxChunkCount = maxChunkCount;
@@ -81,7 +81,7 @@ public class SearchConfiguration
    *
    * @param maxDocumentCount [Only supports &#39;vector&#39; dataRepositoryType] - Maximum number of
    *     documents to be returned. Cannot be used with &#39;maxChunkCount&#39;. If maxDocumentCount
-   *     is given, then only one chunk per document is returned. Minimum: 0 Maximum: 0
+   *     is given, then only one chunk per document is returned. Minimum: 0 (exclusive) Maximum: 0
    * @return The same instance of this {@link SearchConfiguration} class
    */
   @Nonnull
@@ -93,7 +93,7 @@ public class SearchConfiguration
   /**
    * [Only supports &#39;vector&#39; dataRepositoryType] - Maximum number of documents to be
    * returned. Cannot be used with &#39;maxChunkCount&#39;. If maxDocumentCount is given, then only
-   * one chunk per document is returned. minimum: 0 maximum: 0
+   * one chunk per document is returned. minimum: 0 (exclusive) maximum: 0
    *
    * @return maxDocumentCount The maxDocumentCount of this {@link SearchConfiguration} instance.
    */
@@ -107,7 +107,7 @@ public class SearchConfiguration
    *
    * @param maxDocumentCount [Only supports &#39;vector&#39; dataRepositoryType] - Maximum number of
    *     documents to be returned. Cannot be used with &#39;maxChunkCount&#39;. If maxDocumentCount
-   *     is given, then only one chunk per document is returned. Minimum: 0 Maximum: 0
+   *     is given, then only one chunk per document is returned. Minimum: 0 (exclusive) Maximum: 0
    */
   public void setMaxDocumentCount(@Nullable final Integer maxDocumentCount) {
     this.maxDocumentCount = maxDocumentCount;

--- a/core-services/document-grounding/src/main/java/com/sap/ai/sdk/grounding/model/VectorSearchConfiguration.java
+++ b/core-services/document-grounding/src/main/java/com/sap/ai/sdk/grounding/model/VectorSearchConfiguration.java
@@ -45,7 +45,7 @@ public class VectorSearchConfiguration
    * instance.
    *
    * @param maxChunkCount Maximum number of chunks to be returned. Cannot be used with
-   *     &#39;maxDocumentCount&#39;. Minimum: 0 Maximum: 10000000
+   *     &#39;maxDocumentCount&#39;. Minimum: 0 (exclusive) Maximum: 10000000
    * @return The same instance of this {@link VectorSearchConfiguration} class
    */
   @Nonnull
@@ -56,7 +56,7 @@ public class VectorSearchConfiguration
 
   /**
    * Maximum number of chunks to be returned. Cannot be used with &#39;maxDocumentCount&#39;.
-   * minimum: 0 maximum: 10000000
+   * minimum: 0 (exclusive) maximum: 10000000
    *
    * @return maxChunkCount The maxChunkCount of this {@link VectorSearchConfiguration} instance.
    */
@@ -69,7 +69,7 @@ public class VectorSearchConfiguration
    * Set the maxChunkCount of this {@link VectorSearchConfiguration} instance.
    *
    * @param maxChunkCount Maximum number of chunks to be returned. Cannot be used with
-   *     &#39;maxDocumentCount&#39;. Minimum: 0 Maximum: 10000000
+   *     &#39;maxDocumentCount&#39;. Minimum: 0 (exclusive) Maximum: 10000000
    */
   public void setMaxChunkCount(@Nullable final Integer maxChunkCount) {
     this.maxChunkCount = maxChunkCount;
@@ -81,7 +81,8 @@ public class VectorSearchConfiguration
    *
    * @param maxDocumentCount [Only supports &#39;vector&#39; dataRepositoryType] - Maximum number of
    *     documents to be returned. Cannot be used with &#39;maxChunkCount&#39;. If maxDocumentCount
-   *     is given, then only one chunk per document is returned. Minimum: 0 Maximum: 10000000
+   *     is given, then only one chunk per document is returned. Minimum: 0 (exclusive) Maximum:
+   *     10000000
    * @return The same instance of this {@link VectorSearchConfiguration} class
    */
   @Nonnull
@@ -93,7 +94,7 @@ public class VectorSearchConfiguration
   /**
    * [Only supports &#39;vector&#39; dataRepositoryType] - Maximum number of documents to be
    * returned. Cannot be used with &#39;maxChunkCount&#39;. If maxDocumentCount is given, then only
-   * one chunk per document is returned. minimum: 0 maximum: 10000000
+   * one chunk per document is returned. minimum: 0 (exclusive) maximum: 10000000
    *
    * @return maxDocumentCount The maxDocumentCount of this {@link VectorSearchConfiguration}
    *     instance.
@@ -108,7 +109,8 @@ public class VectorSearchConfiguration
    *
    * @param maxDocumentCount [Only supports &#39;vector&#39; dataRepositoryType] - Maximum number of
    *     documents to be returned. Cannot be used with &#39;maxChunkCount&#39;. If maxDocumentCount
-   *     is given, then only one chunk per document is returned. Minimum: 0 Maximum: 10000000
+   *     is given, then only one chunk per document is returned. Minimum: 0 (exclusive) Maximum:
+   *     10000000
    */
   public void setMaxDocumentCount(@Nullable final Integer maxDocumentCount) {
     this.maxDocumentCount = maxDocumentCount;

--- a/core-services/prompt-registry/src/main/java/com/sap/ai/sdk/prompt/registry/model/GroundingFilterSearchConfiguration.java
+++ b/core-services/prompt-registry/src/main/java/com/sap/ai/sdk/prompt/registry/model/GroundingFilterSearchConfiguration.java
@@ -45,7 +45,7 @@ public class GroundingFilterSearchConfiguration
    * the same instance.
    *
    * @param maxChunkCount Maximum number of chunks to be returned. Cannot be used with
-   *     &#39;maxDocumentCount&#39;. Minimum: 0
+   *     &#39;maxDocumentCount&#39;. Minimum: 0 (exclusive)
    * @return The same instance of this {@link GroundingFilterSearchConfiguration} class
    */
   @Nonnull
@@ -56,7 +56,7 @@ public class GroundingFilterSearchConfiguration
 
   /**
    * Maximum number of chunks to be returned. Cannot be used with &#39;maxDocumentCount&#39;.
-   * minimum: 0
+   * minimum: 0 (exclusive)
    *
    * @return maxChunkCount The maxChunkCount of this {@link GroundingFilterSearchConfiguration}
    *     instance.
@@ -70,7 +70,7 @@ public class GroundingFilterSearchConfiguration
    * Set the maxChunkCount of this {@link GroundingFilterSearchConfiguration} instance.
    *
    * @param maxChunkCount Maximum number of chunks to be returned. Cannot be used with
-   *     &#39;maxDocumentCount&#39;. Minimum: 0
+   *     &#39;maxDocumentCount&#39;. Minimum: 0 (exclusive)
    */
   public void setMaxChunkCount(@Nullable final Integer maxChunkCount) {
     this.maxChunkCount = maxChunkCount;
@@ -82,7 +82,7 @@ public class GroundingFilterSearchConfiguration
    *
    * @param maxDocumentCount [Only supports &#39;vector&#39; dataRepositoryType] - Maximum number of
    *     documents to be returned. Cannot be used with &#39;maxChunkCount&#39;. If maxDocumentCount
-   *     is given, then only one chunk per document is returned. Minimum: 0
+   *     is given, then only one chunk per document is returned. Minimum: 0 (exclusive)
    * @return The same instance of this {@link GroundingFilterSearchConfiguration} class
    */
   @Nonnull
@@ -95,7 +95,7 @@ public class GroundingFilterSearchConfiguration
   /**
    * [Only supports &#39;vector&#39; dataRepositoryType] - Maximum number of documents to be
    * returned. Cannot be used with &#39;maxChunkCount&#39;. If maxDocumentCount is given, then only
-   * one chunk per document is returned. minimum: 0
+   * one chunk per document is returned. minimum: 0 (exclusive)
    *
    * @return maxDocumentCount The maxDocumentCount of this {@link
    *     GroundingFilterSearchConfiguration} instance.
@@ -110,7 +110,7 @@ public class GroundingFilterSearchConfiguration
    *
    * @param maxDocumentCount [Only supports &#39;vector&#39; dataRepositoryType] - Maximum number of
    *     documents to be returned. Cannot be used with &#39;maxChunkCount&#39;. If maxDocumentCount
-   *     is given, then only one chunk per document is returned. Minimum: 0
+   *     is given, then only one chunk per document is returned. Minimum: 0 (exclusive)
    */
   public void setMaxDocumentCount(@Nullable final Integer maxDocumentCount) {
     this.maxDocumentCount = maxDocumentCount;

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/GroundingFilterSearchConfiguration.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/GroundingFilterSearchConfiguration.java
@@ -45,7 +45,7 @@ public class GroundingFilterSearchConfiguration
    * the same instance.
    *
    * @param maxChunkCount Maximum number of chunks to be returned. Cannot be used with
-   *     &#39;maxDocumentCount&#39;. Minimum: 0
+   *     &#39;maxDocumentCount&#39;. Minimum: 0 (exclusive)
    * @return The same instance of this {@link GroundingFilterSearchConfiguration} class
    */
   @Nonnull
@@ -56,7 +56,7 @@ public class GroundingFilterSearchConfiguration
 
   /**
    * Maximum number of chunks to be returned. Cannot be used with &#39;maxDocumentCount&#39;.
-   * minimum: 0
+   * minimum: 0 (exclusive)
    *
    * @return maxChunkCount The maxChunkCount of this {@link GroundingFilterSearchConfiguration}
    *     instance.
@@ -70,7 +70,7 @@ public class GroundingFilterSearchConfiguration
    * Set the maxChunkCount of this {@link GroundingFilterSearchConfiguration} instance.
    *
    * @param maxChunkCount Maximum number of chunks to be returned. Cannot be used with
-   *     &#39;maxDocumentCount&#39;. Minimum: 0
+   *     &#39;maxDocumentCount&#39;. Minimum: 0 (exclusive)
    */
   public void setMaxChunkCount(@Nullable final Integer maxChunkCount) {
     this.maxChunkCount = maxChunkCount;
@@ -82,7 +82,7 @@ public class GroundingFilterSearchConfiguration
    *
    * @param maxDocumentCount [Only supports &#39;vector&#39; dataRepositoryType] - Maximum number of
    *     documents to be returned. Cannot be used with &#39;maxChunkCount&#39;. If maxDocumentCount
-   *     is given, then only one chunk per document is returned. Minimum: 0
+   *     is given, then only one chunk per document is returned. Minimum: 0 (exclusive)
    * @return The same instance of this {@link GroundingFilterSearchConfiguration} class
    */
   @Nonnull
@@ -95,7 +95,7 @@ public class GroundingFilterSearchConfiguration
   /**
    * [Only supports &#39;vector&#39; dataRepositoryType] - Maximum number of documents to be
    * returned. Cannot be used with &#39;maxChunkCount&#39;. If maxDocumentCount is given, then only
-   * one chunk per document is returned. minimum: 0
+   * one chunk per document is returned. minimum: 0 (exclusive)
    *
    * @return maxDocumentCount The maxDocumentCount of this {@link
    *     GroundingFilterSearchConfiguration} instance.
@@ -110,7 +110,7 @@ public class GroundingFilterSearchConfiguration
    *
    * @param maxDocumentCount [Only supports &#39;vector&#39; dataRepositoryType] - Maximum number of
    *     documents to be returned. Cannot be used with &#39;maxChunkCount&#39;. If maxDocumentCount
-   *     is given, then only one chunk per document is returned. Minimum: 0
+   *     is given, then only one chunk per document is returned. Minimum: 0 (exclusive)
    */
   public void setMaxDocumentCount(@Nullable final Integer maxDocumentCount) {
     this.maxDocumentCount = maxDocumentCount;


### PR DESCRIPTION
## Context

> [!WARNING]
> DO NOT MERGE!!!

Generate SDK using the local SNAPSHOT version of the new generator SAP/cloud-sdk-java#1231 

Changes are:

- Mark not required properties as `@Nullable` instead of `@Nonnull`
- Exclusive mini-/maximum

CI: Verify Local Changes is failing because it is generating using the old generator.