### PR TITLE
feat: replace inheritance with composition for orch config and prompt clients

### DIFF
--- a/core-services/prompt-registry/src/main/java/com/sap/ai/sdk/prompt/registry/OrchestrationConfigClient.java
+++ b/core-services/prompt-registry/src/main/java/com/sap/ai/sdk/prompt/registry/OrchestrationConfigClient.java
@@ -11,11 +11,19 @@ import com.sap.ai.sdk.prompt.registry.model.AzureContentSafetyInputFilterConfig;
 import com.sap.ai.sdk.prompt.registry.model.AzureContentSafetyOutputFilterConfig;
 import com.sap.ai.sdk.prompt.registry.model.InputFilterConfig;
 import com.sap.ai.sdk.prompt.registry.model.LlamaGuard38bFilterConfig;
+import com.sap.ai.sdk.prompt.registry.model.OrchestrationConfigDeleteResponse;
+import com.sap.ai.sdk.prompt.registry.model.OrchestrationConfigListResponse;
+import com.sap.ai.sdk.prompt.registry.model.OrchestrationConfigPostRequest;
+import com.sap.ai.sdk.prompt.registry.model.OrchestrationConfigPostResponse;
 import com.sap.ai.sdk.prompt.registry.model.OutputFilterConfig;
 import com.sap.cloud.sdk.services.openapi.apache.apiclient.ApiClient;
+import com.sap.cloud.sdk.services.openapi.apache.core.OpenApiRequestException;
+import java.util.UUID;
 import javax.annotation.Nonnull;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
+import lombok.experimental.Tolerate;
 import lombok.val;
 
 /**
@@ -24,11 +32,15 @@ import lombok.val;
  * @since 1.15.0
  */
 @Beta
-public class OrchestrationConfigClient extends OrchestrationConfigsApi {
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+public class OrchestrationConfigClient {
+
+  private final OrchestrationConfigsApi configsApi;
 
   /**
    * Instantiates a client to manage Orchestration Configurations on the Prompt Registry service.
    */
+  @Tolerate
   public OrchestrationConfigClient() {
     this(new AiCoreService());
   }
@@ -38,8 +50,73 @@ public class OrchestrationConfigClient extends OrchestrationConfigsApi {
    *
    * @param aiCoreService The configured connectivity instance to AI Core
    */
+  @Tolerate
   public OrchestrationConfigClient(@Nonnull final AiCoreService aiCoreService) {
-    super(addMixin(aiCoreService));
+    this.configsApi = new OrchestrationConfigsApi(addMixin(aiCoreService));
+  }
+
+  /**
+   * Create or update an orchestration config
+   *
+   * <p><b>200</b> - Successful response
+   *
+   * <p><b>400</b> - Bad Request
+   *
+   * <p><b>403</b> - Forbidden Error
+   *
+   * <p><b>0</b> - Common Error
+   *
+   * @param request The value for the parameter orchestrationConfigPostRequest
+   * @return OrchestrationConfigPostResponse
+   * @throws OpenApiRequestException if an error occurs while attempting to invoke the API
+   */
+  @Nonnull
+  public OrchestrationConfigPostResponse createUpdateOrchestrationConfig(
+      @Nonnull final OrchestrationConfigPostRequest request) throws OpenApiRequestException {
+    return this.configsApi.createUpdateOrchestrationConfig(request);
+  }
+
+  /**
+   * List orchestration configs
+   *
+   * <p><b>200</b> - Successful response
+   *
+   * <p><b>400</b> - Bad Request
+   *
+   * <p><b>403</b> - Forbidden Error
+   *
+   * <p><b>413</b> - Payload Too Large — result set exceeds maximum allowed rows; use $top and $skip
+   * to paginate
+   *
+   * <p><b>0</b> - Common Error
+   *
+   * @return OrchestrationConfigListResponse
+   * @throws OpenApiRequestException if an error occurs while attempting to invoke the API
+   */
+  @Nonnull
+  public OrchestrationConfigListResponse listOrchestrationConfigs() throws OpenApiRequestException {
+    return configsApi.listOrchestrationConfigs();
+  }
+
+  /**
+   * Delete orchestration config
+   *
+   * <p><b>200</b> - Successful response
+   *
+   * <p><b>403</b> - Forbidden Error
+   *
+   * <p><b>404</b> - Bad Request
+   *
+   * <p><b>0</b> - Common Error
+   *
+   * @param id The value for the parameter orchestrationConfigId
+   * @return OrchestrationConfigDeleteResponse
+   * @throws OpenApiRequestException if an error occurs while attempting to invoke the API
+   */
+  @Nonnull
+  public OrchestrationConfigDeleteResponse deleteOrchestrationConfig(@Nonnull final UUID id)
+      throws OpenApiRequestException {
+    return configsApi.deleteOrchestrationConfig(id);
   }
 
   @Nonnull

--- a/core-services/prompt-registry/src/main/java/com/sap/ai/sdk/prompt/registry/PromptClient.java
+++ b/core-services/prompt-registry/src/main/java/com/sap/ai/sdk/prompt/registry/PromptClient.java
@@ -10,22 +10,36 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.annotations.Beta;
 import com.sap.ai.sdk.core.AiCoreService;
 import com.sap.ai.sdk.prompt.registry.client.PromptTemplatesApi;
 import com.sap.ai.sdk.prompt.registry.model.MultiChatContent;
 import com.sap.ai.sdk.prompt.registry.model.MultiChatTemplate;
 import com.sap.ai.sdk.prompt.registry.model.PromptTemplate;
+import com.sap.ai.sdk.prompt.registry.model.PromptTemplateDeleteResponse;
+import com.sap.ai.sdk.prompt.registry.model.PromptTemplateGetResponse;
+import com.sap.ai.sdk.prompt.registry.model.PromptTemplateListResponse;
+import com.sap.ai.sdk.prompt.registry.model.PromptTemplatePostRequest;
+import com.sap.ai.sdk.prompt.registry.model.PromptTemplatePostResponse;
 import com.sap.ai.sdk.prompt.registry.model.PromptTemplateSpecResponseFormat;
+import com.sap.ai.sdk.prompt.registry.model.PromptTemplateSubstitutionRequest;
+import com.sap.ai.sdk.prompt.registry.model.PromptTemplateSubstitutionResponse;
 import com.sap.ai.sdk.prompt.registry.model.ResponseFormatJsonObject;
 import com.sap.ai.sdk.prompt.registry.model.ResponseFormatJsonSchema;
 import com.sap.ai.sdk.prompt.registry.model.ResponseFormatText;
 import com.sap.ai.sdk.prompt.registry.model.SingleChatTemplate;
 import com.sap.cloud.sdk.services.openapi.apache.apiclient.ApiClient;
+import com.sap.cloud.sdk.services.openapi.apache.core.OpenApiRequestException;
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.UUID;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
+import lombok.experimental.Tolerate;
 import lombok.val;
 
 /**
@@ -33,13 +47,17 @@ import lombok.val;
  *
  * @since 1.6.0
  */
-public class PromptClient extends PromptTemplatesApi {
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+public class PromptClient {
+
+  private final PromptTemplatesApi apiClient;
 
   /**
    * Instantiates this a client to invoke operations on the Prompt Registry service.
    *
    * @since 1.6.0
    */
+  @Tolerate
   public PromptClient() {
     this(new AiCoreService());
   }
@@ -50,8 +68,237 @@ public class PromptClient extends PromptTemplatesApi {
    * @param aiCoreService The configured connectivity instance to AI Core
    * @since 1.6.0
    */
+  @Tolerate
   public PromptClient(@Nonnull final AiCoreService aiCoreService) {
-    super(addMixin(aiCoreService));
+    this.apiClient = new PromptTemplatesApi(addMixin(aiCoreService));
+  }
+
+  /**
+   * Parse prompt template by name and version
+   *
+   * <p><b>200</b> - Successful response
+   *
+   * <p><b>400</b> - Bad Request
+   *
+   * <p><b>403</b> - Forbidden Error
+   *
+   * <p><b>0</b> - Common Error
+   *
+   * @param scenario (required) The value for the parameter scenario
+   * @param version (required) The value for the parameter version
+   * @param name (required) The value for the parameter name
+   * @param aiResourceGroup (optional) Specify a resource group id to use
+   * @param aiResourceGroupScope (optional) Specify whether the resource group scope is to be used
+   * @param metadata (optional, default to false) The value for the parameter metadata
+   * @param request (optional) The value for the parameter promptTemplateSubstitutionRequest
+   * @return PromptTemplateSubstitutionResponse
+   * @throws OpenApiRequestException if an error occurs while attempting to invoke the API
+   */
+  @Nonnull
+  @Beta
+  public PromptTemplateSubstitutionResponse parsePromptTemplateByNameVersion(
+      @Nonnull final String scenario,
+      @Nonnull final String version,
+      @Nonnull final String name,
+      @Nullable final String aiResourceGroup,
+      @Nullable final String aiResourceGroupScope,
+      @Nullable final Boolean metadata,
+      @Nullable final PromptTemplateSubstitutionRequest request)
+      throws OpenApiRequestException {
+    return apiClient.parsePromptTemplateByNameVersion(
+        scenario, version, name, aiResourceGroup, aiResourceGroupScope, metadata, request);
+  }
+
+  /**
+   * List prompt templates
+   *
+   * <p><b>200</b> - Successful response
+   *
+   * <p><b>400</b> - Bad Request
+   *
+   * <p><b>403</b> - Forbidden Error
+   *
+   * <p><b>413</b> - Payload Too Large — result set exceeds maximum allowed rows; use $top and $skip
+   * to paginate
+   *
+   * <p><b>0</b> - Common Error
+   *
+   * @return PromptTemplateListResponse
+   * @throws OpenApiRequestException if an error occurs while attempting to invoke the API
+   */
+  @Nonnull
+  public PromptTemplateListResponse listPromptTemplates() throws OpenApiRequestException {
+    return apiClient.listPromptTemplates();
+  }
+
+  /**
+   * Create or update a prompt template
+   *
+   * <p><b>200</b> - Successful response
+   *
+   * <p><b>400</b> - Bad Request
+   *
+   * <p><b>403</b> - Forbidden Error
+   *
+   * <p><b>0</b> - Common Error
+   *
+   * @param request The value for the parameter promptTemplatePostRequest
+   * @return PromptTemplatePostResponse
+   * @throws OpenApiRequestException if an error occurs while attempting to invoke the API
+   */
+  @Beta
+  @Nonnull
+  public PromptTemplatePostResponse createUpdatePromptTemplate(
+      @Nonnull final PromptTemplatePostRequest request) throws OpenApiRequestException {
+    return apiClient.createUpdatePromptTemplate(request);
+  }
+
+  /**
+   * Get prompt template by UUID
+   *
+   * <p><b>200</b> - Successful response
+   *
+   * <p><b>400</b> - Bad Request
+   *
+   * <p><b>403</b> - Forbidden Error
+   *
+   * <p><b>0</b> - Common Error
+   *
+   * @param uuid The value for the parameter promptTemplateId
+   * @return PromptTemplateGetResponse
+   * @throws OpenApiRequestException if an error occurs while attempting to invoke the API
+   */
+  @Nonnull
+  public PromptTemplateGetResponse getPromptTemplateByUuid(@Nonnull final UUID uuid) {
+    return apiClient.getPromptTemplateByUuid(uuid);
+  }
+
+  /**
+   * List prompt template history
+   *
+   * <p><b>200</b> - Successful response
+   *
+   * <p><b>400</b> - Bad Request
+   *
+   * <p><b>403</b> - Forbidden Error
+   *
+   * <p><b>413</b> - Payload Too Large — result set exceeds maximum allowed rows; use $top and $skip
+   * to paginate
+   *
+   * <p><b>0</b> - Common Error
+   *
+   * @param scenario The value for the parameter scenario
+   * @param version The value for the parameter version
+   * @param name The value for the parameter name
+   * @return PromptTemplateListResponse
+   * @throws OpenApiRequestException if an error occurs while attempting to invoke the API
+   */
+  @Nonnull
+  public PromptTemplateListResponse listPromptTemplateHistory(
+      @Nonnull final String scenario, @Nonnull final String version, @Nonnull final String name)
+      throws OpenApiRequestException {
+    return apiClient.listPromptTemplateHistory(scenario, version, name);
+  }
+
+  /**
+   * Import prompt template
+   *
+   * <p><b>200</b> - Successful response
+   *
+   * <p><b>400</b> - Bad Request
+   *
+   * <p><b>0</b> - Common Error
+   *
+   * @param aiResourceGroup (optional) Specify a resource group id to use
+   * @param aiResourceGroupScope (optional) Specify whether the resource group scope is to be used
+   * @param file (optional) The value for the parameter _file
+   * @return PromptTemplatePostResponse
+   * @throws OpenApiRequestException if an error occurs while attempting to invoke the API
+   */
+  @Nonnull
+  public PromptTemplatePostResponse importPromptTemplate(
+      @Nullable final String aiResourceGroup,
+      @Nullable final String aiResourceGroupScope,
+      @Nullable final File file)
+      throws OpenApiRequestException {
+    return apiClient.importPromptTemplate(aiResourceGroup, aiResourceGroupScope, file);
+  }
+
+  /**
+   * Export prompt template
+   *
+   * <p><b>200</b> - Successful response
+   *
+   * <p><b>400</b> - Bad Request
+   *
+   * <p><b>0</b> - Common Error
+   *
+   * @param promptTemplateId The value for the parameter promptTemplateId
+   * @return byte[]
+   * @throws OpenApiRequestException if an error occurs while attempting to invoke the API
+   */
+  @Nonnull
+  public byte[] exportPromptTemplate(@Nonnull final UUID promptTemplateId)
+      throws OpenApiRequestException {
+    return apiClient.exportPromptTemplate(promptTemplateId);
+  }
+
+  /**
+   * Delete prompt template
+   *
+   * <p><b>200</b> - Successful response
+   *
+   * <p><b>403</b> - Forbidden Error
+   *
+   * <p><b>404</b> - Bad Request
+   *
+   * <p><b>0</b> - Common Error
+   *
+   * @param promptTemplateId The value for the parameter promptTemplateId
+   * @return PromptTemplateDeleteResponse
+   * @throws OpenApiRequestException if an error occurs while attempting to invoke the API
+   */
+  @Nonnull
+  public PromptTemplateDeleteResponse deletePromptTemplate(@Nonnull final UUID promptTemplateId)
+      throws OpenApiRequestException {
+    return apiClient.deletePromptTemplate(promptTemplateId);
+  }
+
+  /**
+   * Parse prompt template by ID
+   *
+   * <p><b>200</b> - Successful response
+   *
+   * <p><b>400</b> - Bad Request
+   *
+   * <p><b>403</b> - Forbidden Error
+   *
+   * <p><b>0</b> - Common Error
+   *
+   * @param promptTemplateId (required) The value for the parameter promptTemplateId
+   * @param aiResourceGroup (optional) Specify a resource group id to use
+   * @param aiResourceGroupScope (optional) Specify whether the resource group scope is to be used
+   * @param metadata (optional, default to false) The value for the parameter metadata
+   * @param promptTemplateSubstitutionRequest (optional) The value for the parameter
+   *     promptTemplateSubstitutionRequest
+   * @return PromptTemplateSubstitutionResponse
+   * @throws OpenApiRequestException if an error occurs while attempting to invoke the API
+   */
+  @Nonnull
+  @Beta
+  public PromptTemplateSubstitutionResponse parsePromptTemplateById(
+      @Nonnull final UUID promptTemplateId,
+      @Nullable final String aiResourceGroup,
+      @Nullable final String aiResourceGroupScope,
+      @Nullable final Boolean metadata,
+      @Nullable final PromptTemplateSubstitutionRequest promptTemplateSubstitutionRequest)
+      throws OpenApiRequestException {
+    return apiClient.parsePromptTemplateById(
+        promptTemplateId,
+        aiResourceGroup,
+        aiResourceGroupScope,
+        metadata,
+        promptTemplateSubstitutionRequest);
   }
 
   @Nonnull

--- a/core-services/prompt-registry/src/test/java/com/sap/ai/sdk/prompt/registry/OrchestrationConfigClientTest.java
+++ b/core-services/prompt-registry/src/test/java/com/sap/ai/sdk/prompt/registry/OrchestrationConfigClientTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.sap.ai.sdk.core.AiCoreService;
+import com.sap.ai.sdk.prompt.registry.model.OrchestrationConfigPostRequest;
+import com.sap.ai.sdk.prompt.registry.model.PromptRegistryOrchestrationConfig;
 import com.sap.cloud.sdk.cloudplatform.connectivity.DefaultHttpDestination;
 import com.sap.cloud.sdk.cloudplatform.connectivity.HttpDestination;
 import java.util.UUID;
@@ -27,17 +29,47 @@ public class OrchestrationConfigClientTest {
   }
 
   @Test
-  void testPipelines() {
+  void testListOrchestrationConfigs() {
     final var result = client.listOrchestrationConfigs();
     assertThat(result.getCount()).isEqualTo(2);
     assertThat(result.getResources()).hasSize(2);
-    final var template = result.getResources().get(0);
-    assertThat(template.getId()).isEqualTo(UUID.fromString("62e8638a-ae87-4bd5-9027-a0bc67db1609"));
-    assertThat(template.getName()).isEqualTo("test-config-for-OrchestrationTest");
-    assertThat(template.getVersion()).isEqualTo("0.0.1");
-    assertThat(template.getScenario()).isEqualTo("sdk-test-scenario");
-    assertThat(template.getCreationTimestamp()).isEqualTo("2025-12-19T16:24:27.442000");
-    assertThat(template.getManagedBy()).isEqualTo("imperative");
-    assertThat(template.isIsVersionHead()).isEqualTo(true);
+    final var first = result.getResources().get(0);
+    assertThat(first.getId()).isEqualTo(UUID.fromString("62e8638a-ae87-4bd5-9027-a0bc67db1609"));
+    assertThat(first.getName()).isEqualTo("test-config-for-OrchestrationTest");
+    assertThat(first.getVersion()).isEqualTo("0.0.1");
+    assertThat(first.getScenario()).isEqualTo("sdk-test-scenario");
+    assertThat(first.getCreationTimestamp()).isEqualTo("2025-12-19T16:24:27.442000");
+    assertThat(first.getManagedBy()).isEqualTo("imperative");
+    assertThat(first.isIsVersionHead()).isTrue();
+    final var second = result.getResources().get(1);
+    assertThat(second.getId()).isEqualTo(UUID.fromString("f9f2875a-4c92-471b-a403-51a50e70fe52"));
+    assertThat(second.getName()).isEqualTo("test-config");
+  }
+
+  @Test
+  void testCreateUpdateOrchestrationConfig() {
+    final var request =
+        OrchestrationConfigPostRequest.create()
+            .name("test-config-for-OrchestrationTest")
+            .version("0.0.1")
+            .scenario("sdk-test-scenario")
+            .spec(PromptRegistryOrchestrationConfig.create());
+
+    final var result = client.createUpdateOrchestrationConfig(request);
+
+    assertThat(result.getMessage()).isEqualTo("Orchestration config created successfully");
+    assertThat(result.getId()).isEqualTo(UUID.fromString("62e8638a-ae87-4bd5-9027-a0bc67db1609"));
+    assertThat(result.getScenario()).isEqualTo("sdk-test-scenario");
+    assertThat(result.getName()).isEqualTo("test-config-for-OrchestrationTest");
+    assertThat(result.getVersion()).isEqualTo("0.0.1");
+  }
+
+  @Test
+  void testDeleteOrchestrationConfig() {
+    final var id = UUID.fromString("62e8638a-ae87-4bd5-9027-a0bc67db1609");
+
+    final var result = client.deleteOrchestrationConfig(id);
+
+    assertThat(result.getMessage()).isEqualTo("Orchestration config deleted successfully");
   }
 }

--- a/core-services/prompt-registry/src/test/java/com/sap/ai/sdk/prompt/registry/PromptRegistryClientTest.java
+++ b/core-services/prompt-registry/src/test/java/com/sap/ai/sdk/prompt/registry/PromptRegistryClientTest.java
@@ -8,6 +8,8 @@ import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.sap.ai.sdk.core.AiCoreService;
 import com.sap.ai.sdk.prompt.registry.model.MultiChatTemplate;
 import com.sap.ai.sdk.prompt.registry.model.PromptTemplateGetResponse;
+import com.sap.ai.sdk.prompt.registry.model.PromptTemplatePostRequest;
+import com.sap.ai.sdk.prompt.registry.model.PromptTemplateSpec;
 import com.sap.ai.sdk.prompt.registry.model.PromptTemplateSubstitutionRequest;
 import com.sap.ai.sdk.prompt.registry.model.ResponseFormatJsonObject;
 import com.sap.ai.sdk.prompt.registry.model.ResponseFormatJsonSchema;
@@ -16,6 +18,9 @@ import com.sap.ai.sdk.prompt.registry.model.SingleChatTemplate;
 import com.sap.ai.sdk.prompt.registry.model.TextContent;
 import com.sap.cloud.sdk.cloudplatform.connectivity.DefaultHttpDestination;
 import com.sap.cloud.sdk.cloudplatform.connectivity.HttpDestination;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,7 +42,7 @@ class PromptRegistryClientTest {
   }
 
   @Test
-  void testPipelines() {
+  void testListPromptTemplates() {
     final var result = client.listPromptTemplates();
     assertThat(result.getCount()).isEqualTo(2);
     assertThat(result.getResources()).hasSize(2);
@@ -162,5 +167,90 @@ class PromptRegistryClientTest {
     final var userTemplate = (SingleChatTemplate) response.getParsedPrompt().get(1);
     assertThat(userTemplate.getRole()).isEqualTo("user");
     assertThat(userTemplate.getContent()).isEqualTo("I love football");
+  }
+
+  @Test
+  void testCreateUpdatePromptTemplate() {
+    final var spec =
+        PromptTemplateSpec.create()
+            .template(SingleChatTemplate.create().role("user").content("Hello"));
+    final var request =
+        PromptTemplatePostRequest.create()
+            .name("prompt_template_name")
+            .version("1.0.0")
+            .scenario("MyScenario")
+            .spec(spec);
+
+    final var result = client.createUpdatePromptTemplate(request);
+
+    assertThat(result.getMessage()).isEqualTo("Prompt template created successfully");
+    assertThat(result.getId()).isEqualTo(UUID.fromString("312a9b9c-a532-4c1c-8852-bf75de887d74"));
+    assertThat(result.getScenario()).isEqualTo("MyScenario");
+    assertThat(result.getName()).isEqualTo("prompt_template_name");
+    assertThat(result.getVersion()).isEqualTo("1.0.0");
+  }
+
+  @Test
+  void testDeletePromptTemplate() {
+    final var id = UUID.fromString("312a9b9c-a532-4c1c-8852-bf75de887d74");
+
+    final var result = client.deletePromptTemplate(id);
+
+    assertThat(result.getMessage()).isEqualTo("Prompt template deleted successfully");
+  }
+
+  @Test
+  void testExportPromptTemplate() {
+    final var id = UUID.fromString("312a9b9c-a532-4c1c-8852-bf75de887d74");
+
+    final byte[] result = client.exportPromptTemplate(id);
+
+    assertThat(result).isEqualTo("test-export-content".getBytes());
+  }
+
+  @Test
+  void testImportPromptTemplate() throws IOException {
+    final File tempFile = Files.createTempFile("template-import", ".json").toFile();
+    tempFile.deleteOnExit();
+
+    final var result = client.importPromptTemplate(null, null, tempFile);
+
+    assertThat(result.getMessage()).isEqualTo("Prompt template imported successfully");
+    assertThat(result.getId()).isEqualTo(UUID.fromString("912bda62-ae87-4e73-ab53-08e9a10e2813"));
+    assertThat(result.getScenario()).isEqualTo("e2e-test");
+    assertThat(result.getName()).isEqualTo("get-capital");
+    assertThat(result.getVersion()).isEqualTo("0.0.1");
+  }
+
+  @Test
+  void testListPromptTemplateHistory() {
+    final var result =
+        client.listPromptTemplateHistory("MyScenario", "1.0.0", "prompt_template_name");
+
+    assertThat(result.getCount()).isEqualTo(1);
+    assertThat(result.getResources()).hasSize(1);
+    final var entry = result.getResources().get(0);
+    assertThat(entry.getId()).isEqualTo(UUID.fromString("312a9b9c-a532-4c1c-8852-bf75de887d74"));
+    assertThat(entry.getName()).isEqualTo("prompt_template_name");
+    assertThat(entry.getVersion()).isEqualTo("1.0.0");
+    assertThat(entry.getScenario()).isEqualTo("MyScenario");
+    assertThat(entry.getCreationTimestamp()).isEqualTo("2025-02-26T12:29:55.875000");
+    assertThat(entry.isIsVersionHead()).isTrue();
+  }
+
+  @Test
+  void testParsePromptTemplateById() {
+    final var id = UUID.fromString("312a9b9c-a532-4c1c-8852-bf75de887d74");
+    final var request = PromptTemplateSubstitutionRequest.create().inputParams(Map.of());
+
+    final var result = client.parsePromptTemplateById(id, null, null, false, request);
+
+    assertThat(result.getParsedPrompt()).hasSize(2);
+    final var system = (SingleChatTemplate) result.getParsedPrompt().get(0);
+    assertThat(system.getRole()).isEqualTo("system");
+    assertThat(system.getContent()).isEqualTo("You are a helpful assistant.");
+    final var user = (SingleChatTemplate) result.getParsedPrompt().get(1);
+    assertThat(user.getRole()).isEqualTo("user");
+    assertThat(user.getContent()).isEqualTo("What is the capital of France?");
   }
 }

--- a/core-services/prompt-registry/src/test/resources/mappings/orchestrationConfigCreate.json
+++ b/core-services/prompt-registry/src/test/resources/mappings/orchestrationConfigCreate.json
@@ -1,0 +1,19 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "/v2/registry/v2/orchestrationConfigs"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "message": "Orchestration config created successfully",
+      "id": "62e8638a-ae87-4bd5-9027-a0bc67db1609",
+      "scenario": "sdk-test-scenario",
+      "name": "test-config-for-OrchestrationTest",
+      "version": "0.0.1"
+    }
+  }
+}

--- a/core-services/prompt-registry/src/test/resources/mappings/orchestrationConfigDelete.json
+++ b/core-services/prompt-registry/src/test/resources/mappings/orchestrationConfigDelete.json
@@ -1,0 +1,15 @@
+{
+  "request": {
+    "method": "DELETE",
+    "url": "/v2/registry/v2/orchestrationConfigs/62e8638a-ae87-4bd5-9027-a0bc67db1609"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "message": "Orchestration config deleted successfully"
+    }
+  }
+}

--- a/core-services/prompt-registry/src/test/resources/mappings/templateCreate.json
+++ b/core-services/prompt-registry/src/test/resources/mappings/templateCreate.json
@@ -1,0 +1,19 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "/v2/lm/promptTemplates"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "message": "Prompt template created successfully",
+      "id": "312a9b9c-a532-4c1c-8852-bf75de887d74",
+      "scenario": "MyScenario",
+      "name": "prompt_template_name",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/core-services/prompt-registry/src/test/resources/mappings/templateDelete.json
+++ b/core-services/prompt-registry/src/test/resources/mappings/templateDelete.json
@@ -1,0 +1,15 @@
+{
+  "request": {
+    "method": "DELETE",
+    "url": "/v2/lm/promptTemplates/312a9b9c-a532-4c1c-8852-bf75de887d74"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "message": "Prompt template deleted successfully"
+    }
+  }
+}

--- a/core-services/prompt-registry/src/test/resources/mappings/templateExport.json
+++ b/core-services/prompt-registry/src/test/resources/mappings/templateExport.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/v2/lm/promptTemplates/312a9b9c-a532-4c1c-8852-bf75de887d74/export"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/octet-stream"
+    },
+    "base64Body": "dGVzdC1leHBvcnQtY29udGVudA=="
+  }
+}

--- a/core-services/prompt-registry/src/test/resources/mappings/templateHistory.json
+++ b/core-services/prompt-registry/src/test/resources/mappings/templateHistory.json
@@ -1,0 +1,26 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/v2/lm/scenarios/MyScenario/promptTemplates/prompt_template_name/versions/1.0.0/history"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "count": 1,
+      "resources": [
+        {
+          "id": "312a9b9c-a532-4c1c-8852-bf75de887d74",
+          "name": "prompt_template_name",
+          "version": "1.0.0",
+          "scenario": "MyScenario",
+          "creationTimestamp": "2025-02-26T12:29:55.875000",
+          "managedBy": "imperative",
+          "isVersionHead": true
+        }
+      ]
+    }
+  }
+}

--- a/core-services/prompt-registry/src/test/resources/mappings/templateImport.json
+++ b/core-services/prompt-registry/src/test/resources/mappings/templateImport.json
@@ -1,0 +1,19 @@
+{
+  "request": {
+    "method": "POST",
+    "urlPath": "/v2/lm/promptTemplates/import"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "message": "Prompt template imported successfully",
+      "id": "912bda62-ae87-4e73-ab53-08e9a10e2813",
+      "scenario": "e2e-test",
+      "name": "get-capital",
+      "version": "0.0.1"
+    }
+  }
+}

--- a/core-services/prompt-registry/src/test/resources/mappings/templateParseById.json
+++ b/core-services/prompt-registry/src/test/resources/mappings/templateParseById.json
@@ -1,0 +1,24 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "/v2/lm/promptTemplates/312a9b9c-a532-4c1c-8852-bf75de887d74/substitution?metadata=false"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "jsonBody": {
+      "parsedPrompt": [
+        {
+          "role": "system",
+          "content": "You are a helpful assistant."
+        },
+        {
+          "role": "user",
+          "content": "What is the capital of France?"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Context

[[AI SDK v2] Don't directly extend low-level classes for hand-written SERVICEClient classes
](https://github.com/SAP/ai-sdk-java-backlog/issues/431)

- Replaced inheritance with composition for `OrchestrationConfigClient` and `PromptClient`
- Added simple tests

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] Relevant E2E tests are green (at least locally)
- [x] Error handling created / updated & covered by the tests above
- [ ] ~Aligned changes with the JavaScript SDK~ (not applicable)
- [ ] ~[Documentation](https://github.com/SAP/ai-sdk/tree/main/docs-java) updated~ (apparently not applicable)
- [ ] ~Release notes updated~ (apparently not applicable)
