### PR TITLE
chore: [DevOps] Remove CVE suppression

### DIFF
--- a/.pipeline/dependency-check-suppression.xml
+++ b/.pipeline/dependency-check-suppression.xml
@@ -20,8 +20,4 @@
     <notes><![CDATA[False positive: CVE-2026-68497 does not exist in NVD.]]></notes>
     <cve>CVE-2026-68497</cve>
   </suppress>
-  <suppress>
-    <notes><![CDATA[False positive: CVE-2026-19032 does not exist in NVD.]]></notes>
-    <cve>CVE-2026-19032</cve>
-  </suppress>
 </suppressions>


### PR DESCRIPTION
## Context

This PR remove the suppression of [CVE-2026-19032](https://nvd.nist.gov/vuln/detail/cve-2026-19032). It is now public how to avoid the CVE and we do that already (by using `jackson-databind` in versions `2.22.2` and `3.2.2`). 