### PR TITLE
fix: suppress false cve alarms

### DIFF
--- a/.pipeline/dependency-check-suppression.xml
+++ b/.pipeline/dependency-check-suppression.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
+    <notes><![CDATA[(flase alarm) We do not have spring-ai-transformers in our dep tree. Should be fixed afte ai v2 migration.]]></notes>
+    <cve>CVE-2026-47852</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[(false alarm) We do not have spring-ai-prd-reader in our dep tree. Should be fixed afte ai v2 migration.]]></notes>
+    <cve>CVE-2021-41251</cve>
+  </suppress>
+  <suppress>
     <notes><![CDATA[This is a JS dependency.]]></notes>
     <cve>CVE-2021-41251</cve>
   </suppress>

--- a/.pipeline/dependency-check-suppression.xml
+++ b/.pipeline/dependency-check-suppression.xml
@@ -6,7 +6,7 @@
   </suppress>
   <suppress>
     <notes><![CDATA[(false alarm) We do not have spring-ai-prd-reader in our dep tree. Should be fixed afte ai v2 migration.]]></notes>
-    <cve>CVE-2021-41251</cve>
+    <cve>CVE-2026-47851</cve>
   </suppress>
   <suppress>
     <notes><![CDATA[This is a JS dependency.]]></notes>

--- a/.pipeline/dependency-check-suppression.xml
+++ b/.pipeline/dependency-check-suppression.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
-    <notes><![CDATA[(flase alarm) We do not have spring-ai-transformers in our dep tree. Should be fixed afte ai v2 migration.]]></notes>
+    <notes><![CDATA[(flase alarm) We do not have spring-ai-transformers in our dep tree. Should be fixed after ai v2 migration.]]></notes>
     <cve>CVE-2026-47852</cve>
   </suppress>
   <suppress>
-    <notes><![CDATA[(false alarm) We do not have spring-ai-prd-reader in our dep tree. Should be fixed afte ai v2 migration.]]></notes>
+    <notes><![CDATA[(false alarm) We do not have spring-ai-prd-reader in our dep tree. Should be fixed after ai v2 migration.]]></notes>
     <cve>CVE-2026-47851</cve>
   </suppress>
   <suppress>


### PR DESCRIPTION
**Context**
OWASP security check started to fail a couple of days ago for few false CVE alarms (deps we don't use and don't depend on even transitively)

This PR temporarily supresses these CVEs until we migrate to Spring AI v2 and we could remove the suppression.

OWASP success build: https://github.com/SAP/ai-sdk-java/actions/runs/34330012567/job/102396145668