### PR TITLE
chore: [DevOps] Pin jackson version (v2 and v3) to avoid CVE

### DIFF
--- a/.github/workflows/fosstars-report.yml
+++ b/.github/workflows/fosstars-report.yml
@@ -81,14 +81,3 @@ jobs:
         with:
           report-branch: fosstars-report
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: 'Slack Notification'
-        if: failure()
-        uses: slackapi/slack-github-action@v4.0.0
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "text": "⚠️ OWASP Dependency check failed! 😬 Please inspect & fix by clicking <https://github.com/SAP/ai-sdk-java/actions/runs/${{ github.run_id }}|here>"
-            }

--- a/.github/workflows/fosstars-report.yml
+++ b/.github/workflows/fosstars-report.yml
@@ -81,3 +81,14 @@ jobs:
         with:
           report-branch: fosstars-report
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Slack Notification'
+        if: failure()
+        uses: slackapi/slack-github-action@v4.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "⚠️ OWASP Dependency check failed! 😬 Please inspect & fix by clicking <https://github.com/SAP/ai-sdk-java/actions/runs/${{ github.run_id }}|here>"
+            }

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,8 @@
     <mockito.version>5.23.0</mockito.version>
     <javaparser.version>3.28.2</javaparser.version>
     <jsonschema-generator.version>4.38.0</jsonschema-generator.version>
-    <jackson.version>2.22.1</jackson.version>
+    <jackson.version>2.22.2</jackson.version>
+    <jackson3.version>3.2.2</jackson3.version>
     <logback.version>1.6.3</logback.version>
     <commons-codec.version>1.22.0</commons-codec.version>
     <japicmp.version>0.26.1</japicmp.version>
@@ -131,6 +132,21 @@
         <groupId>io.github.cdimascio</groupId>
         <artifactId>dotenv-java</artifactId>
         <version>${dotenv-java.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>tools.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${jackson3.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>tools.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>${jackson3.version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>


### PR DESCRIPTION
## Context

This PR pins jackson versions used in the AI SDK to the most recent ones (both for major version2 and 3) to mitigate [CVE-2026-77310](https://guide.sonatype.com/vulnerability/CVE-2026-77310).


Successful run on this branch [here](https://github.com/SAP/ai-sdk-java/actions/runs/32713233969).
