### PR TITLE
chore: [DevOps] Revert "bump org.springframework.ai:spring-ai-bom from 1.1.8 to 2.0.0 in the production-major group across 1 directory"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <checkstyle.version>13.6.0</checkstyle.version>
     <system-stubs.version>2.1.3</system-stubs.version>
     <surefire.version>3.5.6</surefire.version>
-    <spring-ai.version>2.0.0</spring-ai.version>
+    <spring-ai.version>1.1.8</spring-ai.version>
     <reactor-core.version>3.8.6</reactor-core.version>
     <dotenv-java.version>3.2.0</dotenv-java.version>
     <mockito.version>5.23.0</mockito.version>


### PR DESCRIPTION
Reverts SAP/ai-sdk-java#964