### PR TITLE
fix: `jackson-databind` was flagged with false positive CVE

### DIFF
--- a/.pipeline/dependency-check-suppression.xml
+++ b/.pipeline/dependency-check-suppression.xml
@@ -16,4 +16,12 @@
     <notes><![CDATA[Temporary, there is no fix yet, plus our customers could upgrade the version themselves.]]></notes>
     <cve>CVE-2026-53914</cve>
   </suppress>
+  <suppress>
+    <notes><![CDATA[False positive: CVE-2026-68497 does not exist in NVD.]]></notes>
+    <cve>CVE-2026-68497</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[False positive: CVE-2026-19032 does not exist in NVD.]]></notes>
+    <cve>CVE-2026-19032</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
## Context

AI/ai-sdk-java-backlog#ISSUENUMBER.
Related CVE Scan: https://github.com/SAP/ai-sdk-java/actions/runs/31457481713

The CVEs flagged are non-existent
- https://nvd.nist.gov/vuln/detail/CVE-2026-19032
- https://nvd.nist.gov/vuln/detail/CVE-2026-68497

Also, no vulnerabilites flagged in [maven repository](https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind)

## Definition of Done

- [x] Functionality scope stated & covered
- [ ] ~Tests cover the scope above~
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Aligned changes with the JavaScript SDK~
- [ ] ~[Documentation](https://github.com/SAP/ai-sdk/tree/main/docs-java) updated~
- [ ] ~Release notes updated~
