### PR TITLE
fix: [Orchestration] prompts with template references

### DIFF
--- a/orchestration/src/main/java/com/sap/ai/sdk/orchestration/ConfigToRequestTransformer.java
+++ b/orchestration/src/main/java/com/sap/ai/sdk/orchestration/ConfigToRequestTransformer.java
@@ -82,6 +82,10 @@ final class ConfigToRequestTransformer {
      * To be fixed with https://github.tools.sap/AI/llm-orchestration/issues/662
      */
     if (config instanceof TemplateRef) {
+      if (!prompt.getMessages().isEmpty()) {
+        throw new IllegalArgumentException(
+            "Prompt must not contain messages when using a template reference");
+      }
       return config;
     }
 

--- a/orchestration/src/test/java/com/sap/ai/sdk/orchestration/ConfigToRequestTransformerTest.java
+++ b/orchestration/src/test/java/com/sap/ai/sdk/orchestration/ConfigToRequestTransformerTest.java
@@ -30,6 +30,17 @@ class ConfigToRequestTransformerTest {
   }
 
   @Test
+  void testThrowsOnTemplateRefWithMessages() {
+    var prompt = new OrchestrationPrompt("Foo bar");
+    var templateRef =
+        TemplateConfig.reference().byId("21cb1358-0bf1-4f43-870b-00f14d0f9f16").toLowLevel();
+
+    assertThatThrownBy(() -> ConfigToRequestTransformer.toTemplateModuleConfig(prompt, templateRef))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Prompt must not contain messages when using a template reference");
+  }
+
+  @Test
   void testEmptyTemplateConfig() {
     var systemMessage = new SystemMessage("foo");
     var userMessage = new UserMessage("Hello");


### PR DESCRIPTION
## Context

AI/ai-sdk-java-backlog#264.

```java
var template = TemplateConfig.reference().byId("21cb1358-0bf1-4f43-870b-00f14d0f9f16");
var configWithTemplate = config.withTemplateConfig(template);

var prompt = new OrchestrationPrompt("Foo bar");

var response = client.chatCompletion(prompt, configWithTemplate);
```

In this case, the prompt message `Foo bar` is simply ignored without warning or error.

The above code should throw an exception due to improper use.


### Feature scope:
 
- [x] bug fixed and test created 

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] Relevant E2E tests are green (at least locally)
- [x] Error handling created / updated & covered by the tests above
- [ ] ~Aligned changes with the JavaScript SDK~
- [ ] ~[Documentation](https://github.com/SAP/ai-sdk/tree/main/docs-java) updated~
- [ ] ~Release notes updated~
