### PR TITLE
fix: spring cves

### DIFF
--- a/.github/workflows/fosstars-report.yml
+++ b/.github/workflows/fosstars-report.yml
@@ -86,7 +86,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 'Slack Notification'
-        if: false # failure()
+        if: failure()
         uses: slackapi/slack-github-action@v4.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/fosstars-report.yml
+++ b/.github/workflows/fosstars-report.yml
@@ -86,7 +86,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 'Slack Notification'
-        if: failure()
+        if: false # failure()
         uses: slackapi/slack-github-action@v4.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/fosstars-report.yml
+++ b/.github/workflows/fosstars-report.yml
@@ -86,7 +86,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 'Slack Notification'
-        if: failure()
+        if: github.ref_name == 'main' && failure()
         uses: slackapi/slack-github-action@v4.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,9 @@
     <surefire.version>3.5.6</surefire.version>
     <spring-ai.version>1.1.8</spring-ai.version>
     <spring-expressions.version>7.0.9</spring-expressions.version>
+    <spring-core.version>7.0.9</spring-core.version>
+    <spring-beans.version>7.0.9</spring-beans.version>
+    <spring-messaging.version>7.0.9</spring-messaging.version>
     <reactor-core.version>3.8.7</reactor-core.version>
     <dotenv-java.version>3.2.0</dotenv-java.version>
     <mockito.version>5.23.0</mockito.version>
@@ -202,6 +205,23 @@
         <artifactId>spring-expression</artifactId>
         <version>${spring-expressions.version}</version>
       </dependency>
+      <!-- CVE-2026-CVE-2026-59313, CVE-2026-47892, CVE-2026-47893, CVE-2026-59283 >= 7.0.9 until we migrate to spring-ai 2 -->
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-beans</artifactId>
+        <version>${spring-beans.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-core</artifactId>
+        <version>${spring-core.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-messaging</artifactId>
+        <version>${spring-messaging.version}</version>
+      </dependency>
+
       <!-- CVE-2026-54428, 54399, 71290: pin httpcore5-h2, httpcore5 >= 5.6.4 until httpclient5 (pulled via cloud-sdk openapi-core-apache) ships with fixed versions -->
       <dependency>
         <groupId>org.apache.httpcomponents.core5</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
     <surefire.version>3.5.6</surefire.version>
     <spring-ai.version>1.1.8</spring-ai.version>
     <spring-aop.version>7.0.9</spring-aop.version>
+    <spring-context.version>7.0.9</spring-context.version>
     <spring-expressions.version>7.0.9</spring-expressions.version>
     <spring-core.version>7.0.9</spring-core.version>
     <spring-beans.version>7.0.9</spring-beans.version>
@@ -207,6 +208,11 @@
         <version>${spring-expressions.version}</version>
       </dependency>
       <!-- CVE-2026-CVE-2026-59313, CVE-2026-47892, CVE-2026-47893, CVE-2026-59283 >= 7.0.9 until we migrate to spring-ai 2 -->
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-context</artifactId>
+        <version>${spring-context.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-aop</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
         <version>${jackson.version}</version>
       </dependency>
       <!-- conflicts resolution scope "compile" -->
-      <!-- CVE-2026-CVE-2026-59313, 47892, 47893, 59283 >= 7.0.9 until we migrate to spring-ai 2 -->
+      <!-- CVE-2026-CVE-2026-59313, 47892, 47893, 59283 pin spring deps >= 7.0.9 until we migrate to spring-ai 2 -->
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-expression</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
     <system-stubs.version>2.1.3</system-stubs.version>
     <surefire.version>3.5.6</surefire.version>
     <spring-ai.version>1.1.8</spring-ai.version>
+    <spring-aop.version>7.0.9</spring-aop.version>
     <spring-expressions.version>7.0.9</spring-expressions.version>
     <spring-core.version>7.0.9</spring-core.version>
     <spring-beans.version>7.0.9</spring-beans.version>
@@ -206,6 +207,11 @@
         <version>${spring-expressions.version}</version>
       </dependency>
       <!-- CVE-2026-CVE-2026-59313, CVE-2026-47892, CVE-2026-47893, CVE-2026-59283 >= 7.0.9 until we migrate to spring-ai 2 -->
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-aop</artifactId>
+        <version>${spring-aop.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-beans</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -201,13 +201,12 @@
         <version>${jackson.version}</version>
       </dependency>
       <!-- conflicts resolution scope "compile" -->
-      <!-- CVE-2026-59283: pin spring-expression >= 7.0.9 until we migrate to spring-ai 2 -->
+      <!-- CVE-2026-CVE-2026-59313, 47892, 47893, 59283 >= 7.0.9 until we migrate to spring-ai 2 -->
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-expression</artifactId>
         <version>${spring-expressions.version}</version>
       </dependency>
-      <!-- CVE-2026-CVE-2026-59313, CVE-2026-47892, CVE-2026-47893, CVE-2026-59283 >= 7.0.9 until we migrate to spring-ai 2 -->
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-context</artifactId>


### PR DESCRIPTION
fixes [spring cves ](https://github.com/SAP/ai-sdk-java/actions/runs/33588325963/job/100116986832) by pinning affected transitive dependencies versions before we migrate to spring-ai v2

- CVEs scan [passes](https://github.com/SAP/ai-sdk-java/actions/runs/33620137606)
- E2E tests [pass](https://github.com/SAP/ai-sdk-java/actions/runs/33621230180/job/100218466277)