### PR TITLE
chore: [DevOps] Revert temporary switch to NVD datafeed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -866,7 +866,6 @@ https://gitbox.apache.org/repos/asf?p=maven-pmd-plugin.git;a=blob_plain;f=src/ma
         <version>13.0.0</version>
         <configuration>
           <connectionTimeout>60000</connectionTimeout>
-          <nvdDatafeedUrl>https://dependency-check.github.io/DependencyCheck_Builder/nvd_cache/nvdcve-{0}.json.gz</nvdDatafeedUrl>
           <nvdMaxRetryCount>20</nvdMaxRetryCount>
           <failBuildOnCVSS>7</failBuildOnCVSS>
           <nvdApiKeyEnvironmentVariable>NVD_API_KEY</nvdApiKeyEnvironmentVariable>


### PR DESCRIPTION
## Context

Earlier this year we [had to switch to the NVD datafeed](https://github.com/SAP/ai-sdk-java/pull/921) because their API became unusable. That switch was planned as a temporary solution. This PR switches back to using the API.

Successful run [here](https://github.com/SAP/ai-sdk-java/actions/runs/32487861759).
