### PR TITLE
fix: [DevOps] Remove kotlin from parent pom

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -20,4 +20,4 @@
 
 ### 🐛 Fixed Issues
 
--
+- Fixed `kotlin-stdlib` dependency issues by removing the version management from the parent POM.

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,6 @@
     <!--  Binary compatibility check old/new version file -->
     <japicmp.oldVersion.file>/tmp/baseline.jar</japicmp.oldVersion.file>
     <japicmp.newVersion.file>${project.build.directory}/${project.build.finalName}.jar</japicmp.newVersion.file>
-    <kotlin.stdlib.jdk8.version>2.4.10</kotlin.stdlib.jdk8.version>
   </properties>
 
   <dependencyManagement>
@@ -189,32 +188,6 @@
         <groupId>org.apache.httpcomponents.client5</groupId>
         <artifactId>httpclient5</artifactId>
         <version>${httpcomponents-client5.version}</version>
-      </dependency>
-      <dependency>
-        <!--> Pinned to align all kotlin-stdlib transitive versions pulled via openai-java and okio <-->
-        <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-stdlib-jdk8</artifactId>
-        <version>${kotlin.stdlib.jdk8.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-stdlib</artifactId>
-        <version>${kotlin.stdlib.jdk8.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-stdlib-common</artifactId>
-        <version>${kotlin.stdlib.jdk8.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-stdlib-jdk7</artifactId>
-        <version>${kotlin.stdlib.jdk8.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-reflect</artifactId>
-        <version>${kotlin.stdlib.jdk8.version}</version>
       </dependency>
       <dependency>
         <groupId>io.micrometer</groupId>


### PR DESCRIPTION
## Context

- https://github.com/SAP/ai-sdk-java/issues/1004

Please provide a short description of what your change does and why it is needed.

### Feature scope:
 
- [x] Remove kotlin from parent pom
- [x] `spring-app` runs well with both `1.8.0` and `2.4.10`

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [ ] Error handling created / updated & covered by the tests above
- [ ] ~Aligned changes with the JavaScript SDK~
- [ ] [Documentation](https://github.com/SAP/ai-sdk/tree/main/docs-java) updated
- [x] Release notes updated
