### PR TITLE
fix: Fix failed e2e tests slack notifications

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -52,7 +52,7 @@ jobs:
           MVN_ARGS="${{ env.MVN_MULTI_THREADED_ARGS }} surefire:test -pl :spring-app -DskipTests=false"
           mvn $MVN_ARGS "-Daicore.landscape=${{ matrix.environment }}" 2>&1 | tee mvn_output.log # tee writes to both the console and a file
 
-          ERROR_MSG=$(grep -E '^\[ERROR\] +[A-Za-z][A-Za-z0-9_]*\.[a-zA-Z][a-zA-Z0-9_]*:[0-9]+' mvn_output.log | sed $'s/\\[ERROR\\] */\\\n 🔴 /' || true)
+          ERROR_MSG=$(grep -E '^\[ERROR\] +[A-Za-z][A-Za-z0-9_]*\.[a-zA-Z][a-zA-Z0-9_]*(:[0-9]+| »)' mvn_output.log | sed $'s/\\[ERROR\\] */\\\n 🔴 /' || true)
           echo "$ERROR_MSG"
           # Escape newlines so the value is safe to embed in a YAML/JSON string
           ERROR_MSG_ESCAPED=$(printf '%s' "$ERROR_MSG" | sed ':a;N;$!ba;s/\n/\\n/g')

--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/RealtimeApiTest.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/RealtimeApiTest.java
@@ -12,8 +12,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -36,24 +34,6 @@ public class RealtimeApiTest {
       fail(e.getMessage());
     }
   }
-
-  @Test
-  @Timeout(value = 30, unit = TimeUnit.SECONDS)
-  void testThisThingAlwaysFails() {
-    fail("This always fails");
-  }
-
-  @Test
-  @Timeout(value = 100, unit = TimeUnit.MILLISECONDS)
-  void testThisAlwaysTimesOut() {
-    try {
-      Thread.sleep(1000L);
-    } catch (InterruptedException e) {
-      // do nothing
-    }
-  }
-
-
 
   @Test
   @Timeout(value = 30, unit = TimeUnit.SECONDS)

--- a/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/RealtimeApiTest.java
+++ b/sample-code/spring-app/src/test/java/com/sap/ai/sdk/app/controllers/RealtimeApiTest.java
@@ -12,6 +12,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -34,6 +36,24 @@ public class RealtimeApiTest {
       fail(e.getMessage());
     }
   }
+
+  @Test
+  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  void testThisThingAlwaysFails() {
+    fail("This always fails");
+  }
+
+  @Test
+  @Timeout(value = 100, unit = TimeUnit.MILLISECONDS)
+  void testThisAlwaysTimesOut() {
+    try {
+      Thread.sleep(1000L);
+    } catch (InterruptedException e) {
+      // do nothing
+    }
+  }
+
+
 
   @Test
   @Timeout(value = 30, unit = TimeUnit.SECONDS)


### PR DESCRIPTION
## Context

Fixed regexp to support `test timeout` logs which are (pattern-wise) different from typical test failures