### PR TITLE
chore: Update spring-app to Spring 7

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -22,7 +22,6 @@
 - [OpenAI] You can now add multiple custom headers to an `OpenAiClient` at once via `.withHeaders()`.
 - [Orchestration] Added `GEMINI_3_1_PRO_PREVIEW_EA` and `MISTRAL_MEDIUM` to model list in `OrchestrationAiModel`.
 - [Orchestration] Reasoning content is now supported for users through `OrchestrationChatResponse.getReasoningText()` and `OrchestrationChatCompletionDelta.getDeltaReasoningText()` to see the thinking processes when using the reasoning models.
-- [spring-app] The `spring-app` is now updated to Spring 7 Spring Boot 4.
 
 ### 📈 Improvements
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -22,6 +22,7 @@
 - [OpenAI] You can now add multiple custom headers to an `OpenAiClient` at once via `.withHeaders()`.
 - [Orchestration] Added `GEMINI_3_1_PRO_PREVIEW_EA` and `MISTRAL_MEDIUM` to model list in `OrchestrationAiModel`.
 - [Orchestration] Reasoning content is now supported for users through `OrchestrationChatResponse.getReasoningText()` and `OrchestrationChatCompletionDelta.getDeltaReasoningText()` to see the thinking processes when using the reasoning models.
+- [spring-app] The `spring-app` is now updated to Spring 7 Spring Boot 4.
 
 ### 📈 Improvements
 

--- a/sample-code/spring-app/pom.xml
+++ b/sample-code/spring-app/pom.xml
@@ -33,7 +33,7 @@
   </developers>
   <properties>
     <project.rootdir>${project.basedir}/../../</project.rootdir>
-    <spring-boot.version>3.5.16</spring-boot.version>
+    <spring-boot.version>4.1.0</spring-boot.version>
     <cf-logging.version>4.2.0</cf-logging.version>
     <apache-tomcat-embed.version>11.0.24</apache-tomcat-embed.version>
     <mcp-core.version>2.0.0</mcp-core.version>

--- a/sample-code/spring-app/pom.xml
+++ b/sample-code/spring-app/pom.xml
@@ -187,6 +187,11 @@
       <artifactId>spring-boot</artifactId>
     </dependency>
     <dependency>
+      <!-- Provides ServletComponentScan, relocated here in Spring Boot 4 -->
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-web-server</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/Application.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/Application.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import javax.annotation.Nonnull;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.server.servlet.context.ServletComponentScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Primary;
@@ -15,6 +16,7 @@ import org.springframework.context.annotation.Primary;
 /** Main class to start the Spring Boot application. */
 @SpringBootApplication
 @ComponentScan({"com.sap.cloud.sdk", "com.sap.ai.sdk.app"})
+@ServletComponentScan({"com.sap.cloud.sdk", "com.sap.ai.sdk.app"})
 public class Application {
 
   /**

--- a/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/Application.java
+++ b/sample-code/spring-app/src/main/java/com/sap/ai/sdk/app/Application.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import javax.annotation.Nonnull;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.web.servlet.ServletComponentScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Primary;
@@ -16,7 +15,6 @@ import org.springframework.context.annotation.Primary;
 /** Main class to start the Spring Boot application. */
 @SpringBootApplication
 @ComponentScan({"com.sap.cloud.sdk", "com.sap.ai.sdk.app"})
-@ServletComponentScan({"com.sap.cloud.sdk", "com.sap.ai.sdk.app"})
 public class Application {
 
   /**


### PR DESCRIPTION
## Context

AI/ai-sdk-java-backlog#496.

The [sample code spring-app](https://github.com/SAP/ai-sdk-java/tree/main/sample-code/spring-app) is the only module that uses the outdated Spring 6 - Spring Boot 4 dependecies. It needs to be updated.


## Definition of Done

- [x] Functionality scope stated & covered
- [ ] ~Tests cover the scope above~
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Aligned changes with the JavaScript SDK~
- [ ] [Documentation](https://github.com/SAP/ai-sdk/tree/main/docs-java) updated
- [ ] Release notes updated
