### PR TITLE
chore: [DevOps] Update Cloud SDK to `5.33` and OpenAPI to `7.24`

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -26,8 +26,6 @@ updates:
         versions: [ ">=5.0.0" ]
       - dependency-name: "com.github.victools:jsonschema-module-jackson"
         versions: [ ">=5.0.0" ]
-      - dependency-name: "org.openapitools:openapi-generator"
-        versions: [ ">=7.23.0" ]
     groups:
       production-minor-patch:
         dependency-type: "production"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -14,10 +14,6 @@ updates:
     cooldown:
       default-days: 4
     ignore:
-      - dependency-name: "org.springframework.boot:*"
-        versions: [ ">=4.0.0" ]
-      - dependency-name: "org.springframework:*"
-        versions: [ ">=7.0.0" ]
       - dependency-name: "com.fasterxml.jackson.*:*"
         versions: [ ">=3.0.0" ]
       - dependency-name: "tools.jackson.*:*"
@@ -26,8 +22,6 @@ updates:
         versions: [ ">=5.0.0" ]
       - dependency-name: "com.github.victools:jsonschema-module-jackson"
         versions: [ ">=5.0.0" ]
-      - dependency-name: "org.openapitools:openapi-generator"
-        versions: [ ">=7.23.0" ]
     groups:
       production-minor-patch:
         dependency-type: "production"

--- a/core-services/document-grounding/src/main/java/com/sap/ai/sdk/grounding/model/PostProcessingOperation.java
+++ b/core-services/document-grounding/src/main/java/com/sap/ai/sdk/grounding/model/PostProcessingOperation.java
@@ -85,7 +85,7 @@ public class PostProcessingOperation implements RetrievalSearchInputPostProcessi
    * instance.
    *
    * @param maxChunkCount Maximum number of chunks to be retained in final PerSearchFilterResult.
-   *     Minimum: 0 Maximum: 10000000
+   *     Minimum: 0 (exclusive) Maximum: 10000000
    * @return The same instance of this {@link PostProcessingOperation} class
    */
   @Nonnull
@@ -95,8 +95,8 @@ public class PostProcessingOperation implements RetrievalSearchInputPostProcessi
   }
 
   /**
-   * Maximum number of chunks to be retained in final PerSearchFilterResult. minimum: 0 maximum:
-   * 10000000
+   * Maximum number of chunks to be retained in final PerSearchFilterResult. minimum: 0 (exclusive)
+   * maximum: 10000000
    *
    * @return maxChunkCount The maxChunkCount of this {@link PostProcessingOperation} instance.
    */
@@ -109,7 +109,7 @@ public class PostProcessingOperation implements RetrievalSearchInputPostProcessi
    * Set the maxChunkCount of this {@link PostProcessingOperation} instance.
    *
    * @param maxChunkCount Maximum number of chunks to be retained in final PerSearchFilterResult.
-   *     Minimum: 0 Maximum: 10000000
+   *     Minimum: 0 (exclusive) Maximum: 10000000
    */
   public void setMaxChunkCount(@Nullable final Integer maxChunkCount) {
     this.maxChunkCount = maxChunkCount;

--- a/core-services/document-grounding/src/main/java/com/sap/ai/sdk/grounding/model/RetrievalSearchConfiguration.java
+++ b/core-services/document-grounding/src/main/java/com/sap/ai/sdk/grounding/model/RetrievalSearchConfiguration.java
@@ -45,7 +45,7 @@ public class RetrievalSearchConfiguration
    * instance.
    *
    * @param maxChunkCount Maximum number of chunks to be returned. Cannot be used with
-   *     &#39;maxDocumentCount&#39;. Minimum: 0 Maximum: 10000000
+   *     &#39;maxDocumentCount&#39;. Minimum: 0 (exclusive) Maximum: 10000000
    * @return The same instance of this {@link RetrievalSearchConfiguration} class
    */
   @Nonnull
@@ -56,7 +56,7 @@ public class RetrievalSearchConfiguration
 
   /**
    * Maximum number of chunks to be returned. Cannot be used with &#39;maxDocumentCount&#39;.
-   * minimum: 0 maximum: 10000000
+   * minimum: 0 (exclusive) maximum: 10000000
    *
    * @return maxChunkCount The maxChunkCount of this {@link RetrievalSearchConfiguration} instance.
    */
@@ -69,7 +69,7 @@ public class RetrievalSearchConfiguration
    * Set the maxChunkCount of this {@link RetrievalSearchConfiguration} instance.
    *
    * @param maxChunkCount Maximum number of chunks to be returned. Cannot be used with
-   *     &#39;maxDocumentCount&#39;. Minimum: 0 Maximum: 10000000
+   *     &#39;maxDocumentCount&#39;. Minimum: 0 (exclusive) Maximum: 10000000
    */
   public void setMaxChunkCount(@Nullable final Integer maxChunkCount) {
     this.maxChunkCount = maxChunkCount;
@@ -81,7 +81,8 @@ public class RetrievalSearchConfiguration
    *
    * @param maxDocumentCount [Only supports &#39;vector&#39; dataRepositoryType] - Maximum number of
    *     documents to be returned. Cannot be used with &#39;maxChunkCount&#39;. If maxDocumentCount
-   *     is given, then only one chunk per document is returned. Minimum: 0 Maximum: 10000000
+   *     is given, then only one chunk per document is returned. Minimum: 0 (exclusive) Maximum:
+   *     10000000
    * @return The same instance of this {@link RetrievalSearchConfiguration} class
    */
   @Nonnull
@@ -93,7 +94,7 @@ public class RetrievalSearchConfiguration
   /**
    * [Only supports &#39;vector&#39; dataRepositoryType] - Maximum number of documents to be
    * returned. Cannot be used with &#39;maxChunkCount&#39;. If maxDocumentCount is given, then only
-   * one chunk per document is returned. minimum: 0 maximum: 10000000
+   * one chunk per document is returned. minimum: 0 (exclusive) maximum: 10000000
    *
    * @return maxDocumentCount The maxDocumentCount of this {@link RetrievalSearchConfiguration}
    *     instance.
@@ -108,7 +109,8 @@ public class RetrievalSearchConfiguration
    *
    * @param maxDocumentCount [Only supports &#39;vector&#39; dataRepositoryType] - Maximum number of
    *     documents to be returned. Cannot be used with &#39;maxChunkCount&#39;. If maxDocumentCount
-   *     is given, then only one chunk per document is returned. Minimum: 0 Maximum: 10000000
+   *     is given, then only one chunk per document is returned. Minimum: 0 (exclusive) Maximum:
+   *     10000000
    */
   public void setMaxDocumentCount(@Nullable final Integer maxDocumentCount) {
     this.maxDocumentCount = maxDocumentCount;

--- a/core-services/document-grounding/src/main/java/com/sap/ai/sdk/grounding/model/RetrievalSearchInputPostProcessingInner.java
+++ b/core-services/document-grounding/src/main/java/com/sap/ai/sdk/grounding/model/RetrievalSearchInputPostProcessingInner.java
@@ -86,7 +86,7 @@ public class RetrievalSearchInputPostProcessingInner
    * return the same instance.
    *
    * @param maxChunkCount Maximum number of chunks to be retained in final PerSearchFilterResult.
-   *     Minimum: 0 Maximum: 10000000
+   *     Minimum: 0 (exclusive) Maximum: 10000000
    * @return The same instance of this {@link RetrievalSearchInputPostProcessingInner} class
    */
   @Nonnull
@@ -97,8 +97,8 @@ public class RetrievalSearchInputPostProcessingInner
   }
 
   /**
-   * Maximum number of chunks to be retained in final PerSearchFilterResult. minimum: 0 maximum:
-   * 10000000
+   * Maximum number of chunks to be retained in final PerSearchFilterResult. minimum: 0 (exclusive)
+   * maximum: 10000000
    *
    * @return maxChunkCount The maxChunkCount of this {@link RetrievalSearchInputPostProcessingInner}
    *     instance.
@@ -112,7 +112,7 @@ public class RetrievalSearchInputPostProcessingInner
    * Set the maxChunkCount of this {@link RetrievalSearchInputPostProcessingInner} instance.
    *
    * @param maxChunkCount Maximum number of chunks to be retained in final PerSearchFilterResult.
-   *     Minimum: 0 Maximum: 10000000
+   *     Minimum: 0 (exclusive) Maximum: 10000000
    */
   public void setMaxChunkCount(@Nullable final Integer maxChunkCount) {
     this.maxChunkCount = maxChunkCount;

--- a/core-services/document-grounding/src/main/java/com/sap/ai/sdk/grounding/model/SearchConfiguration.java
+++ b/core-services/document-grounding/src/main/java/com/sap/ai/sdk/grounding/model/SearchConfiguration.java
@@ -45,7 +45,7 @@ public class SearchConfiguration
    * instance.
    *
    * @param maxChunkCount Maximum number of chunks to be returned. Cannot be used with
-   *     &#39;maxDocumentCount&#39;. Minimum: 0 Maximum: 0
+   *     &#39;maxDocumentCount&#39;. Minimum: 0 (exclusive) Maximum: 0
    * @return The same instance of this {@link SearchConfiguration} class
    */
   @Nonnull
@@ -56,7 +56,7 @@ public class SearchConfiguration
 
   /**
    * Maximum number of chunks to be returned. Cannot be used with &#39;maxDocumentCount&#39;.
-   * minimum: 0 maximum: 0
+   * minimum: 0 (exclusive) maximum: 0
    *
    * @return maxChunkCount The maxChunkCount of this {@link SearchConfiguration} instance.
    */
@@ -69,7 +69,7 @@ public class SearchConfiguration
    * Set the maxChunkCount of this {@link SearchConfiguration} instance.
    *
    * @param maxChunkCount Maximum number of chunks to be returned. Cannot be used with
-   *     &#39;maxDocumentCount&#39;. Minimum: 0 Maximum: 0
+   *     &#39;maxDocumentCount&#39;. Minimum: 0 (exclusive) Maximum: 0
    */
   public void setMaxChunkCount(@Nullable final Integer maxChunkCount) {
     this.maxChunkCount = maxChunkCount;
@@ -81,7 +81,7 @@ public class SearchConfiguration
    *
    * @param maxDocumentCount [Only supports &#39;vector&#39; dataRepositoryType] - Maximum number of
    *     documents to be returned. Cannot be used with &#39;maxChunkCount&#39;. If maxDocumentCount
-   *     is given, then only one chunk per document is returned. Minimum: 0 Maximum: 0
+   *     is given, then only one chunk per document is returned. Minimum: 0 (exclusive) Maximum: 0
    * @return The same instance of this {@link SearchConfiguration} class
    */
   @Nonnull
@@ -93,7 +93,7 @@ public class SearchConfiguration
   /**
    * [Only supports &#39;vector&#39; dataRepositoryType] - Maximum number of documents to be
    * returned. Cannot be used with &#39;maxChunkCount&#39;. If maxDocumentCount is given, then only
-   * one chunk per document is returned. minimum: 0 maximum: 0
+   * one chunk per document is returned. minimum: 0 (exclusive) maximum: 0
    *
    * @return maxDocumentCount The maxDocumentCount of this {@link SearchConfiguration} instance.
    */
@@ -107,7 +107,7 @@ public class SearchConfiguration
    *
    * @param maxDocumentCount [Only supports &#39;vector&#39; dataRepositoryType] - Maximum number of
    *     documents to be returned. Cannot be used with &#39;maxChunkCount&#39;. If maxDocumentCount
-   *     is given, then only one chunk per document is returned. Minimum: 0 Maximum: 0
+   *     is given, then only one chunk per document is returned. Minimum: 0 (exclusive) Maximum: 0
    */
   public void setMaxDocumentCount(@Nullable final Integer maxDocumentCount) {
     this.maxDocumentCount = maxDocumentCount;

--- a/core-services/document-grounding/src/main/java/com/sap/ai/sdk/grounding/model/VectorSearchConfiguration.java
+++ b/core-services/document-grounding/src/main/java/com/sap/ai/sdk/grounding/model/VectorSearchConfiguration.java
@@ -45,7 +45,7 @@ public class VectorSearchConfiguration
    * instance.
    *
    * @param maxChunkCount Maximum number of chunks to be returned. Cannot be used with
-   *     &#39;maxDocumentCount&#39;. Minimum: 0 Maximum: 10000000
+   *     &#39;maxDocumentCount&#39;. Minimum: 0 (exclusive) Maximum: 10000000
    * @return The same instance of this {@link VectorSearchConfiguration} class
    */
   @Nonnull
@@ -56,7 +56,7 @@ public class VectorSearchConfiguration
 
   /**
    * Maximum number of chunks to be returned. Cannot be used with &#39;maxDocumentCount&#39;.
-   * minimum: 0 maximum: 10000000
+   * minimum: 0 (exclusive) maximum: 10000000
    *
    * @return maxChunkCount The maxChunkCount of this {@link VectorSearchConfiguration} instance.
    */
@@ -69,7 +69,7 @@ public class VectorSearchConfiguration
    * Set the maxChunkCount of this {@link VectorSearchConfiguration} instance.
    *
    * @param maxChunkCount Maximum number of chunks to be returned. Cannot be used with
-   *     &#39;maxDocumentCount&#39;. Minimum: 0 Maximum: 10000000
+   *     &#39;maxDocumentCount&#39;. Minimum: 0 (exclusive) Maximum: 10000000
    */
   public void setMaxChunkCount(@Nullable final Integer maxChunkCount) {
     this.maxChunkCount = maxChunkCount;
@@ -81,7 +81,8 @@ public class VectorSearchConfiguration
    *
    * @param maxDocumentCount [Only supports &#39;vector&#39; dataRepositoryType] - Maximum number of
    *     documents to be returned. Cannot be used with &#39;maxChunkCount&#39;. If maxDocumentCount
-   *     is given, then only one chunk per document is returned. Minimum: 0 Maximum: 10000000
+   *     is given, then only one chunk per document is returned. Minimum: 0 (exclusive) Maximum:
+   *     10000000
    * @return The same instance of this {@link VectorSearchConfiguration} class
    */
   @Nonnull
@@ -93,7 +94,7 @@ public class VectorSearchConfiguration
   /**
    * [Only supports &#39;vector&#39; dataRepositoryType] - Maximum number of documents to be
    * returned. Cannot be used with &#39;maxChunkCount&#39;. If maxDocumentCount is given, then only
-   * one chunk per document is returned. minimum: 0 maximum: 10000000
+   * one chunk per document is returned. minimum: 0 (exclusive) maximum: 10000000
    *
    * @return maxDocumentCount The maxDocumentCount of this {@link VectorSearchConfiguration}
    *     instance.
@@ -108,7 +109,8 @@ public class VectorSearchConfiguration
    *
    * @param maxDocumentCount [Only supports &#39;vector&#39; dataRepositoryType] - Maximum number of
    *     documents to be returned. Cannot be used with &#39;maxChunkCount&#39;. If maxDocumentCount
-   *     is given, then only one chunk per document is returned. Minimum: 0 Maximum: 10000000
+   *     is given, then only one chunk per document is returned. Minimum: 0 (exclusive) Maximum:
+   *     10000000
    */
   public void setMaxDocumentCount(@Nullable final Integer maxDocumentCount) {
     this.maxDocumentCount = maxDocumentCount;

--- a/core-services/prompt-registry/src/main/java/com/sap/ai/sdk/prompt/registry/model/GroundingFilterSearchConfiguration.java
+++ b/core-services/prompt-registry/src/main/java/com/sap/ai/sdk/prompt/registry/model/GroundingFilterSearchConfiguration.java
@@ -45,7 +45,7 @@ public class GroundingFilterSearchConfiguration
    * the same instance.
    *
    * @param maxChunkCount Maximum number of chunks to be returned. Cannot be used with
-   *     &#39;maxDocumentCount&#39;. Minimum: 0
+   *     &#39;maxDocumentCount&#39;. Minimum: 0 (exclusive)
    * @return The same instance of this {@link GroundingFilterSearchConfiguration} class
    */
   @Nonnull
@@ -56,7 +56,7 @@ public class GroundingFilterSearchConfiguration
 
   /**
    * Maximum number of chunks to be returned. Cannot be used with &#39;maxDocumentCount&#39;.
-   * minimum: 0
+   * minimum: 0 (exclusive)
    *
    * @return maxChunkCount The maxChunkCount of this {@link GroundingFilterSearchConfiguration}
    *     instance.
@@ -70,7 +70,7 @@ public class GroundingFilterSearchConfiguration
    * Set the maxChunkCount of this {@link GroundingFilterSearchConfiguration} instance.
    *
    * @param maxChunkCount Maximum number of chunks to be returned. Cannot be used with
-   *     &#39;maxDocumentCount&#39;. Minimum: 0
+   *     &#39;maxDocumentCount&#39;. Minimum: 0 (exclusive)
    */
   public void setMaxChunkCount(@Nullable final Integer maxChunkCount) {
     this.maxChunkCount = maxChunkCount;
@@ -82,7 +82,7 @@ public class GroundingFilterSearchConfiguration
    *
    * @param maxDocumentCount [Only supports &#39;vector&#39; dataRepositoryType] - Maximum number of
    *     documents to be returned. Cannot be used with &#39;maxChunkCount&#39;. If maxDocumentCount
-   *     is given, then only one chunk per document is returned. Minimum: 0
+   *     is given, then only one chunk per document is returned. Minimum: 0 (exclusive)
    * @return The same instance of this {@link GroundingFilterSearchConfiguration} class
    */
   @Nonnull
@@ -95,7 +95,7 @@ public class GroundingFilterSearchConfiguration
   /**
    * [Only supports &#39;vector&#39; dataRepositoryType] - Maximum number of documents to be
    * returned. Cannot be used with &#39;maxChunkCount&#39;. If maxDocumentCount is given, then only
-   * one chunk per document is returned. minimum: 0
+   * one chunk per document is returned. minimum: 0 (exclusive)
    *
    * @return maxDocumentCount The maxDocumentCount of this {@link
    *     GroundingFilterSearchConfiguration} instance.
@@ -110,7 +110,7 @@ public class GroundingFilterSearchConfiguration
    *
    * @param maxDocumentCount [Only supports &#39;vector&#39; dataRepositoryType] - Maximum number of
    *     documents to be returned. Cannot be used with &#39;maxChunkCount&#39;. If maxDocumentCount
-   *     is given, then only one chunk per document is returned. Minimum: 0
+   *     is given, then only one chunk per document is returned. Minimum: 0 (exclusive)
    */
   public void setMaxDocumentCount(@Nullable final Integer maxDocumentCount) {
     this.maxDocumentCount = maxDocumentCount;

--- a/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/generated/model/ChatCompletionsRequestCommon.java
+++ b/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/generated/model/ChatCompletionsRequestCommon.java
@@ -39,7 +39,7 @@ public class ChatCompletionsRequestCommon
   private Boolean stream = false;
 
   @JsonProperty("stop")
-  private ChatCompletionsRequestCommonStop stop = null;
+  private ChatCompletionsRequestCommonStop stop;
 
   @JsonProperty("max_tokens")
   private Integer maxTokens = 4096;

--- a/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/generated/model/CreateChatCompletionRequest.java
+++ b/foundation-models/openai/src/main/java/com/sap/ai/sdk/foundationmodels/openai/generated/model/CreateChatCompletionRequest.java
@@ -42,7 +42,7 @@ public class CreateChatCompletionRequest
   private Boolean stream = false;
 
   @JsonProperty("stop")
-  private CreateChatCompletionRequestAllOfStop stop = null;
+  private CreateChatCompletionRequestAllOfStop stop;
 
   @JsonProperty("max_tokens")
   private Integer maxTokens;

--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/GroundingFilterSearchConfiguration.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/model/GroundingFilterSearchConfiguration.java
@@ -45,7 +45,7 @@ public class GroundingFilterSearchConfiguration
    * the same instance.
    *
    * @param maxChunkCount Maximum number of chunks to be returned. Cannot be used with
-   *     &#39;maxDocumentCount&#39;. Minimum: 0
+   *     &#39;maxDocumentCount&#39;. Minimum: 0 (exclusive)
    * @return The same instance of this {@link GroundingFilterSearchConfiguration} class
    */
   @Nonnull
@@ -56,7 +56,7 @@ public class GroundingFilterSearchConfiguration
 
   /**
    * Maximum number of chunks to be returned. Cannot be used with &#39;maxDocumentCount&#39;.
-   * minimum: 0
+   * minimum: 0 (exclusive)
    *
    * @return maxChunkCount The maxChunkCount of this {@link GroundingFilterSearchConfiguration}
    *     instance.
@@ -70,7 +70,7 @@ public class GroundingFilterSearchConfiguration
    * Set the maxChunkCount of this {@link GroundingFilterSearchConfiguration} instance.
    *
    * @param maxChunkCount Maximum number of chunks to be returned. Cannot be used with
-   *     &#39;maxDocumentCount&#39;. Minimum: 0
+   *     &#39;maxDocumentCount&#39;. Minimum: 0 (exclusive)
    */
   public void setMaxChunkCount(@Nullable final Integer maxChunkCount) {
     this.maxChunkCount = maxChunkCount;
@@ -82,7 +82,7 @@ public class GroundingFilterSearchConfiguration
    *
    * @param maxDocumentCount [Only supports &#39;vector&#39; dataRepositoryType] - Maximum number of
    *     documents to be returned. Cannot be used with &#39;maxChunkCount&#39;. If maxDocumentCount
-   *     is given, then only one chunk per document is returned. Minimum: 0
+   *     is given, then only one chunk per document is returned. Minimum: 0 (exclusive)
    * @return The same instance of this {@link GroundingFilterSearchConfiguration} class
    */
   @Nonnull
@@ -95,7 +95,7 @@ public class GroundingFilterSearchConfiguration
   /**
    * [Only supports &#39;vector&#39; dataRepositoryType] - Maximum number of documents to be
    * returned. Cannot be used with &#39;maxChunkCount&#39;. If maxDocumentCount is given, then only
-   * one chunk per document is returned. minimum: 0
+   * one chunk per document is returned. minimum: 0 (exclusive)
    *
    * @return maxDocumentCount The maxDocumentCount of this {@link
    *     GroundingFilterSearchConfiguration} instance.
@@ -110,7 +110,7 @@ public class GroundingFilterSearchConfiguration
    *
    * @param maxDocumentCount [Only supports &#39;vector&#39; dataRepositoryType] - Maximum number of
    *     documents to be returned. Cannot be used with &#39;maxChunkCount&#39;. If maxDocumentCount
-   *     is given, then only one chunk per document is returned. Minimum: 0
+   *     is given, then only one chunk per document is returned. Minimum: 0 (exclusive)
    */
   public void setMaxDocumentCount(@Nullable final Integer maxDocumentCount) {
     this.maxDocumentCount = maxDocumentCount;

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <maven.compiler.proc>full</maven.compiler.proc>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.outputTimestamp>2025-04-03T13:23:00Z</project.build.outputTimestamp>
-    <cloud-sdk.version>5.32.0</cloud-sdk.version>
+    <cloud-sdk.version>5.33.0</cloud-sdk.version>
     <junit-jupiter.version>6.1.2</junit-jupiter.version>
     <wiremock.version>3.13.2</wiremock.version>
     <assertj-core.version>3.27.7</assertj-core.version>
@@ -319,14 +319,6 @@
           <groupId>com.sap.cloud.sdk.datamodel</groupId>
           <artifactId>openapi-generator-maven-plugin</artifactId>
           <version>${cloud-sdk.version}</version>
-          <dependencies>
-            <!-- Handle regression in 7.23.0 -->
-            <dependency>
-              <groupId>org.openapitools</groupId>
-              <artifactId>openapi-generator</artifactId>
-              <version>7.22.0</version>
-            </dependency>
-          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.openapitools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -324,7 +324,7 @@
             <dependency>
               <groupId>org.openapitools</groupId>
               <artifactId>openapi-generator</artifactId>
-              <version>7.22.0</version>
+              <version>7.24.0</version>
             </dependency>
           </dependencies>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <maven.compiler.proc>full</maven.compiler.proc>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.outputTimestamp>2025-04-03T13:23:00Z</project.build.outputTimestamp>
-    <cloud-sdk.version>5.32.0</cloud-sdk.version>
+    <cloud-sdk.version>5.33.0-SNAPSHOT</cloud-sdk.version>
     <junit-jupiter.version>6.1.0</junit-jupiter.version>
     <wiremock.version>3.13.2</wiremock.version>
     <assertj-core.version>3.27.7</assertj-core.version>
@@ -319,19 +319,6 @@
           <groupId>com.sap.cloud.sdk.datamodel</groupId>
           <artifactId>openapi-generator-maven-plugin</artifactId>
           <version>${cloud-sdk.version}</version>
-          <dependencies>
-            <!-- Handle regression in 7.23.0 -->
-            <dependency>
-              <groupId>org.openapitools</groupId>
-              <artifactId>openapi-generator</artifactId>
-              <version>7.24.0</version>
-            </dependency>
-          </dependencies>
-        </plugin>
-        <plugin>
-          <groupId>org.openapitools</groupId>
-          <artifactId>openapi-generator-maven-plugin</artifactId>
-          <version>7.24.0</version>
         </plugin>
         <plugin>
           <groupId>com.github.siom79.japicmp</groupId>


### PR DESCRIPTION
## Context

- https://github.com/SAP/ai-sdk-java-backlog/issues/403

### We need to wait for Cloud SDK `5.33.0`

- [x] Remove OpenAPI blocker to `7.22.0`
- [x] Remove dependabot ignore
  - [x] Drive-by remove Spring dependabot ignore
- [x] Re-generate clients
