### PR TITLE
chore: [DevOps] Add E2E tests to DoD of PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,7 @@ Please provide a short description of what your change does and why it is needed
 
 - [ ] Functionality scope stated & covered
 - [ ] Tests cover the scope above
+- [ ] Relevant E2E tests are green (at least locally)
 - [ ] Error handling created / updated & covered by the tests above
 - [ ] ~Aligned changes with the JavaScript SDK~
 - [ ] [Documentation](https://github.com/SAP/ai-sdk/tree/main/docs-java) updated


### PR DESCRIPTION
## Context

As discussed in last weeks retro, this PR adds a checkbox to run the relevant E2E tests to the DoD section of the PR template.