### PR TITLE
fix: [DevOps] NVD scan remove branch specific caches and increase timeout

### DIFF
--- a/.github/workflows/fosstars-report.yml
+++ b/.github/workflows/fosstars-report.yml
@@ -29,6 +29,7 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           cache: 'maven'
 
+      # The main branch cache will be used by default for all branches
       - name: 'Restore CVE Database'
         uses: actions/cache/restore@v6
         with:
@@ -60,8 +61,9 @@ jobs:
           retention-days: 7
 
       - name: 'Delete Old CVE Cache'
+        if: github.ref == 'refs/heads/main'
         run: |
-          CACHE_IDS=$(gh cache list --key "${{ env.CVE_CACHE_KEY }}" --ref "${{ env.CVE_CACHE_REF }}" --json id | jq -r '.[] | .id')
+          CACHE_IDS=$(gh cache list --key "${{ env.CVE_CACHE_KEY }}" --json id | jq -r '.[] | .id')
           for CACHE_ID in $CACHE_IDS; do
               echo "Deleting cache with ID: $CACHE_ID"
               gh cache delete "${CACHE_ID}"
@@ -70,6 +72,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 'Create Updated CVE Cache'
+        if: github.ref == 'refs/heads/main'
         uses: actions/cache/save@v6
         with:
           path: ${{ env.CVE_CACHE_DIR }}

--- a/pom.xml
+++ b/pom.xml
@@ -881,7 +881,7 @@ https://gitbox.apache.org/repos/asf?p=maven-pmd-plugin.git;a=blob_plain;f=src/ma
         <artifactId>dependency-check-maven</artifactId>
         <version>13.0.0</version>
         <configuration>
-          <connectionTimeout>60000</connectionTimeout>
+          <connectionTimeout>3600000</connectionTimeout>
           <nvdMaxRetryCount>20</nvdMaxRetryCount>
           <failBuildOnCVSS>7</failBuildOnCVSS>
           <nvdApiKeyEnvironmentVariable>NVD_API_KEY</nvdApiKeyEnvironmentVariable>


### PR DESCRIPTION
## Context

- https://github.com/SAP/cloud-sdk-java-backlog/issues/448

Please provide a short description of what your change does and why it is needed.

### Feature scope:
 
- [x] The only cache used will be main on all branches, only main branches run will delete and re-update the cache.
- [x] Increase timeout to 1 hour

