### PR TITLE
chore: [DevOps] Wait for 4 days to update dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -11,6 +11,8 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: 'chore: [DevOps] '
+    cooldown:
+      default-days: 4
     ignore:
       - dependency-name: "org.springframework.boot:*"
         versions: [ ">=4.0.0" ]


### PR DESCRIPTION
## Context

We are supposed to wait 4 days before automatically updating dependencies.

For more context see the [BLI on SDOL-025](https://github.com/SAP/ai-sdk-java-backlog/issues/384).

Note: 
- JS team [does it the same way](https://github.com/SAP/ai-sdk-js/blob/0294a140247f50c46ebfe4d8de60e62649be0cdc/.github/dependabot.yml#L12-L15). 
- I did not exclude Cloud SDK since we anyways nearly always merge it by hand.