### PR TITLE
chore: [DevOps] Handle CVEs

### DIFF
--- a/.github/workflows/fosstars-report.yml
+++ b/.github/workflows/fosstars-report.yml
@@ -81,14 +81,3 @@ jobs:
         with:
           report-branch: fosstars-report
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: 'Slack Notification'
-        if: failure()
-        uses: slackapi/slack-github-action@v4.0.0
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "text": "⚠️ OWASP Dependency check failed! 😬 Please inspect & fix by clicking <https://github.com/SAP/ai-sdk-java/actions/runs/${{ github.run_id }}|here>"
-            }

--- a/.github/workflows/fosstars-report.yml
+++ b/.github/workflows/fosstars-report.yml
@@ -81,3 +81,14 @@ jobs:
         with:
           report-branch: fosstars-report
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Slack Notification'
+        if: failure()
+        uses: slackapi/slack-github-action@v4.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "⚠️ OWASP Dependency check failed! 😬 Please inspect & fix by clicking <https://github.com/SAP/ai-sdk-java/actions/runs/${{ github.run_id }}|here>"
+            }

--- a/.pipeline/dependency-check-suppression.xml
+++ b/.pipeline/dependency-check-suppression.xml
@@ -24,4 +24,8 @@
     <notes><![CDATA[False positive: CVE-2026-19032 does not exist in NVD.]]></notes>
     <cve>CVE-2026-19032</cve>
   </suppress>
+  <suppress>
+    <notes><![CDATA[Temporary, there is no fix yet, plus our customers could upgrade the version themselves.]]></notes>
+    <cve>CVE-2026-66299</cve>
+  </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,8 @@
     <japicmp.version>0.26.1</japicmp.version>
     <openai-java.version>4.45.0</openai-java.version>
     <!-- conflicts resolution -->
-    <httpcomponents-core5.version>5.4.3</httpcomponents-core5.version>
+    <httpcomponents-core5.version>5.6.4</httpcomponents-core5.version>
+    <httpcomponents-client5.version>5.6.4</httpcomponents-client5.version>
     <micrometer.version>1.17.0</micrometer.version>
     <json.version>20260719</json.version>
     <snakeyaml.version>2.6</snakeyaml.version>
@@ -158,7 +159,7 @@
         <version>${jackson.version}</version>
       </dependency>
       <!-- conflicts resolution scope "compile" -->
-      <!-- CVE-2026-54428, 54399: pin httpcore5-h2, httpcore5 >= 5.4.3 until httpclient5 (pulled via cloud-sdk openapi-core-apache) ships with fixed versions -->
+      <!-- CVE-2026-54428, 54399, 71290: pin httpcore5-h2, httpcore5 >= 5.6.4 until httpclient5 (pulled via cloud-sdk openapi-core-apache) ships with fixed versions -->
       <dependency>
         <groupId>org.apache.httpcomponents.core5</groupId>
         <artifactId>httpcore5-h2</artifactId>
@@ -168,6 +169,11 @@
         <groupId>org.apache.httpcomponents.core5</groupId>
         <artifactId>httpcore5</artifactId>
         <version>${httpcomponents-core5.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.client5</groupId>
+        <artifactId>httpclient5</artifactId>
+        <version>${httpcomponents-client5.version}</version>
       </dependency>
       <dependency>
         <!--> Pinned to align all kotlin-stdlib transitive versions pulled via openai-java and okio <-->

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <japicmp.version>0.26.1</japicmp.version>
     <openai-java.version>4.45.0</openai-java.version>
     <!-- conflicts resolution -->
-    <httpcomponents-core5.version>5.6.4</httpcomponents-core5.version>
+    <httpcomponents-core5.version>5.4.3</httpcomponents-core5.version>
     <httpcomponents-client5.version>5.6.4</httpcomponents-client5.version>
     <micrometer.version>1.17.0</micrometer.version>
     <json.version>20260719</json.version>


### PR DESCRIPTION
## Context

This PR does the following:
- fix [CVE-2026-71290](https://nvd.nist.gov/vuln/detail/CVE-2026-71290) by bumping the used httpclient5 version,
- suppress [CVE-2026-66299](https://nvd.nist.gov/vuln/detail/CVE-2026-66299) for our Fosstars check since there is no fixed version of the vulnerable dependency yet.

Successful run of the Fosstars check on this branch [here](https://github.com/SAP/ai-sdk-java/actions/runs/32262047315).

