### PR TITLE
chore: [DevOps] Fix E2E Slack notification

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -54,9 +54,11 @@ jobs:
 
           ERROR_MSG=$(grep -E '^\[ERROR\] +[A-Za-z][A-Za-z0-9_]*\.[a-zA-Z][a-zA-Z0-9_]*:[0-9]+' mvn_output.log | sed $'s/\\[ERROR\\] */\\\n 🔴 /' || true)
           echo "$ERROR_MSG"
+          # Escape newlines so the value is safe to embed in a YAML/JSON string
+          ERROR_MSG_ESCAPED=$(printf '%s' "$ERROR_MSG" | sed ':a;N;$!ba;s/\n/\\n/g')
           {
             echo "error_message<<EOF"
-            printf '%s\n' "$ERROR_MSG"
+            printf '%s\n' "$ERROR_MSG_ESCAPED"
             echo "EOF"
           } >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Context

The [E2E test Slack notification failed](https://github.com/SAP/ai-sdk-java/actions/runs/32209306995/job/95938610927#step:8:113) since we updated to `slackapi/slack-github-action@v4.0.0`. The problem is that this action now uses a more strict handling of yaml (for more info see [here](https://github.com/slackapi/slack-github-action/releases/tag/v4.0.0)).

This PR fixes this by changing newlines in the error message to `\n` so that the Slack action is able to handle it correctly.