### PR TITLE
chore: [DevOps] Fix spring-expression version to avoid CVE-2026-59283

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
     <system-stubs.version>2.1.3</system-stubs.version>
     <surefire.version>3.5.6</surefire.version>
     <spring-ai.version>1.1.8</spring-ai.version>
+    <spring-expressions.version>7.0.9</spring-expressions.version>
     <reactor-core.version>3.8.7</reactor-core.version>
     <dotenv-java.version>3.2.0</dotenv-java.version>
     <mockito.version>5.23.0</mockito.version>
@@ -195,6 +196,12 @@
         <version>${jackson.version}</version>
       </dependency>
       <!-- conflicts resolution scope "compile" -->
+      <!-- CVE-2026-59283: pin spring-expression >= 7.0.9 until we migrate to spring-ai 2 -->
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-expression</artifactId>
+        <version>${spring-expressions.version}</version>
+      </dependency>
       <!-- CVE-2026-54428, 54399, 71290: pin httpcore5-h2, httpcore5 >= 5.6.4 until httpclient5 (pulled via cloud-sdk openapi-core-apache) ships with fixed versions -->
       <dependency>
         <groupId>org.apache.httpcomponents.core5</groupId>


### PR DESCRIPTION
## Context

We pull in [a vulnerable version](https://spring.io/security/cve-2026-59283) of `spring-expression` through Spring AI v1. Until we migrate to Spring AI v2, we need to fix that version >= 7.0.9.

Related:
- https://github.com/SAP/ai-sdk-java/pull/1006