### PR TITLE
chore: [DevOps] Ignore Spring AI v2 update

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -22,6 +22,8 @@ updates:
         versions: [ ">=5.0.0" ]
       - dependency-name: "com.github.victools:jsonschema-module-jackson"
         versions: [ ">=5.0.0" ]
+      - dependency-name: "org.springframework.ai:spring-ai-bom"
+        versions: [ ">=2.0.0" ]
     groups:
       production-minor-patch:
         dependency-type: "production"


### PR DESCRIPTION
## Context

This PR lets the dependabot check ignore Spring AI v2 for the moment until we can actually migrate to it.
